### PR TITLE
Add website_sale builder commits and weekly standouts

### DIFF
--- a/docs/reports/2025-09-24-odoo-website-html-builder-commits.md
+++ b/docs/reports/2025-09-24-odoo-website-html-builder-commits.md
@@ -2,6 +2,10 @@
 
 This digest covers all commits that touched the `addons/website` and `addons/html_builder` directories of the [Odoo community repository](https://github.com/odoo/odoo) between **17 and 24 September 2025** (UTC). The list was assembled on 24 Sep 2025 using the GitHub REST API with path filters for both modules.
 
+## Commit of the Week
+
+- **[0a0aa09](https://github.com/odoo/odoo/commit/0a0aa09651849d0f35a4490573e5218b82aa2f1f)** — Enabled full-page AI translation flows so site builders can localise entire layouts in a single action.
+
 ## Highlights
 
 - **Editor resilience & usability.** Patches harden the website/html editor against tricky scenarios such as pasting cross-document nodes, losing selection when triple-clicking UI controls, or drifting tooltips/popovers inside the iframe.
@@ -32,6 +36,7 @@ This digest covers all commits that touched the `addons/website` and `addons/htm
 | 2025-09-17 | [940d08c](https://github.com/odoo/odoo/commit/940d08c1f21cb2e25ac7d1a18de77d7dbac32feb) | Xavier Morel | website | Remove the obsolete `link_tools` tour that no longer reflects current flows. |
 | 2025-09-17 | [c82b4a8](https://github.com/odoo/odoo/commit/c82b4ad87de66d4b890c64feaff8dd691e18a563) | Laetitia (ldau) | auth_totp_mail, website | Drop the deprecated `.btn-block` class across mail/login flows, including Website pages. |
 | 2025-09-17 | [d4e0deb](https://github.com/odoo/odoo/commit/d4e0deb08bd31295deff94526260770a5f15eca8) | Claire Nguyen (clan) | website | Swap the empty-search icon for a maintained asset to avoid broken links. |
+| 2025-09-17 | [5345971](https://github.com/odoo/odoo/commit/5345971bc27d156df7038ebd9294e1ab55321b34) | Brieuc Dejean (brd) | website_sale | Restore the showcase design overlay option inside the shop builder panel. |
 | 2025-09-17 | [0a0aa09](https://github.com/odoo/odoo/commit/0a0aa09651849d0f35a4490573e5218b82aa2f1f) | Garvish Panchal | website, html_builder | Allow translating an entire page with AI, wiring builder actions into the new flow. |
 | 2025-09-17 | [42c1ef9](https://github.com/odoo/odoo/commit/42c1ef9c6a21fbfcec05f72c07e33ef88939bf75) | divy-odoo | website | Move the translation tab template into its own folder to match refactored structure. |
 | 2025-09-17 | [65cdbec](https://github.com/odoo/odoo/commit/65cdbece7edfd4e48807aa0b183265377b075a88) | Lucas Perais (lpe) | web_tour, website | Drop hard hoot-dom dependencies from website/web tours for compatibility with the new test runner. |

--- a/docs/reports/2025-10-01-odoo-website-html-builder-commits.md
+++ b/docs/reports/2025-10-01-odoo-website-html-builder-commits.md
@@ -2,6 +2,10 @@
 
 This digest covers all commits that touched the `addons/website` and `addons/html_builder` directories of the [Odoo community repository](https://github.com/odoo/odoo) between **25 September and 1 October 2025** (UTC). The list was assembled on 1 Oct 2025 using the GitHub REST API with path filters for both modules.
 
+## Commit of the Week
+
+- **[4682748](https://github.com/odoo/odoo/commit/4682748e6e3c2c6df3f50e2840b9931cd7a934a2)** — Refactored Website Sale interactions into focused modules, paving the way for cleaner cart and product page behaviours.
+
 ## Highlights
 
 - **Builder polish & preview parity.** HTML Builder regains live previews for many2one pickers, improves translation handling, fixes color picker previews, and tweaks the mobile preview button and background overlay assets for smoother authoring.
@@ -24,8 +28,10 @@ This digest covers all commits that touched the `addons/website` and `addons/htm
 | 2025-09-30 | [daacfee](https://github.com/odoo/odoo/commit/daacfee5b89b3dd5bac4e4edbd15bdd0bf65fa77) | Benjamin Vray | web, website | Show an image icon fallback for broken SEO previews so missing assets remain obvious. |
 | 2025-09-30 | [9d513f9](https://github.com/odoo/odoo/commit/9d513f9187dcc04354345690b850184a2cdbe2ee) | Parth Vyas | web, website | Exclude dynamic template images from the SEO dialog to avoid flagging transient placeholders. |
 | 2025-09-30 | [bbced6f](https://github.com/odoo/odoo/commit/bbced6fc418f0ddef977698c7e886ea9d11416d6) | Julien (jula) | web, website | Fix an asynchronous wait in website animation tests so reposition checks don’t race. |
+| 2025-09-29 | [1739b95](https://github.com/odoo/odoo/commit/1739b954fa34bc62223d892f2cdacbccebd5f8a2) | Brieuc Dejean (brd) | website_sale, website_sale_wishlist | Introduce the “Bento” showcase design with new assets and styling tweaks. |
 | 2025-09-29 | [b4a2b5a](https://github.com/odoo/odoo/commit/b4a2b5a47a0c79b9ececec8fbaf9e1bd712a9ea4) | Louis (loco) | html_builder, web, website | Rework the translation plugin to rely on new `o_editable_attribute` markers instead of forcing `contenteditable`. |
 | 2025-09-26 | [4ed28a0](https://github.com/odoo/odoo/commit/4ed28a0cebe847ab69d1e58840b38be49707cada) | Augustin (duau) | html_builder, web, website, website_sale | Retool website and builder tests to share html_builder utilities, cutting suite runtime. |
+| 2025-09-26 | [4682748](https://github.com/odoo/odoo/commit/4682748e6e3c2c6df3f50e2840b9931cd7a934a2) | Louis (loti) | website_sale, website_sale_stock, website_sale_collect, website_sale_wishlist, l10n_ar_website_sale | Split the Website Sale interaction bundle into targeted files for cart, product, and shop flows. |
 | 2025-09-26 | [beef707](https://github.com/odoo/odoo/commit/beef7078138c4185f912ebbd042faf2782b2d17e) | Augustin (duau) | html_builder, web, website | Relocate generic builder tests into the html_builder module to match their scope. |
 | 2025-09-25 | [df61467](https://github.com/odoo/odoo/commit/df6146737aa0b3963d4341100b0a1214e5345d41) | Rodolpho Lima | html_builder, html_editor, mass_mailing | Split the color tooling into separate logic and UI plugins so editors can opt out of the selector. |
 | 2025-09-25 | [11e13e0](https://github.com/odoo/odoo/commit/11e13e0907ca92442d0547c97dd5ed3c26a99c46) | romo | web, website | Reset section backgrounds when applying color combinations to avoid residual styling. |


### PR DESCRIPTION
## Summary
- add website_sale builder coverage to the 17–24 Sep weekly digest
- add website_sale builder coverage to the 25 Sep – 1 Oct weekly digest
- surface the most important commit of the week ahead of each highlight section

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68de2f036bb8833188868d4968c19120