### PR TITLE
Add weekly digest for 9–15 Oct 2025 website/html builder commits

### DIFF
--- a/docs/reports/2025-10-15-odoo-website-html-builder-commits.md
+++ b/docs/reports/2025-10-15-odoo-website-html-builder-commits.md
@@ -1,0 +1,45 @@
+# Odoo Website & HTML Builder — Weekly Commit Digest (9–15 Oct 2025)
+This digest covers all commits that touched the `addons/website`, `addons/html_builder`, and `addons/website_sale/static/src/website_builder` directories of the [Odoo community repository](https://github.com/odoo/odoo) between **9 and 15 October 2025** (UTC). The list was assembled on 15 Oct 2025 using the GitHub REST API with path filters for all three areas.
+
+## Commit of the Week
+- **[a5c02da](https://github.com/odoo/odoo/commit/a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8)** — Introduces binary font bundles so icon fonts get cache-busted URLs and year-long CDN lifetimes without manual tweaks.
+
+## Highlights
+- **Faster, longer-lived assets.** Front-end fonts now ship through fingerprinted asset bundles, trimming weekly cache misses and simplifying preload links, while media utilities were cleaned up to keep editor checks lightweight.
+- **Announcement Scroll overhaul.** Dedicated plugins now restart marquee interactions safely, honour reduced-motion, and use real dialogs for translations instead of brittle prompts.
+- **Builder stability & ergonomics.** Color pickers remember the last tab, Safari configurator clicks are reliable again, and refreshed sidebar helpers eliminate reload races and flaky job-location crashes.
+- **Content editing polish.** Showcase videos stop flickering, highlighted SVGs stay within the viewport, configurator menus match the new offer set, and multiple tours/tests gained deterministic helpers.
+
+## Commit details
+| Date (UTC) | Commit | Author | Scope | Summary |
+| --- | --- | --- | --- | --- |
+| 2025-10-15 | [faf42a1](https://github.com/odoo/odoo/commit/faf42a1555fd6d268a0b47a2692ceeabde058aef) | Tiffany Chang (tic) | html_builder | Restore the missing empty translation entry in the HTML Builder POT so exports stay valid. |
+| 2025-10-15 | [899c08b](https://github.com/odoo/odoo/commit/899c08bd2ba2f8571cf025245219621d36ed999c) | Serhii Rubanskyi | html_builder | Export every color picker tab module so downstream patches can hook the pluggable tabs. |
+| 2025-10-14 | [1d04c87](https://github.com/odoo/odoo/commit/1d04c87836daa17ecf0fafc1931395d169372e66) | Rahil Ghanchi | website | Make card snippet images inherit the card border radius for consistent rounded corners. |
+| 2025-10-14 | [ba2ba3f](https://github.com/odoo/odoo/commit/ba2ba3f4da043664e17fc62c81ba1f18f4e744be) | Antoine (anso) | website | Let `.btn-close` buttons pick up themed colours so modals, off-canvas panes, and alerts retain contrast. |
+| 2025-10-14 | [3893156](https://github.com/odoo/odoo/commit/3893156f9319b08453eaa1e1264952c936d315c8) | Robin Lejeune (role) | website | Rename add-dialog preview styles to the `.preview.scss` convention to keep bundles lean. |
+| 2025-10-14 | [798ad29](https://github.com/odoo/odoo/commit/798ad29a9d898230ddbfdc5b144fa08fcc755190) | Robin Lejeune (role) | website | Replace the announcement scroll prompt with a proper dialog plugin and shared translation hook. |
+| 2025-10-14 | [0e03cf9](https://github.com/odoo/odoo/commit/0e03cf93a331b096b79a523cc7f1709b612896ec) | Robin Lejeune (role) | website | Rebuild the announcement scroll restart flow, tweak previews, and respect reduced-motion users. |
+| 2025-10-14 | [1940931](https://github.com/odoo/odoo/commit/19409315e54c28d1b411e0e6ea3226ee09d20084) | Julien (jula) | html_builder, website | Guard builder refreshes during editor reloads and harden the product page options test. |
+| 2025-10-14 | [239fce0](https://github.com/odoo/odoo/commit/239fce02bec48e06bbeeb00062a320c3111205dd) | Krzysztof Magusiak (krma) | website | Update website visitor tracking and friends to the new GeoIP API ahead of the old hook’s removal. |
+| 2025-10-14 | [8783ee5](https://github.com/odoo/odoo/commit/8783ee50708eb6a7289589c895f78a5fb8197728) | divy-odoo | website | Keep selected blog tags when changing archive dates by routing the filters through POST links. |
+| 2025-10-14 | [7a291d5](https://github.com/odoo/odoo/commit/7a291d59909b2ee57111ddec35a20a2302291f29) | Guillaume Jacquet | website | Delay configurator focusout handlers so Safari users can click dropdown options without losing focus. |
+| 2025-10-13 | [482c459](https://github.com/odoo/odoo/commit/482c4597ca8081e29b7cb41039ef7433ff02ce59) | Serhii Rubanskyi | html_builder, website | Remember the last-used color picker tab and extend the behaviour across editor surfaces and tests. |
+| 2025-10-13 | [6df92ce](https://github.com/odoo/odoo/commit/6df92ce41681118c15e0c9613a430682f566079d) | romo | website | Ensure every carousel instance gets a unique ID so controls don’t cross-wire between snippets. |
+| 2025-10-13 | [ef789d3](https://github.com/odoo/odoo/commit/ef789d3c50869ccb8651b7056c725257eb069759) | Krzysztof Magusiak (krma) | website | Move the Query helper into `odoo.orm` as groundwork for deeper ORM integration. |
+| 2025-10-13 | [2b12fda](https://github.com/odoo/odoo/commit/2b12fdaa91fba6e6a27818e7ee4f028ef3fa6877) | Raphael Collet | website | Allow instantiating ORM queries from the model to align with the Query relocation work. |
+| 2025-10-13 | [82b518e](https://github.com/odoo/odoo/commit/82b518e3747d202131534b08df07bbc101124883) | Nicolas Lempereur | website | Reorder translation setup so nested editable fields stay translatable on product pages. |
+| 2025-10-13 | [a35f834](https://github.com/odoo/odoo/commit/a35f834df59b75adaa7d845bc89bc3a1946fc2b7) | Garvish Panchal | website | Stop the events-only configurator from pulling in eCommerce unnecessarily. |
+| 2025-10-13 | [fe1c0e1](https://github.com/odoo/odoo/commit/fe1c0e1b3b588d765f2cc570fd8e57e15a326799) | qsm-odoo | website | Clarify media/void element utilities so editor contentEditable logic covers images consistently. |
+| 2025-10-11 | [f56528c](https://github.com/odoo/odoo/commit/f56528cecfa81cc5e3b239b7fbe2c9ea5fe13ca6) | sben-odoo | website | Give video containers an explicit width so flex layouts don’t squeeze embedded players. |
+| 2025-10-11 | [7450ed3](https://github.com/odoo/odoo/commit/7450ed30ddb54b74993885d4d9b98a26f9e2a85b) | Sébastien (blse) | html_builder, website | Introduce `waitSidebarUpdated` to replace brittle DOM waits in sidebar-related tests. |
+| 2025-10-10 | [80942fa](https://github.com/odoo/odoo/commit/80942fa5162cd069037065f85abc574732d14b7c) | Serge Bayet (seba) | website | Inline the “New Content” access checks client-side and drop the temporary filtering controller. |
+| 2025-10-10 | [cf30344](https://github.com/odoo/odoo/commit/cf30344a3af56b187f7de15ee1b3e543ae0066a5) | KAEI | website | Rename “Job Offer” strings to “Job Opportunity” across website recruitment flows. |
+| 2025-10-10 | [a34aee6](https://github.com/odoo/odoo/commit/a34aee6aadb8c9a26d1f1d93bc8d94d964bbe8dc) | assk-odoo | html_builder | Restore the Remote option in job-location selectors to stop builder crashes. |
+| 2025-10-10 | [be0d11b](https://github.com/odoo/odoo/commit/be0d11b9b8a9b9a077221e9f3a4aef94636fd571) | Arib Ansari | website | Switch the translation tour to the shared helper so site switching stays deterministic. |
+| 2025-10-10 | [af291ad](https://github.com/odoo/odoo/commit/af291ad69a5a7befe0878d8314b81aa96e0a1a35) | sben-odoo | website | Cap highlighted SVG widths so mobile highlights no longer force sideways scrolling. |
+| 2025-10-10 | [4f87601](https://github.com/odoo/odoo/commit/4f87601c5c81df6cdcbbfc9d9364f684ecc1cfae) | Jinjiu Liu | website | Only prefix links with `@` inside the website app so backend redirects keep working. |
+| 2025-10-09 | [a5c02da](https://github.com/odoo/odoo/commit/a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8) | qsm-odoo | website | Serve icon fonts through hashed asset bundles for year-long caching and automatic preloads. |
+| 2025-10-09 | [b7d9ae5](https://github.com/odoo/odoo/commit/b7d9ae53ff0b6df8ceb1f8be79ad3304c843e258) | assk-odoo | website | Fix the mobile new-page dialog so it grabs the right iframe document before loading. |
+| 2025-10-09 | [0cb4545](https://github.com/odoo/odoo/commit/0cb45457ccd59c4caf28fddccb43ccdbd3e73257) | khaj-odoo | website | Refresh configurator menus, feature toggles, and tours to match the current offer mix. |
+| 2025-10-09 | [d3dc69b](https://github.com/odoo/odoo/commit/d3dc69b0431ae2f037ddb9e0e881ddf03b657638) | Benjamin Vray | website | Lock the showcase video iframe size so Chrome stops flickering on hover. |

--- a/docs/reports/data/2025-10-15-website-html-builder.json
+++ b/docs/reports/data/2025-10-15-website-html-builder.json
@@ -1,0 +1,4515 @@
+[
+  {
+    "sha": "1d04c87836daa17ecf0fafc1931395d169372e66",
+    "node_id": "C_kwDOAS1I7NoAKDFkMDRjODc4MzZkYWExN2VjZjBmYWZjMTkzMTM5NWQxNjkzNzJlNjY",
+    "commit": {
+      "author": {
+        "name": "Rahil Ghanchi",
+        "email": "rahg@odoo.com",
+        "date": "2025-06-10T13:37:27Z"
+      },
+      "committer": {
+        "name": "Rahil Ghanchi",
+        "email": "rahg@odoo.com",
+        "date": "2025-10-14T18:27:54Z"
+      },
+      "message": "[FIX] website: fix border-radius of image in card snippet\n\nSpecification:\n- Border radius on the image in the card snippet was not being\napplied correctly.\n- Border radius should be consistent with the card's border radius.\n\nAfter this commit:\n- The image inside the card snippet will now correctly inherit the\nborder radius from the card.\n- This change ensures that the image appears rounded in the same\nway as the card itself.\n\ntask-4848288\n\ncloses odoo/odoo#231534\n\nX-original-commit: 7191bdcc49c3d3968d0999a38e0cd622e9a102ea\nSigned-off-by: Quentin Smetz (qsm) <qsm@odoo.com>",
+      "tree": {
+        "sha": "6b3c8587c07c93bb0b1add3c90104683c2355250",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/6b3c8587c07c93bb0b1add3c90104683c2355250"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/1d04c87836daa17ecf0fafc1931395d169372e66",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/1d04c87836daa17ecf0fafc1931395d169372e66",
+    "html_url": "https://github.com/odoo/odoo/commit/1d04c87836daa17ecf0fafc1931395d169372e66",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/1d04c87836daa17ecf0fafc1931395d169372e66/comments",
+    "author": {
+      "login": "rahg-odoo",
+      "id": 157004424,
+      "node_id": "U_kgDOCVuyiA",
+      "avatar_url": "https://avatars.githubusercontent.com/u/157004424?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/rahg-odoo",
+      "html_url": "https://github.com/rahg-odoo",
+      "followers_url": "https://api.github.com/users/rahg-odoo/followers",
+      "following_url": "https://api.github.com/users/rahg-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/rahg-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/rahg-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/rahg-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/rahg-odoo/orgs",
+      "repos_url": "https://api.github.com/users/rahg-odoo/repos",
+      "events_url": "https://api.github.com/users/rahg-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/rahg-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "rahg-odoo",
+      "id": 157004424,
+      "node_id": "U_kgDOCVuyiA",
+      "avatar_url": "https://avatars.githubusercontent.com/u/157004424?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/rahg-odoo",
+      "html_url": "https://github.com/rahg-odoo",
+      "followers_url": "https://api.github.com/users/rahg-odoo/followers",
+      "following_url": "https://api.github.com/users/rahg-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/rahg-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/rahg-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/rahg-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/rahg-odoo/orgs",
+      "repos_url": "https://api.github.com/users/rahg-odoo/repos",
+      "events_url": "https://api.github.com/users/rahg-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/rahg-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "ba2ba3f4da043664e17fc62c81ba1f18f4e744be",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/ba2ba3f4da043664e17fc62c81ba1f18f4e744be",
+        "html_url": "https://github.com/odoo/odoo/commit/ba2ba3f4da043664e17fc62c81ba1f18f4e744be"
+      }
+    ],
+    "stats": {
+      "total": 10,
+      "additions": 10,
+      "deletions": 0
+    },
+    "files": [
+      {
+        "sha": "d0f0a6e467a9ede175ce8cd59bb2a170843187bc",
+        "filename": "addons/website/static/src/snippets/s_card/000.scss",
+        "status": "modified",
+        "additions": 10,
+        "deletions": 0,
+        "changes": 10,
+        "blob_url": "https://github.com/odoo/odoo/blob/1d04c87836daa17ecf0fafc1931395d169372e66/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_card%2F000.scss",
+        "raw_url": "https://github.com/odoo/odoo/raw/1d04c87836daa17ecf0fafc1931395d169372e66/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_card%2F000.scss",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_card%2F000.scss?ref=1d04c87836daa17ecf0fafc1931395d169372e66",
+        "patch": "@@ -19,6 +19,16 @@\n         &[data-shape] {\n             object-fit: contain;\n         }\n+\n+        &.rounded-start {\n+            border-bottom-left-radius: var(--card-inner-border-radius) !important;\n+            border-top-left-radius: var(--card-inner-border-radius) !important;\n+        }\n+\n+        &.rounded-end {\n+            border-top-right-radius: var(--card-inner-border-radius) !important;\n+            border-bottom-right-radius: var(--card-inner-border-radius) !important;\n+        }\n     }\n \n     .o_card_img_wrapper.ratio {"
+      }
+    ],
+    "paths": [
+      "addons/website"
+    ]
+  },
+  {
+    "sha": "ba2ba3f4da043664e17fc62c81ba1f18f4e744be",
+    "node_id": "C_kwDOAS1I7NoAKGJhMmJhM2Y0ZGEwNDM2NjRlMTdmYzYyYzgxYmExZjE4ZjRlNzQ0YmU",
+    "commit": {
+      "author": {
+        "name": "Antoine (anso)",
+        "email": "anso@odoo.com",
+        "date": "2025-07-29T13:50:22Z"
+      },
+      "committer": {
+        "name": "qsm-odoo",
+        "email": "qsm@odoo.com",
+        "date": "2025-10-14T18:27:53Z"
+      },
+      "message": "[FIX] website, html_editor: make `.btn-close` color dynamic\n\nThis commit makes `.btn-close` color dynamic based on the color palette\nof the website.\n\nImpacted components that are using `.btn-close`:\n- `.modal` (e.g.: `.o_sale_product_configurator_dialog`\n- `.offcanvas` (e.g.: `#o_wsale_offcanvas`)\n- `.o_notification`\n\ntask-4630175\n\ncloses odoo/odoo#231525\n\nX-original-commit: cb4be2e2eed6f0ed08e123788528ce8d4c85c003\nSigned-off-by: Quentin Smetz (qsm) <qsm@odoo.com>",
+      "tree": {
+        "sha": "260a5018dcb34187a07b4ad55c18007225c164f1",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/260a5018dcb34187a07b4ad55c18007225c164f1"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/ba2ba3f4da043664e17fc62c81ba1f18f4e744be",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/ba2ba3f4da043664e17fc62c81ba1f18f4e744be",
+    "html_url": "https://github.com/odoo/odoo/commit/ba2ba3f4da043664e17fc62c81ba1f18f4e744be",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/ba2ba3f4da043664e17fc62c81ba1f18f4e744be/comments",
+    "author": {
+      "login": "anso-odoo",
+      "id": 110090660,
+      "node_id": "U_kgDOBo_ZpA",
+      "avatar_url": "https://avatars.githubusercontent.com/u/110090660?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/anso-odoo",
+      "html_url": "https://github.com/anso-odoo",
+      "followers_url": "https://api.github.com/users/anso-odoo/followers",
+      "following_url": "https://api.github.com/users/anso-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/anso-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/anso-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/anso-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/anso-odoo/orgs",
+      "repos_url": "https://api.github.com/users/anso-odoo/repos",
+      "events_url": "https://api.github.com/users/anso-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/anso-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "qsm-odoo",
+      "id": 10338094,
+      "node_id": "MDQ6VXNlcjEwMzM4MDk0",
+      "avatar_url": "https://avatars.githubusercontent.com/u/10338094?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/qsm-odoo",
+      "html_url": "https://github.com/qsm-odoo",
+      "followers_url": "https://api.github.com/users/qsm-odoo/followers",
+      "following_url": "https://api.github.com/users/qsm-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/qsm-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/qsm-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/qsm-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/qsm-odoo/orgs",
+      "repos_url": "https://api.github.com/users/qsm-odoo/repos",
+      "events_url": "https://api.github.com/users/qsm-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/qsm-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "9bb48e72624c6261a0fcd0731f93b25d039f6ee4",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/9bb48e72624c6261a0fcd0731f93b25d039f6ee4",
+        "html_url": "https://github.com/odoo/odoo/commit/9bb48e72624c6261a0fcd0731f93b25d039f6ee4"
+      }
+    ],
+    "stats": {
+      "total": 18,
+      "additions": 18,
+      "deletions": 0
+    },
+    "files": [
+      {
+        "sha": "70e2824b21fb17ae41481ac803b56354eb3baadc",
+        "filename": "addons/html_editor/static/src/scss/html_editor.common.scss",
+        "status": "modified",
+        "additions": 10,
+        "deletions": 0,
+        "changes": 10,
+        "blob_url": "https://github.com/odoo/odoo/blob/ba2ba3f4da043664e17fc62c81ba1f18f4e744be/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fscss%2Fhtml_editor.common.scss",
+        "raw_url": "https://github.com/odoo/odoo/raw/ba2ba3f4da043664e17fc62c81ba1f18f4e744be/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fscss%2Fhtml_editor.common.scss",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fscss%2Fhtml_editor.common.scss?ref=ba2ba3f4da043664e17fc62c81ba1f18f4e744be",
+        "patch": "@@ -569,6 +569,10 @@ pre {\n                 }\n             }\n         }\n+\n+        .btn-close {\n+            filter: unset;\n+        }\n     }\n }\n @for $index from 1 through length($o-color-combinations) {\n@@ -676,6 +680,12 @@ pre {\n                     border-color: $-btn-primary-color;\n                 }\n             }\n+\n+            .btn-close {\n+                @if lightness($-bg-color) < 50 {\n+                    @include btn-close-white();\n+                }\n+            }\n         }\n     }\n }"
+      },
+      {
+        "sha": "c7a8a261eba261c11f107a55269addf049290554",
+        "filename": "addons/website/static/src/scss/website.scss",
+        "status": "modified",
+        "additions": 8,
+        "deletions": 0,
+        "changes": 8,
+        "blob_url": "https://github.com/odoo/odoo/blob/ba2ba3f4da043664e17fc62c81ba1f18f4e744be/addons%2Fwebsite%2Fstatic%2Fsrc%2Fscss%2Fwebsite.scss",
+        "raw_url": "https://github.com/odoo/odoo/raw/ba2ba3f4da043664e17fc62c81ba1f18f4e744be/addons%2Fwebsite%2Fstatic%2Fsrc%2Fscss%2Fwebsite.scss",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fscss%2Fwebsite.scss?ref=ba2ba3f4da043664e17fc62c81ba1f18f4e744be",
+        "patch": "@@ -714,6 +714,14 @@ font[class*='bg-'] {\n     }\n }\n \n+.btn-close {\n+    // Most components with an integrated .btn-close (o_notification, modals,\n+    // offcanvas, ...) use $body-bg by default, which is why we check it here.\n+    @if lightness($body-bg) < 50 {\n+        @include btn-close-white();\n+    }\n+}\n+\n // Badges\n .badge, .o_filter_tag {\n     --badge-color: var(--color);"
+      }
+    ],
+    "paths": [
+      "addons/website"
+    ]
+  },
+  {
+    "sha": "3893156f9319b08453eaa1e1264952c936d315c8",
+    "node_id": "C_kwDOAS1I7NoAKDM4OTMxNTZmOTMxOWIwODQ1M2VhYTFlMTI2NDk1MmM5MzZkMzE1Yzg",
+    "commit": {
+      "author": {
+        "name": "Robin Lejeune (role)",
+        "email": "role@odoo.com",
+        "date": "2025-09-10T11:40:05Z"
+      },
+      "committer": {
+        "name": "Robin Lejeune (role)",
+        "email": "role@odoo.com",
+        "date": "2025-10-14T14:35:49Z"
+      },
+      "message": "[FIX] website: use `.preview.scss` pattern in add dialog bundle\n\nCommit [ad6e2d3] extracted preview-specific CSS styles from `.edit.scss`\nfiles, in order to load the strict minimum with the bundle.\nCommit [a58f8cf] introduced the pattern `.iframe_add_dialog.scss` for\nSCSS files specific to the add snippet dialog.\nHowever, we already use `.preview.js` patterns for interactions. We will\nthus use the same kind of pattern for the preview styles, by suffixing\nfiles with `.preview.scss`.\n\n[ad6e2d3]: https://github.com/odoo/odoo/commit/ad6e2d3857a87a0dfec93c2bcc597328ef21ba00\n[a58f8cf]: https://github.com/odoo/odoo/commit/a58f8cfd881864e853ce39b7033a2fdec67f721e\n\ncloses odoo/odoo#230945\n\nSigned-off-by: Francois Georis (fge) <fge@odoo.com>",
+      "tree": {
+        "sha": "431c36b1d4101fcb0366a059eab33e06b4900097",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/431c36b1d4101fcb0366a059eab33e06b4900097"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/3893156f9319b08453eaa1e1264952c936d315c8",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/3893156f9319b08453eaa1e1264952c936d315c8",
+    "html_url": "https://github.com/odoo/odoo/commit/3893156f9319b08453eaa1e1264952c936d315c8",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/3893156f9319b08453eaa1e1264952c936d315c8/comments",
+    "author": {
+      "login": "robinlej",
+      "id": 95914584,
+      "node_id": "U_kgDOBbeKWA",
+      "avatar_url": "https://avatars.githubusercontent.com/u/95914584?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/robinlej",
+      "html_url": "https://github.com/robinlej",
+      "followers_url": "https://api.github.com/users/robinlej/followers",
+      "following_url": "https://api.github.com/users/robinlej/following{/other_user}",
+      "gists_url": "https://api.github.com/users/robinlej/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/robinlej/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/robinlej/subscriptions",
+      "organizations_url": "https://api.github.com/users/robinlej/orgs",
+      "repos_url": "https://api.github.com/users/robinlej/repos",
+      "events_url": "https://api.github.com/users/robinlej/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/robinlej/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "robinlej",
+      "id": 95914584,
+      "node_id": "U_kgDOBbeKWA",
+      "avatar_url": "https://avatars.githubusercontent.com/u/95914584?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/robinlej",
+      "html_url": "https://github.com/robinlej",
+      "followers_url": "https://api.github.com/users/robinlej/followers",
+      "following_url": "https://api.github.com/users/robinlej/following{/other_user}",
+      "gists_url": "https://api.github.com/users/robinlej/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/robinlej/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/robinlej/subscriptions",
+      "organizations_url": "https://api.github.com/users/robinlej/orgs",
+      "repos_url": "https://api.github.com/users/robinlej/repos",
+      "events_url": "https://api.github.com/users/robinlej/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/robinlej/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "798ad29a9d898230ddbfdc5b144fa08fcc755190",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/798ad29a9d898230ddbfdc5b144fa08fcc755190",
+        "html_url": "https://github.com/odoo/odoo/commit/798ad29a9d898230ddbfdc5b144fa08fcc755190"
+      }
+    ],
+    "stats": {
+      "total": 1,
+      "additions": 0,
+      "deletions": 1
+    },
+    "files": [
+      {
+        "sha": "47e7c01416ba740b570095608b883ebd5a8b5eb8",
+        "filename": "addons/website/__manifest__.py",
+        "status": "modified",
+        "additions": 0,
+        "deletions": 1,
+        "changes": 1,
+        "blob_url": "https://github.com/odoo/odoo/blob/3893156f9319b08453eaa1e1264952c936d315c8/addons%2Fwebsite%2F__manifest__.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/3893156f9319b08453eaa1e1264952c936d315c8/addons%2Fwebsite%2F__manifest__.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2F__manifest__.py?ref=3893156f9319b08453eaa1e1264952c936d315c8",
+        "patch": "@@ -439,7 +439,6 @@\n             ('remove', 'website/static/src/builder/**/*.edit.*'),\n         ],\n         'html_builder.iframe_add_dialog': [\n-            'website/static/src/snippets/**/*.iframe_add_dialog.scss',\n             'website/static/src/snippets/**/*.preview.scss',\n         ],\n     },"
+      },
+      {
+        "sha": "c342441236614daf81738afda3bf572b883b1c3d",
+        "filename": "addons/website/static/src/snippets/s_banner_product/s_banner_product.preview.scss",
+        "status": "renamed",
+        "additions": 0,
+        "deletions": 0,
+        "changes": 0,
+        "blob_url": "https://github.com/odoo/odoo/blob/3893156f9319b08453eaa1e1264952c936d315c8/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_banner_product%2Fs_banner_product.preview.scss",
+        "raw_url": "https://github.com/odoo/odoo/raw/3893156f9319b08453eaa1e1264952c936d315c8/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_banner_product%2Fs_banner_product.preview.scss",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_banner_product%2Fs_banner_product.preview.scss?ref=3893156f9319b08453eaa1e1264952c936d315c8",
+        "previous_filename": "addons/website/static/src/snippets/s_banner_product/s_banner_product.iframe_add_dialog.scss"
+      },
+      {
+        "sha": "089a0f1d9d60b991c1c6622df371b025508a4d50",
+        "filename": "addons/website/static/src/snippets/s_color_blocks_2/s_color_blocks_2.preview.scss",
+        "status": "renamed",
+        "additions": 0,
+        "deletions": 0,
+        "changes": 0,
+        "blob_url": "https://github.com/odoo/odoo/blob/3893156f9319b08453eaa1e1264952c936d315c8/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_color_blocks_2%2Fs_color_blocks_2.preview.scss",
+        "raw_url": "https://github.com/odoo/odoo/raw/3893156f9319b08453eaa1e1264952c936d315c8/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_color_blocks_2%2Fs_color_blocks_2.preview.scss",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_color_blocks_2%2Fs_color_blocks_2.preview.scss?ref=3893156f9319b08453eaa1e1264952c936d315c8",
+        "previous_filename": "addons/website/static/src/snippets/s_color_blocks_2/s_color_blocks_2.iframe_add_dialog.scss"
+      },
+      {
+        "sha": "751ff3cae3361d3cb45f5b706a68a1769d19e730",
+        "filename": "addons/website/static/src/snippets/s_ecomm_categories_showcase/categories_showcase.preview.scss",
+        "status": "renamed",
+        "additions": 0,
+        "deletions": 0,
+        "changes": 0,
+        "blob_url": "https://github.com/odoo/odoo/blob/3893156f9319b08453eaa1e1264952c936d315c8/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_ecomm_categories_showcase%2Fcategories_showcase.preview.scss",
+        "raw_url": "https://github.com/odoo/odoo/raw/3893156f9319b08453eaa1e1264952c936d315c8/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_ecomm_categories_showcase%2Fcategories_showcase.preview.scss",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_ecomm_categories_showcase%2Fcategories_showcase.preview.scss?ref=3893156f9319b08453eaa1e1264952c936d315c8",
+        "previous_filename": "addons/website/static/src/snippets/s_ecomm_categories_showcase/categories_showcase.iframe_add_dialog.scss"
+      },
+      {
+        "sha": "390d555a0572280254deb6d23c5722003294c61d",
+        "filename": "addons/website/static/src/snippets/s_floating_blocks/floating_blocks.preview.scss",
+        "status": "renamed",
+        "additions": 0,
+        "deletions": 0,
+        "changes": 0,
+        "blob_url": "https://github.com/odoo/odoo/blob/3893156f9319b08453eaa1e1264952c936d315c8/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_floating_blocks%2Ffloating_blocks.preview.scss",
+        "raw_url": "https://github.com/odoo/odoo/raw/3893156f9319b08453eaa1e1264952c936d315c8/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_floating_blocks%2Ffloating_blocks.preview.scss",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_floating_blocks%2Ffloating_blocks.preview.scss?ref=3893156f9319b08453eaa1e1264952c936d315c8",
+        "previous_filename": "addons/website/static/src/snippets/s_floating_blocks/floating_blocks.iframe_add_dialog.scss"
+      }
+    ],
+    "paths": [
+      "addons/website"
+    ]
+  },
+  {
+    "sha": "798ad29a9d898230ddbfdc5b144fa08fcc755190",
+    "node_id": "C_kwDOAS1I7NoAKDc5OGFkMjlhOWQ4OTgyMzBkZGJmZGM1YjE0NGZhMDhmY2M3NTUxOTA",
+    "commit": {
+      "author": {
+        "name": "Robin Lejeune (role)",
+        "email": "role@odoo.com",
+        "date": "2025-09-10T09:50:09Z"
+      },
+      "committer": {
+        "name": "Robin Lejeune (role)",
+        "email": "role@odoo.com",
+        "date": "2025-10-14T14:35:49Z"
+      },
+      "message": "[FIX] website: use a dialog for AnnouncementScroll translation\n\nCommit [e1cc670] added the `s_announcement_scroll` snippet, using a\nbrowser prompt to update the translation of its text. We would rather\nuse an Odoo dialog.\n\nIn the same time, we introduce a resource `mark_translatable_nodes`\ncalled in the `TranslationPlugin`. This will allow a better separation\nof concerns between what is the core translation setup and what is\nspecific to some snippets or elements on the page.\n\n[e1cc670]: https://github.com/odoo/odoo/commit/e1cc6702a4416204e446d51fdfe047d4ebfd402c\n\ntask-5069849\n\nPart-of: odoo/odoo#230945\nSigned-off-by: Francois Georis (fge) <fge@odoo.com>",
+      "tree": {
+        "sha": "c3ebc4017546d5e20eb4e457ea068cd10cec8357",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/c3ebc4017546d5e20eb4e457ea068cd10cec8357"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/798ad29a9d898230ddbfdc5b144fa08fcc755190",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/798ad29a9d898230ddbfdc5b144fa08fcc755190",
+    "html_url": "https://github.com/odoo/odoo/commit/798ad29a9d898230ddbfdc5b144fa08fcc755190",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/798ad29a9d898230ddbfdc5b144fa08fcc755190/comments",
+    "author": {
+      "login": "robinlej",
+      "id": 95914584,
+      "node_id": "U_kgDOBbeKWA",
+      "avatar_url": "https://avatars.githubusercontent.com/u/95914584?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/robinlej",
+      "html_url": "https://github.com/robinlej",
+      "followers_url": "https://api.github.com/users/robinlej/followers",
+      "following_url": "https://api.github.com/users/robinlej/following{/other_user}",
+      "gists_url": "https://api.github.com/users/robinlej/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/robinlej/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/robinlej/subscriptions",
+      "organizations_url": "https://api.github.com/users/robinlej/orgs",
+      "repos_url": "https://api.github.com/users/robinlej/repos",
+      "events_url": "https://api.github.com/users/robinlej/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/robinlej/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "robinlej",
+      "id": 95914584,
+      "node_id": "U_kgDOBbeKWA",
+      "avatar_url": "https://avatars.githubusercontent.com/u/95914584?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/robinlej",
+      "html_url": "https://github.com/robinlej",
+      "followers_url": "https://api.github.com/users/robinlej/followers",
+      "following_url": "https://api.github.com/users/robinlej/following{/other_user}",
+      "gists_url": "https://api.github.com/users/robinlej/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/robinlej/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/robinlej/subscriptions",
+      "organizations_url": "https://api.github.com/users/robinlej/orgs",
+      "repos_url": "https://api.github.com/users/robinlej/repos",
+      "events_url": "https://api.github.com/users/robinlej/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/robinlej/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "0e03cf93a331b096b79a523cc7f1709b612896ec",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/0e03cf93a331b096b79a523cc7f1709b612896ec",
+        "html_url": "https://github.com/odoo/odoo/commit/0e03cf93a331b096b79a523cc7f1709b612896ec"
+      }
+    ],
+    "stats": {
+      "total": 95,
+      "additions": 66,
+      "deletions": 29
+    },
+    "files": [
+      {
+        "sha": "af38008b28fb88970433d757e98ac1d2c997b7f8",
+        "filename": "addons/website/static/src/builder/plugins/translate_announcement_scroll_plugin.js",
+        "status": "added",
+        "additions": 57,
+        "deletions": 0,
+        "changes": 57,
+        "blob_url": "https://github.com/odoo/odoo/blob/798ad29a9d898230ddbfdc5b144fa08fcc755190/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fplugins%2Ftranslate_announcement_scroll_plugin.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/798ad29a9d898230ddbfdc5b144fa08fcc755190/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fplugins%2Ftranslate_announcement_scroll_plugin.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fplugins%2Ftranslate_announcement_scroll_plugin.js?ref=798ad29a9d898230ddbfdc5b144fa08fcc755190",
+        "patch": "@@ -0,0 +1,57 @@\n+import { InputConfirmationDialog } from \"@html_builder/snippets/input_confirmation_dialog\";\n+import { Plugin } from \"@html_editor/plugin\";\n+import { _t } from \"@web/core/l10n/translation\";\n+\n+export class TranslateAnnouncementScrollPlugin extends Plugin {\n+    static id = \"translateAnnouncementScroll\";\n+    static dependencies = [\"history\"];\n+\n+    resources = {\n+        mark_translatable_nodes: this.listenToAnnouncementScrollClick.bind(this),\n+    };\n+\n+    /**\n+     * On click, opens a dialog to translate the interaction's text.\n+     */\n+    listenToAnnouncementScrollClick() {\n+        const announcementScrollEls = this.document.querySelectorAll(\".s_announcement_scroll\");\n+\n+        for (const announcementScrollEl of announcementScrollEls) {\n+            this.addDomListener(announcementScrollEl, \"click\", () => {\n+                this.rollbackHistory = this.dependencies.history.makeSavePoint();\n+\n+                const translatableEl = announcementScrollEl.querySelector(\n+                    \".s_announcement_scroll_marquee_item:first-child > [data-oe-translation-source-sha]\"\n+                );\n+\n+                this.services.dialog.add(InputConfirmationDialog, {\n+                    defaultValue: translatableEl.textContent,\n+                    title: _t(\"Translate Text\"),\n+                    confirmLabel: _t(\"Save\"),\n+                    cancelLabel: _t(\"Apply\"),\n+                    inputLabel: _t(\"Translation\"),\n+                    confirm: this.updateText.bind(this, translatableEl),\n+                    // Override \"cancel\" to have an \"apply\" button.\n+                    cancel: (inputValue) => {\n+                        this.updateText.apply(this, [translatableEl, inputValue]);\n+                        return false;\n+                    },\n+                    dismiss: this.rollbackHistory,\n+                });\n+            });\n+        }\n+    }\n+    /**\n+     * Update the translated text.\n+     *\n+     * @param {HTMLElement} translatableEl\n+     * @param {String} inputValue\n+     */\n+    updateText(translatableEl, inputValue) {\n+        if (inputValue !== translatableEl.textContent) {\n+            translatableEl.textContent = inputValue;\n+            translatableEl.dataset.oeTranslationState = \"translated\";\n+            this.dependencies.history.addStep();\n+        }\n+    }\n+}"
+      },
+      {
+        "sha": "fed9dd2dc0e978ecae87c3efc698252be4cce219",
+        "filename": "addons/website/static/src/builder/plugins/translation_plugin.js",
+        "status": "modified",
+        "additions": 5,
+        "deletions": 28,
+        "changes": 33,
+        "blob_url": "https://github.com/odoo/odoo/blob/798ad29a9d898230ddbfdc5b144fa08fcc755190/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fplugins%2Ftranslation_plugin.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/798ad29a9d898230ddbfdc5b144fa08fcc755190/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fplugins%2Ftranslation_plugin.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fplugins%2Ftranslation_plugin.js?ref=798ad29a9d898230ddbfdc5b144fa08fcc755190",
+        "patch": "@@ -86,10 +86,9 @@ export class TranslationPlugin extends Plugin {\n     }\n \n     prepareTranslation() {\n-        const editableEls = findOEditable(this.editable);\n-        this.buildTranslationInfoMap(editableEls);\n-        this.handleSelectTranslation(editableEls);\n-        this.handleAnnouncementScrollTranslation(editableEls);\n+        this.editableEls = findOEditable(this.editable);\n+        this.buildTranslationInfoMap(this.editableEls);\n+        this.handleSelectTranslation(this.editableEls);\n         this.markTranslatableNodes();\n         for (const [translatedEl] of this.elToTranslationInfoMap) {\n             if (translatedEl.matches(\"input[type=hidden].o_translatable_input_hidden\")) {\n@@ -130,7 +129,7 @@ export class TranslationPlugin extends Plugin {\n                 sticky: false,\n             });\n         };\n-        for (const translateEl of editableEls) {\n+        for (const translateEl of this.editableEls) {\n             this.handleToC(translateEl);\n         }\n         const savableInsideNotEditableEls = this.editable.querySelectorAll(\n@@ -234,14 +233,6 @@ export class TranslationPlugin extends Plugin {\n         }\n     }\n \n-    handleAnnouncementScrollTranslation(editableEls) {\n-        this.announcementScrollEls = editableEls\n-            .filter((el) =>\n-                el.parentElement.classList.contains(\"s_announcement_scroll_marquee_item\")\n-            )\n-            .map((el) => el.closest(\".s_announcement_scroll\"));\n-    }\n-\n     handleToC(translateEl) {\n         if (translateEl.closest(\".s_table_of_content_navbar_wrap\")) {\n             // Make sure the same translation ids are used\n@@ -305,21 +296,7 @@ export class TranslationPlugin extends Plugin {\n                 });\n             });\n         }\n-        for (const announcementScrollEl of this.announcementScrollEls) {\n-            // FIXME\n-            // 1. Do not use prompt but an Odoo dialog\n-            // 2. The interaction should be restarted when the text changes\n-            // => There should probably be a better way to handle this.\n-            this.addDomListener(announcementScrollEl, \"click\", (ev) => {\n-                const els = announcementScrollEl.querySelectorAll(\n-                    \".s_announcement_scroll_marquee_item > [data-oe-translation-source-sha]\"\n-                );\n-                const value = prompt(\"\", els[0].textContent);\n-                for (const el of els) {\n-                    el.textContent = value;\n-                }\n-            });\n-        }\n+        this.dispatchTo(\"mark_translatable_nodes\", this.editableEls);\n     }\n \n     updateTranslationMap(translateEl, translation, attrName) {"
+      },
+      {
+        "sha": "5ed5551c522ed28216ec822382a9e2af59358d39",
+        "filename": "addons/website/static/src/builder/website_builder.js",
+        "status": "modified",
+        "additions": 2,
+        "deletions": 0,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/798ad29a9d898230ddbfdc5b144fa08fcc755190/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fwebsite_builder.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/798ad29a9d898230ddbfdc5b144fa08fcc755190/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fwebsite_builder.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fwebsite_builder.js?ref=798ad29a9d898230ddbfdc5b144fa08fcc755190",
+        "patch": "@@ -17,6 +17,7 @@ import { useSetupAction } from \"@web/search/action_hook\";\n import { HighlightPlugin } from \"./plugins/highlight/highlight_plugin\";\n import { PopupVisibilityPlugin } from \"./plugins/popup_visibility_plugin\";\n import { SaveTranslationPlugin } from \"./plugins/save_translation_plugin\";\n+import { TranslateAnnouncementScrollPlugin } from \"./plugins/translate_announcement_scroll_plugin\";\n import { TranslateLinkInlinePlugin } from \"./plugins/translate_link_inline_plugin\";\n import { TranslationPlugin } from \"./plugins/translation_plugin\";\n import { WebsiteVisibilityPlugin } from \"./plugins/website_visibility_plugin\";\n@@ -56,6 +57,7 @@ const TRANSLATION_PLUGINS = [\n     SaveTranslationPlugin,\n     TranslateLinkInlinePlugin,\n     TranslationPlugin,\n+    TranslateAnnouncementScrollPlugin,\n     WebsiteVisibilityPlugin,\n     AnimateOptionPlugin,\n     HighlightPlugin,"
+      },
+      {
+        "sha": "e27eb0b2114a1dbee8e66369aa4ec5b0223ca1a6",
+        "filename": "addons/website/static/src/snippets/s_announcement_scroll/announcement_scroll.edit.js",
+        "status": "modified",
+        "additions": 2,
+        "deletions": 1,
+        "changes": 3,
+        "blob_url": "https://github.com/odoo/odoo/blob/798ad29a9d898230ddbfdc5b144fa08fcc755190/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_announcement_scroll%2Fannouncement_scroll.edit.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/798ad29a9d898230ddbfdc5b144fa08fcc755190/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_announcement_scroll%2Fannouncement_scroll.edit.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_announcement_scroll%2Fannouncement_scroll.edit.js?ref=798ad29a9d898230ddbfdc5b144fa08fcc755190",
+        "patch": "@@ -14,7 +14,8 @@ export const AnnouncementScrollEdit = (I) =>\n                 this.el.contains(el) &&\n                 el.matches(\n                     `.s_announcement_scroll_marquee_container,\n-                    .s_announcement_scroll_marquee_item:first-child`\n+                    .s_announcement_scroll_marquee_item:first-child,\n+                    .s_announcement_scroll_marquee_item:first-child > [data-oe-translation-source-sha]`\n                 )\n             );\n         }"
+      }
+    ],
+    "paths": [
+      "addons/website"
+    ]
+  },
+  {
+    "sha": "0e03cf93a331b096b79a523cc7f1709b612896ec",
+    "node_id": "C_kwDOAS1I7NoAKDBlMDNjZjkzYTMzMWIwOTZiNzlhNTIzY2M3ZjE3MDliNjEyODk2ZWM",
+    "commit": {
+      "author": {
+        "name": "Robin Lejeune (role)",
+        "email": "role@odoo.com",
+        "date": "2025-09-10T09:21:16Z"
+      },
+      "committer": {
+        "name": "Robin Lejeune (role)",
+        "email": "role@odoo.com",
+        "date": "2025-10-14T14:35:49Z"
+      },
+      "message": "[FIX] website: properly restart AnnouncementScroll interaction\n\nCommit [e1cc670] introduced the `s_announcement_scroll` snippet, with an\ninteraction and some options. The way the interaction was restarted\nafter each option change was hacky, which is what this commit intends to\nfix.\n\nWe also make small CSS adjustements:\n- Make sure the preview is working both on hover and when focusing with\nTab.\n- Avoid the hover effect on mobile. On mobile, a click triggers the\n`:hover` styles, but there is no way to go back to the initial state\nafterwards, leading to the snippet being paused forever.\n- Prevent auto scrolling and parallax if the user's preference is set to\n`prefers-reduced-motion: reduce`.\n\n[e1cc670]: https://github.com/odoo/odoo/commit/e1cc6702a4416204e446d51fdfe047d4ebfd402c\n\ntask-5069849\n\nPart-of: odoo/odoo#230945\nSigned-off-by: Francois Georis (fge) <fge@odoo.com>",
+      "tree": {
+        "sha": "1bb6090aeabd1b0c14d806b26588f16c372291e2",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/1bb6090aeabd1b0c14d806b26588f16c372291e2"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/0e03cf93a331b096b79a523cc7f1709b612896ec",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/0e03cf93a331b096b79a523cc7f1709b612896ec",
+    "html_url": "https://github.com/odoo/odoo/commit/0e03cf93a331b096b79a523cc7f1709b612896ec",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/0e03cf93a331b096b79a523cc7f1709b612896ec/comments",
+    "author": {
+      "login": "robinlej",
+      "id": 95914584,
+      "node_id": "U_kgDOBbeKWA",
+      "avatar_url": "https://avatars.githubusercontent.com/u/95914584?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/robinlej",
+      "html_url": "https://github.com/robinlej",
+      "followers_url": "https://api.github.com/users/robinlej/followers",
+      "following_url": "https://api.github.com/users/robinlej/following{/other_user}",
+      "gists_url": "https://api.github.com/users/robinlej/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/robinlej/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/robinlej/subscriptions",
+      "organizations_url": "https://api.github.com/users/robinlej/orgs",
+      "repos_url": "https://api.github.com/users/robinlej/repos",
+      "events_url": "https://api.github.com/users/robinlej/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/robinlej/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "robinlej",
+      "id": 95914584,
+      "node_id": "U_kgDOBbeKWA",
+      "avatar_url": "https://avatars.githubusercontent.com/u/95914584?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/robinlej",
+      "html_url": "https://github.com/robinlej",
+      "followers_url": "https://api.github.com/users/robinlej/followers",
+      "following_url": "https://api.github.com/users/robinlej/following{/other_user}",
+      "gists_url": "https://api.github.com/users/robinlej/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/robinlej/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/robinlej/subscriptions",
+      "organizations_url": "https://api.github.com/users/robinlej/orgs",
+      "repos_url": "https://api.github.com/users/robinlej/repos",
+      "events_url": "https://api.github.com/users/robinlej/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/robinlej/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "51be3b456d0a65c10175a56a1ba965c35a4e7c62",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/51be3b456d0a65c10175a56a1ba965c35a4e7c62",
+        "html_url": "https://github.com/odoo/odoo/commit/51be3b456d0a65c10175a56a1ba965c35a4e7c62"
+      }
+    ],
+    "stats": {
+      "total": 105,
+      "additions": 55,
+      "deletions": 50
+    },
+    "files": [
+      {
+        "sha": "cac4d7f0edc3947eba749cbdb9ee339ec5b39b01",
+        "filename": "addons/website/__manifest__.py",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 0,
+        "changes": 1,
+        "blob_url": "https://github.com/odoo/odoo/blob/0e03cf93a331b096b79a523cc7f1709b612896ec/addons%2Fwebsite%2F__manifest__.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/0e03cf93a331b096b79a523cc7f1709b612896ec/addons%2Fwebsite%2F__manifest__.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2F__manifest__.py?ref=0e03cf93a331b096b79a523cc7f1709b612896ec",
+        "patch": "@@ -440,6 +440,7 @@\n         ],\n         'html_builder.iframe_add_dialog': [\n             'website/static/src/snippets/**/*.iframe_add_dialog.scss',\n+            'website/static/src/snippets/**/*.preview.scss',\n         ],\n     },\n     'configurator_snippets': {"
+      },
+      {
+        "sha": "4092e22b7d8bd724d8d12ef1532aafdb06c612bf",
+        "filename": "addons/website/static/src/builder/plugins/options/announcement_scroll_option.xml",
+        "status": "modified",
+        "additions": 4,
+        "deletions": 7,
+        "changes": 11,
+        "blob_url": "https://github.com/odoo/odoo/blob/0e03cf93a331b096b79a523cc7f1709b612896ec/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fplugins%2Foptions%2Fannouncement_scroll_option.xml",
+        "raw_url": "https://github.com/odoo/odoo/raw/0e03cf93a331b096b79a523cc7f1709b612896ec/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fplugins%2Foptions%2Fannouncement_scroll_option.xml",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fplugins%2Foptions%2Fannouncement_scroll_option.xml?ref=0e03cf93a331b096b79a523cc7f1709b612896ec",
+        "patch": "@@ -8,7 +8,7 @@\n             applyTo=\"'.s_announcement_scroll_marquee_item:first-child'\"/>\n     </BuilderRow>\n     <BuilderRow label.translate=\"Direction\">\n-        <BuilderSelect action=\"'restartInteraction'\">\n+        <BuilderSelect>\n             <BuilderSelectItem classAction=\"'s_announcement_scroll_direction_left'\">Left</BuilderSelectItem>\n             <BuilderSelectItem classAction=\"'s_announcement_scroll_direction_right'\">Right</BuilderSelectItem>\n             <BuilderSelectItem id=\"'announcement_scroll_direction_none_opt'\"\n@@ -20,14 +20,13 @@\n     <t t-if=\"!this.isActiveItem('announcement_scroll_direction_none_opt')\">\n         <BuilderRow level=\"1\" label.translate=\"Scroll Speed\">\n             <BuilderRange styleAction=\"'--marquee-animation-speed'\"\n-                action=\"'restartInteraction'\"\n                 min=\"1\"\n                 max=\"10\"\n                 step=\"1\"\n                 unit=\"'s'\"/>\n         </BuilderRow>\n         <BuilderRow label.translate=\"Hover effect\">\n-            <BuilderSelect action=\"'restartInteraction'\">\n+            <BuilderSelect>\n                 <BuilderSelectItem classAction=\"''\">None</BuilderSelectItem>\n                 <BuilderSelectItem classAction=\"'s_announcement_scroll_hover_pause'\">Pause</BuilderSelectItem>\n                 <BuilderSelectItem classAction=\"'s_announcement_scroll_hover_slow'\">Slowdown</BuilderSelectItem>\n@@ -36,12 +35,10 @@\n         </BuilderRow>\n     </t>\n     <BuilderRow label.translate=\"Parallax\">\n-        <BuilderCheckbox classAction=\"'s_announcement_scroll_parallax'\"\n-            action=\"'restartInteraction'\"/>\n+        <BuilderCheckbox classAction=\"'s_announcement_scroll_parallax'\"/>\n     </BuilderRow>\n     <BuilderRow label.translate=\"Font Size\">\n         <BuilderRange styleAction=\"'--marquee-item-font-size'\"\n-            action=\"'restartInteraction'\"\n             min=\"40\"\n             max=\"320\"\n             step=\"8\"\n@@ -50,7 +47,7 @@\n     <BuilderRow label.translate=\"Font Family\"\n             applyTo=\"'.s_announcement_scroll_marquee_container'\"\n             tooltip.translate=\"Apply the font-family of your paragraph or headings from your Theme settings\">\n-        <BuilderSelect action=\"'restartInteraction'\">\n+        <BuilderSelect>\n             <BuilderSelectItem classAction=\"'s_announcement_scroll_heading_family'\">Headings</BuilderSelectItem>\n             <BuilderSelectItem classAction=\"''\">Paragraph</BuilderSelectItem>\n         </BuilderSelect>"
+      },
+      {
+        "sha": "614eb406d40c257b9e36b1540cde3a56daf36b03",
+        "filename": "addons/website/static/src/builder/plugins/options/announcement_scroll_option_plugin.js",
+        "status": "modified",
+        "additions": 0,
+        "deletions": 23,
+        "changes": 23,
+        "blob_url": "https://github.com/odoo/odoo/blob/0e03cf93a331b096b79a523cc7f1709b612896ec/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fplugins%2Foptions%2Fannouncement_scroll_option_plugin.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/0e03cf93a331b096b79a523cc7f1709b612896ec/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fplugins%2Foptions%2Fannouncement_scroll_option_plugin.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fplugins%2Foptions%2Fannouncement_scroll_option_plugin.js?ref=0e03cf93a331b096b79a523cc7f1709b612896ec",
+        "patch": "@@ -5,24 +5,6 @@ import { BuilderAction } from \"@html_builder/core/builder_action\";\n import { after } from \"@html_builder/utils/option_sequence\";\n import { WEBSITE_BACKGROUND_OPTIONS } from \"@website/builder/option_sequence\";\n \n-\n-// TODO this should not be needed: the interaction of this snippet heavily\n-// relies on the size of its inner elements: it should restart on any change\n-// of the related options, at least... but this does not seem achievable without\n-// something like this (`getConfigurationSnapshot` does not work). Even changes\n-// of style/class on the main element does not restart the animation without\n-// overriding `getConfigurationSnapshot` in this case (?).\n-// See ANNOUNCEMENT_SCROLL_INTERACTION_RESTART.\n-class RestartInteraction extends BuilderAction {\n-    static id = \"restartInteraction\";\n-    static dependencies = [\"edit_interaction\"];\n-\n-    apply({ editingElement, value, params }) {\n-        const snippetEl = editingElement.closest('.s_announcement_scroll');\n-        this.dependencies.edit_interaction.restartInteractions(snippetEl);\n-    }\n-}\n-\n class SetItemTextAction extends BuilderAction {\n     static id = \"setItemTextAction\";\n     static dependencies = [\"edit_interaction\"];\n@@ -32,10 +14,6 @@ class SetItemTextAction extends BuilderAction {\n     }\n     apply({ editingElement, value, params }) {\n         editingElement.textContent = value;\n-\n-        // TODO. See ANNOUNCEMENT_SCROLL_INTERACTION_RESTART.\n-        const snippetEl = editingElement.closest('.s_announcement_scroll');\n-        this.dependencies.edit_interaction.restartInteractions(snippetEl);\n     }\n }\n \n@@ -50,7 +28,6 @@ export class AnnouncementScrollOptionPlugin extends Plugin {\n             }),\n         ],\n         builder_actions: {\n-            RestartInteraction,\n             SetItemTextAction,\n         },\n     };"
+      },
+      {
+        "sha": "e7971e54793d79eeae47f43a55003819fe20191a",
+        "filename": "addons/website/static/src/snippets/s_announcement_scroll/000.scss",
+        "status": "modified",
+        "additions": 19,
+        "deletions": 12,
+        "changes": 31,
+        "blob_url": "https://github.com/odoo/odoo/blob/0e03cf93a331b096b79a523cc7f1709b612896ec/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_announcement_scroll%2F000.scss",
+        "raw_url": "https://github.com/odoo/odoo/raw/0e03cf93a331b096b79a523cc7f1709b612896ec/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_announcement_scroll%2F000.scss",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_announcement_scroll%2F000.scss?ref=0e03cf93a331b096b79a523cc7f1709b612896ec",
+        "patch": "@@ -5,6 +5,12 @@\n     .s_announcement_scroll_marquee_item {\n         white-space: preserve nowrap;\n         caret-color: transparent; // o_not_editable doesn't hide the caret on Firefox\n+\n+        @media (prefers-reduced-motion: reduce) {\n+            & {\n+                animation: none !important;\n+            }\n+        }\n     }\n \n     // Item options\n@@ -36,23 +42,24 @@\n             --marquee-animation-hover-multiplier: 2;\n         }\n \n-        // Hover effects, only when not scrolling\n-        &:where(:hover:not(.s_announcement_scroll_page_scrolling)) {\n-\n-            &.s_announcement_scroll_hover_pause .s_announcement_scroll_marquee_item {\n-                animation-play-state: paused;\n-            }\n-            &.s_announcement_scroll_hover_slow .s_announcement_scroll_marquee_item {\n-                animation-play-state: running;\n-            }\n-            &.s_announcement_scroll_hover_direction .s_announcement_scroll_marquee_item {\n-                animation-play-state: paused, running;\n+        // Hover effects, only when not scrolling and on devices that support\n+        // hover.\n+        @media (hover: hover) {\n+            &:where(:hover:not(.s_announcement_scroll_page_scrolling)) {\n+                &.s_announcement_scroll_hover_pause .s_announcement_scroll_marquee_item {\n+                    animation-play-state: paused;\n+                }\n+                &.s_announcement_scroll_hover_slow .s_announcement_scroll_marquee_item {\n+                    animation-play-state: running;\n+                }\n+                &.s_announcement_scroll_hover_direction .s_announcement_scroll_marquee_item {\n+                    animation-play-state: paused, running;\n+                }\n             }\n         }\n \n         // Parallax effects: disabling the CSS animation while scrolling\n         &:where(.s_announcement_scroll_page_scrolling) {\n-\n             &.s_announcement_scroll_parallax .s_announcement_scroll_marquee_item {\n                 animation-play-state: paused;\n             }"
+      },
+      {
+        "sha": "53811cd3d16233c501cfaecb8bfffa25ca31e94d",
+        "filename": "addons/website/static/src/snippets/s_announcement_scroll/announcement_scroll.edit.js",
+        "status": "added",
+        "additions": 26,
+        "deletions": 0,
+        "changes": 26,
+        "blob_url": "https://github.com/odoo/odoo/blob/0e03cf93a331b096b79a523cc7f1709b612896ec/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_announcement_scroll%2Fannouncement_scroll.edit.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/0e03cf93a331b096b79a523cc7f1709b612896ec/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_announcement_scroll%2Fannouncement_scroll.edit.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_announcement_scroll%2Fannouncement_scroll.edit.js?ref=0e03cf93a331b096b79a523cc7f1709b612896ec",
+        "patch": "@@ -0,0 +1,26 @@\n+import { registry } from \"@web/core/registry\";\n+import { AnnouncementScroll } from \"./announcement_scroll\";\n+\n+export const AnnouncementScrollEdit = (I) =>\n+    class extends I {\n+        shouldStop() {\n+            // Should always restart, because each option may modify the width of\n+            // the element, meaning the interaction needs to recompute.\n+            return true;\n+        }\n+        isImpactedBy(el) {\n+            // After an update of the font family or the text content.\n+            return (\n+                this.el.contains(el) &&\n+                el.matches(\n+                    `.s_announcement_scroll_marquee_container,\n+                    .s_announcement_scroll_marquee_item:first-child`\n+                )\n+            );\n+        }\n+    };\n+\n+registry.category(\"public.interactions.edit\").add(\"website.announcement_scroll\", {\n+    Interaction: AnnouncementScroll,\n+    mixin: AnnouncementScrollEdit,\n+});"
+      },
+      {
+        "sha": "d7d4c319f9c6aed1b2f6759acf8e324f0c2d22b4",
+        "filename": "addons/website/static/src/snippets/s_announcement_scroll/announcement_scroll.js",
+        "status": "modified",
+        "additions": 4,
+        "deletions": 7,
+        "changes": 11,
+        "blob_url": "https://github.com/odoo/odoo/blob/0e03cf93a331b096b79a523cc7f1709b612896ec/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_announcement_scroll%2Fannouncement_scroll.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/0e03cf93a331b096b79a523cc7f1709b612896ec/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_announcement_scroll%2Fannouncement_scroll.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_announcement_scroll%2Fannouncement_scroll.js?ref=0e03cf93a331b096b79a523cc7f1709b612896ec",
+        "patch": "@@ -74,7 +74,10 @@ export class AnnouncementScroll extends Interaction {\n     setParallaxPosition() {\n         const MIN_LEFT_SHIFT = 50;\n \n-        if (!this.el.classList.contains('s_announcement_scroll_parallax')) {\n+        if (\n+            !this.el.classList.contains(\"s_announcement_scroll_parallax\") ||\n+            window.matchMedia(\"(prefers-reduced-motion: reduce)\").matches === true\n+        ) {\n             this.parallaxPosition = -MIN_LEFT_SHIFT;\n             return;\n         }\n@@ -133,9 +136,3 @@ export class AnnouncementScroll extends Interaction {\n registry\n     .category(\"public.interactions\")\n     .add(\"website.announcement_scroll\", AnnouncementScroll);\n-\n-registry\n-    .category(\"public.interactions.edit\")\n-    .add(\"website.announcement_scroll\", {\n-        Interaction: AnnouncementScroll,\n-    });"
+      },
+      {
+        "sha": "f43162c1c4c54864c7d94707e8667b13a7987a2f",
+        "filename": "addons/website/static/src/snippets/s_announcement_scroll/announcement_scroll.preview.scss",
+        "status": "renamed",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/0e03cf93a331b096b79a523cc7f1709b612896ec/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_announcement_scroll%2Fannouncement_scroll.preview.scss",
+        "raw_url": "https://github.com/odoo/odoo/raw/0e03cf93a331b096b79a523cc7f1709b612896ec/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_announcement_scroll%2Fannouncement_scroll.preview.scss",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_announcement_scroll%2Fannouncement_scroll.preview.scss?ref=0e03cf93a331b096b79a523cc7f1709b612896ec",
+        "patch": "@@ -3,7 +3,7 @@\n // Performs an animation on :hover showcasing the user how the snippet behaves\n // in use. Measurements and values are arbitrary, the goal is just to provide\n // a preview.\n-.o_snippet_preview_wrap:hover [data-snippet=\"s_announcement_scroll\"] {\n+.o_snippet_preview_wrap:where(:hover, :focus-visible)  [data-snippet=\"s_announcement_scroll\"] {\n     animation-play-state: running;\n \n     .s_announcement_scroll_marquee_item {",
+        "previous_filename": "addons/website/static/src/snippets/s_announcement_scroll/announcement_scroll.edit.scss"
+      }
+    ],
+    "paths": [
+      "addons/website"
+    ]
+  },
+  {
+    "sha": "239fce02bec48e06bbeeb00062a320c3111205dd",
+    "node_id": "C_kwDOAS1I7NoAKDIzOWZjZTAyYmVjNDhlMDZiYmVlYjAwMDYyYTMyMGMzMTExMjA1ZGQ",
+    "commit": {
+      "author": {
+        "name": "Krzysztof Magusiak (krma)",
+        "email": "krma@odoo.com",
+        "date": "2025-08-06T10:59:22Z"
+      },
+      "committer": {
+        "name": "Krzysztof Magusiak (krma)",
+        "email": "krma@odoo.com",
+        "date": "2025-10-14T10:10:10Z"
+      },
+      "message": "[IMP] http: deprecate GeoIP dictionnary API\n\nThe API was scheduled for removal. Updating last references.\n\nPart-of: odoo/odoo#231365\nSigned-off-by: Julien Castiaux (juc) <juc@odoo.com>",
+      "tree": {
+        "sha": "bf2e673b8d5a15df373b7b7826c56a797e0b7b8d",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/bf2e673b8d5a15df373b7b7826c56a797e0b7b8d"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/239fce02bec48e06bbeeb00062a320c3111205dd",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/239fce02bec48e06bbeeb00062a320c3111205dd",
+    "html_url": "https://github.com/odoo/odoo/commit/239fce02bec48e06bbeeb00062a320c3111205dd",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/239fce02bec48e06bbeeb00062a320c3111205dd/comments",
+    "author": {
+      "login": "kmagusiak",
+      "id": 1943198,
+      "node_id": "MDQ6VXNlcjE5NDMxOTg=",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1943198?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/kmagusiak",
+      "html_url": "https://github.com/kmagusiak",
+      "followers_url": "https://api.github.com/users/kmagusiak/followers",
+      "following_url": "https://api.github.com/users/kmagusiak/following{/other_user}",
+      "gists_url": "https://api.github.com/users/kmagusiak/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/kmagusiak/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/kmagusiak/subscriptions",
+      "organizations_url": "https://api.github.com/users/kmagusiak/orgs",
+      "repos_url": "https://api.github.com/users/kmagusiak/repos",
+      "events_url": "https://api.github.com/users/kmagusiak/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/kmagusiak/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "kmagusiak",
+      "id": 1943198,
+      "node_id": "MDQ6VXNlcjE5NDMxOTg=",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1943198?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/kmagusiak",
+      "html_url": "https://github.com/kmagusiak",
+      "followers_url": "https://api.github.com/users/kmagusiak/followers",
+      "following_url": "https://api.github.com/users/kmagusiak/following{/other_user}",
+      "gists_url": "https://api.github.com/users/kmagusiak/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/kmagusiak/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/kmagusiak/subscriptions",
+      "organizations_url": "https://api.github.com/users/kmagusiak/orgs",
+      "repos_url": "https://api.github.com/users/kmagusiak/repos",
+      "events_url": "https://api.github.com/users/kmagusiak/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/kmagusiak/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "d338a8f21521979986fc359f8b6dc3537993ba6d",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/d338a8f21521979986fc359f8b6dc3537993ba6d",
+        "html_url": "https://github.com/odoo/odoo/commit/d338a8f21521979986fc359f8b6dc3537993ba6d"
+      }
+    ],
+    "stats": {
+      "total": 15,
+      "additions": 8,
+      "deletions": 7
+    },
+    "files": [
+      {
+        "sha": "0e533be642e98c4ab57211c9d4bd43170d660cac",
+        "filename": "addons/mail/models/res_users.py",
+        "status": "modified",
+        "additions": 4,
+        "deletions": 3,
+        "changes": 7,
+        "blob_url": "https://github.com/odoo/odoo/blob/239fce02bec48e06bbeeb00062a320c3111205dd/addons%2Fmail%2Fmodels%2Fres_users.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/239fce02bec48e06bbeeb00062a320c3111205dd/addons%2Fmail%2Fmodels%2Fres_users.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fmail%2Fmodels%2Fres_users.py?ref=239fce02bec48e06bbeeb00062a320c3111205dd",
+        "patch": "@@ -331,9 +331,10 @@ def _notify_security_setting_update_prepare_values(self, content, **kwargs):\n         if not request:\n             return values\n \n-        city = request.geoip.get('city') or False\n-        region = request.geoip.get('region_name') or False\n-        country = request.geoip.get('country') or False\n+        city = request.geoip.city.name or False\n+        subdivisons = request.geoip.subdivisions\n+        region = subdivisons[0].iso_code if subdivisons and subdivisons[0].iso_code else False\n+        country = request.geoip.country_name or False\n         if country:\n             if region and city:\n                 values['location_address'] = _(\"Near %(city)s, %(region)s, %(country)s\", city=city, region=region, country=country)"
+      },
+      {
+        "sha": "030145903a2bfbfeb580d2c0ac55dc27d3ac750d",
+        "filename": "addons/website/models/website_visitor.py",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/239fce02bec48e06bbeeb00062a320c3111205dd/addons%2Fwebsite%2Fmodels%2Fwebsite_visitor.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/239fce02bec48e06bbeeb00062a320c3111205dd/addons%2Fwebsite%2Fmodels%2Fwebsite_visitor.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fmodels%2Fwebsite_visitor.py?ref=239fce02bec48e06bbeeb00062a320c3111205dd",
+        "patch": "@@ -208,7 +208,7 @@ def _upsert_visitor(self, access_token, force_track_values=None):\n             'lang_id': request.lang.id,\n             # Note that it's possible for the GEOIP database to return a country\n             # code which is unknown in Odoo\n-            'country_code': request.geoip.get('country_code'),\n+            'country_code': request.geoip.country_code,\n             'website_id': request.website.id,\n             'timezone': self._get_visitor_timezone() or None,\n             'write_uid': self.env.uid,"
+      },
+      {
+        "sha": "1be28137b8f1b38fb783ff16c25cfaa580837c62",
+        "filename": "odoo/addons/base/models/res_device.py",
+        "status": "modified",
+        "additions": 2,
+        "deletions": 2,
+        "changes": 4,
+        "blob_url": "https://github.com/odoo/odoo/blob/239fce02bec48e06bbeeb00062a320c3111205dd/odoo%2Faddons%2Fbase%2Fmodels%2Fres_device.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/239fce02bec48e06bbeeb00062a320c3111205dd/odoo%2Faddons%2Fbase%2Fmodels%2Fres_device.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/odoo%2Faddons%2Fbase%2Fmodels%2Fres_device.py?ref=239fce02bec48e06bbeeb00062a320c3111205dd",
+        "patch": "@@ -103,8 +103,8 @@ def _update_device(self, request):\n                 platform=trace['platform'],\n                 browser=trace['browser'],\n                 ip_address=trace['ip_address'],\n-                country=geoip.get('country_name'),\n-                city=geoip.get('city'),\n+                country=geoip.country_name,\n+                city=geoip.city.name,\n                 device_type='mobile' if self._is_mobile(trace['platform']) else 'computer',\n                 user_id=user_id,\n                 first_activity=datetime.fromtimestamp(trace['first_activity']),"
+      },
+      {
+        "sha": "2d6bf4b121c7a3f9ecc2c4b9b754c67929f299bb",
+        "filename": "odoo/http.py",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/239fce02bec48e06bbeeb00062a320c3111205dd/odoo%2Fhttp.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/239fce02bec48e06bbeeb00062a320c3111205dd/odoo%2Fhttp.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/odoo%2Fhttp.py?ref=239fce02bec48e06bbeeb00062a320c3111205dd",
+        "patch": "@@ -1446,8 +1446,8 @@ def __getattr__(self, attr):\n     def __bool__(self):\n         return self.country_name is not None\n \n-    # Old dict API, undocumented for now, will be deprecated some day\n     def __getitem__(self, item):\n+        warnings.warn(\"Since 20.0, dictionnary GeoIP API is deprecated.\", DeprecationWarning, stacklevel=2)\n         if item == 'country_name':\n             return self.country_name\n "
+      }
+    ],
+    "paths": [
+      "addons/website"
+    ]
+  },
+  {
+    "sha": "8783ee50708eb6a7289589c895f78a5fb8197728",
+    "node_id": "C_kwDOAS1I7NoAKDg3ODNlZTUwNzA4ZWI2YTcyODk1ODljODk1Zjc4YTVmYjgxOTc3Mjg",
+    "commit": {
+      "author": {
+        "name": "divy-odoo",
+        "email": "divy@odoo.com",
+        "date": "2024-07-30T13:19:40Z"
+      },
+      "committer": {
+        "name": "divy-odoo",
+        "email": "divy@odoo.com",
+        "date": "2025-10-14T07:58:42Z"
+      },
+      "message": "[FIX] website_blog: fix filters removal on date change\n\nSteps to reproduce:\n\n1. Go to website blog page, open editor & turn on the blog page sidebar.\n2. Select two tags from the \"All\" blog page.\n3. From the sidebar, select a date from the archives.\n   - one tag is removed.\n4. Change the archive date back to \"All Dates\".\n   - all selected tags are removed.\n\nProblem:\nSelecting or clearing an archive date filter caused previously selected\ntags to be dropped, leaving only the first tag (or none).\n\nSolution:\nAdded post_link class to <select> and <a> elements to trigger a POST\nrequest and keep tag selections intact\n\ntask-3937884\n\ncloses odoo/odoo#231328\n\nX-original-commit: 45b2ac979737db6c1ba0f651381fe07bbabd21d7\nSigned-off-by: Serge Bayet (seba) <seba@odoo.com>\nSigned-off-by: Divyesh Vyas (divy) <divy@odoo.com>",
+      "tree": {
+        "sha": "9ae12469dc8bbd35419ba2db86c8e26c961a6d84",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/9ae12469dc8bbd35419ba2db86c8e26c961a6d84"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/8783ee50708eb6a7289589c895f78a5fb8197728",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/8783ee50708eb6a7289589c895f78a5fb8197728",
+    "html_url": "https://github.com/odoo/odoo/commit/8783ee50708eb6a7289589c895f78a5fb8197728",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/8783ee50708eb6a7289589c895f78a5fb8197728/comments",
+    "author": {
+      "login": "divy-odoo",
+      "id": 125337508,
+      "node_id": "U_kgDOB3h_pA",
+      "avatar_url": "https://avatars.githubusercontent.com/u/125337508?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/divy-odoo",
+      "html_url": "https://github.com/divy-odoo",
+      "followers_url": "https://api.github.com/users/divy-odoo/followers",
+      "following_url": "https://api.github.com/users/divy-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/divy-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/divy-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/divy-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/divy-odoo/orgs",
+      "repos_url": "https://api.github.com/users/divy-odoo/repos",
+      "events_url": "https://api.github.com/users/divy-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/divy-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "divy-odoo",
+      "id": 125337508,
+      "node_id": "U_kgDOB3h_pA",
+      "avatar_url": "https://avatars.githubusercontent.com/u/125337508?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/divy-odoo",
+      "html_url": "https://github.com/divy-odoo",
+      "followers_url": "https://api.github.com/users/divy-odoo/followers",
+      "following_url": "https://api.github.com/users/divy-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/divy-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/divy-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/divy-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/divy-odoo/orgs",
+      "repos_url": "https://api.github.com/users/divy-odoo/repos",
+      "events_url": "https://api.github.com/users/divy-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/divy-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "5d5e7e5a03a662ea838b010e83de5dfeb0170667",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/5d5e7e5a03a662ea838b010e83de5dfeb0170667",
+        "html_url": "https://github.com/odoo/odoo/commit/5d5e7e5a03a662ea838b010e83de5dfeb0170667"
+      }
+    ],
+    "stats": {
+      "total": 89,
+      "additions": 79,
+      "deletions": 10
+    },
+    "files": [
+      {
+        "sha": "06a92b1e3cd7527ec95ae0b3f625aef21ff9e276",
+        "filename": "addons/website/static/src/interactions/post_link.js",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/8783ee50708eb6a7289589c895f78a5fb8197728/addons%2Fwebsite%2Fstatic%2Fsrc%2Finteractions%2Fpost_link.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/8783ee50708eb6a7289589c895f78a5fb8197728/addons%2Fwebsite%2Fstatic%2Fsrc%2Finteractions%2Fpost_link.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Finteractions%2Fpost_link.js?ref=8783ee50708eb6a7289589c895f78a5fb8197728",
+        "patch": "@@ -21,7 +21,7 @@ export class PostLink extends Interaction {\n                 data[key.slice(5)] = value;\n             }\n         }\n-        sendRequest(this.el.dataset.post || this.el.href, data);\n+        sendRequest(this.el.dataset.post || this.el.href || this.el.value, data);\n     }\n }\n "
+      },
+      {
+        "sha": "1223218900e3c6d1e506b4890d20e511dc65e88f",
+        "filename": "addons/website_blog/static/tests/tours/blog_tags_with_date.js",
+        "status": "added",
+        "additions": 66,
+        "deletions": 0,
+        "changes": 66,
+        "blob_url": "https://github.com/odoo/odoo/blob/8783ee50708eb6a7289589c895f78a5fb8197728/addons%2Fwebsite_blog%2Fstatic%2Ftests%2Ftours%2Fblog_tags_with_date.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/8783ee50708eb6a7289589c895f78a5fb8197728/addons%2Fwebsite_blog%2Fstatic%2Ftests%2Ftours%2Fblog_tags_with_date.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite_blog%2Fstatic%2Ftests%2Ftours%2Fblog_tags_with_date.js?ref=8783ee50708eb6a7289589c895f78a5fb8197728",
+        "patch": "@@ -0,0 +1,66 @@\n+import { registerWebsitePreviewTour } from \"@website/js/tours/tour_utils\";\n+\n+/**\n+ * Makes sure that blog tags should not be removed on the addition of date filter\n+ * and on the removal of date filter.\n+ */\n+registerWebsitePreviewTour(\n+    \"blog_tags_with_date\",\n+    {\n+        url: \"/blog\",\n+    },\n+    () => [\n+        {\n+            content: \"Check that the sidebar is present\",\n+            trigger: \":iframe #o_wblog_sidebar\",\n+        },\n+        {\n+            content: \"Click on 'adventure' tag\",\n+            trigger: \":iframe #o_wblog_sidebar a:contains('adventure')\",\n+            run: \"click\",\n+        },\n+        {\n+            content: \"Check 'adventure' tag has been added\",\n+            trigger: \":iframe #o_wblog_posts_loop span:contains('adventure')\",\n+        },\n+        {\n+            content: \"Click on 'discovery' tag\",\n+            trigger: \":iframe #o_wblog_sidebar a:contains('discovery')\",\n+            run: \"click\",\n+        },\n+        {\n+            content: \"Check 'discovery' tag has been added\",\n+            trigger: \":iframe #o_wblog_posts_loop span:contains('discovery')\",\n+        },\n+        {\n+            content: \"Select first month\",\n+            trigger: \":iframe select[name=archive]\",\n+            run: \"selectByLabel October\",\n+        },\n+        {\n+            content: \"Check date filter has been added\",\n+            trigger: \":iframe #o_wblog_posts_loop span>i.fa-calendar-o\",\n+        },\n+        {\n+            content:\n+                \"Check 'adventure' and 'discovery' tag is present after addition of date filter\",\n+            trigger:\n+                \":iframe #o_wblog_posts_loop:has(span:contains('adventure'), span:contains('discovery'))\",\n+        },\n+        {\n+            content: \"Remove the date filter\",\n+            trigger: \":iframe #o_wblog_posts_loop span:has(i.fa-calendar-o) a\",\n+            run: \"click\",\n+        },\n+        {\n+            content: \"Date filter should not be present\",\n+            trigger: \":iframe #o_wblog_posts_loop span:not(:has(i.fa-calendar-o))\",\n+        },\n+        {\n+            content:\n+                \"Check 'adventure' and 'discovery' tag is present after removal of date filter\",\n+            trigger:\n+                \":iframe #o_wblog_posts_loop:has(span:contains('adventure'), span:contains('discovery'))\",\n+        },\n+    ]\n+);"
+      },
+      {
+        "sha": "184d2efea8baf943f7c94223efdb5599ab5ba255",
+        "filename": "addons/website_blog/tests/test_ui.py",
+        "status": "modified",
+        "additions": 10,
+        "deletions": 2,
+        "changes": 12,
+        "blob_url": "https://github.com/odoo/odoo/blob/8783ee50708eb6a7289589c895f78a5fb8197728/addons%2Fwebsite_blog%2Ftests%2Ftest_ui.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/8783ee50708eb6a7289589c895f78a5fb8197728/addons%2Fwebsite_blog%2Ftests%2Ftest_ui.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite_blog%2Ftests%2Ftest_ui.py?ref=8783ee50708eb6a7289589c895f78a5fb8197728",
+        "patch": "@@ -92,7 +92,7 @@ def test_sidebar_with_date_and_tag(self):\n         Blog2 = Blog.create({'name': 'Space'})\n \n         # Create first blog post (Feb 2025)\n-        Post.create({\n+        blog_post_1 = Post.create({\n             'name': 'First Blog Post',\n             'blog_id': Blog1.id,\n             'author_id': self.env.user.id,\n@@ -101,7 +101,7 @@ def test_sidebar_with_date_and_tag(self):\n         })\n \n         # Create second blog post (Jan 2025)\n-        Post.create({\n+        blog_post_2 = Post.create({\n             'name': 'Second Blog Post',\n             'blog_id': Blog2.id,\n             'author_id': self.env.user.id,\n@@ -112,3 +112,11 @@ def test_sidebar_with_date_and_tag(self):\n         self.env.ref(\"website_blog.opt_blog_sidebar_show\").active = True\n         self.env.ref(\"website_blog.opt_blog_post_sidebar\").active = True\n         self.start_tour(\"/blog\", \"blog_sidebar_with_date_and_tag\", login=\"admin\")\n+\n+        blog_tag = self.env.ref('website_blog.blog_tag_5', raise_if_not_found=False)\n+        if not blog_tag:\n+            blog_tag = self.env['blog.tag'].create({'name': \"discovery\"})\n+        blog_post_1.write({'tag_ids': [(4, blog_tag.id)]})\n+        blog_post_2.write({'tag_ids': [(4, blog_tag.id)]})\n+\n+        self.start_tour(\"/blog\", \"blog_tags_with_date\", login=\"admin\")"
+      },
+      {
+        "sha": "5bce8494cfd495a27f9e38e35d64925468fbbf72",
+        "filename": "addons/website_blog/views/website_blog_components.xml",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 6,
+        "changes": 7,
+        "blob_url": "https://github.com/odoo/odoo/blob/8783ee50708eb6a7289589c895f78a5fb8197728/addons%2Fwebsite_blog%2Fviews%2Fwebsite_blog_components.xml",
+        "raw_url": "https://github.com/odoo/odoo/raw/8783ee50708eb6a7289589c895f78a5fb8197728/addons%2Fwebsite_blog%2Fviews%2Fwebsite_blog_components.xml",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite_blog%2Fviews%2Fwebsite_blog_components.xml?ref=8783ee50708eb6a7289589c895f78a5fb8197728",
+        "patch": "@@ -116,12 +116,7 @@\n <!-- ======   Template: Date Selector   ========================================\n ============================================================================ -->\n <template id=\"date_selector\">\n-    <select name=\"archive\" oninput=\"location = this.value;\" class=\"form-select\">\n-        <!-- TODO: remove in master -->\n-        <option t-if=\"False\" t-att-value=\"blog_url(date_begin=False, date_end=False) if blog else '/blog'\"\n-                t-att=\"[('selected' if (not date_begin) else 'unselected' ) , 'true' ]\">\n-                -- All dates\n-        </option>\n+    <select name=\"archive\" oninput=\"location = this.value;\" class=\"form-select post_link\">\n         <option t-att-value=\"blog_url(date_begin=False, date_end=False, tag=tag)\"\n                 t-att=\"[('selected' if (not date_begin) else 'unselected' ) , 'true' ]\">\n                 All dates"
+      },
+      {
+        "sha": "1f5be61efda341cb96a1e58985254c84d93e3e55",
+        "filename": "addons/website_blog/views/website_blog_posts_loop.xml",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/8783ee50708eb6a7289589c895f78a5fb8197728/addons%2Fwebsite_blog%2Fviews%2Fwebsite_blog_posts_loop.xml",
+        "raw_url": "https://github.com/odoo/odoo/raw/8783ee50708eb6a7289589c895f78a5fb8197728/addons%2Fwebsite_blog%2Fviews%2Fwebsite_blog_posts_loop.xml",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite_blog%2Fviews%2Fwebsite_blog_posts_loop.xml?ref=8783ee50708eb6a7289589c895f78a5fb8197728",
+        "patch": "@@ -66,7 +66,7 @@ according to the enabled options.\n                 <span t-if=\"date_begin\" class=\"align-items-baseline border d-inline-flex ps-2 rounded mb-2\">\n                     <i class=\"fa fa-calendar-o me-2 text-muted\"/>\n                     <t t-out=\"date_begin\" t-options=\"{'widget': 'date', 'format': 'MMM yyyy'}\"></t>\n-                    <a t-attf-href=\"#{blog_url(date_begin=False, date_end=False, tag=tag)}\" class=\"btn border-0 py-1\">&#215;</a>\n+                    <a t-attf-href=\"#{blog_url(date_begin=False, date_end=False, tag=tag)}\" class=\"btn border-0 py-1 post_link\">&#215;</a>\n                 </span>\n                 <hr class=\"mt-2\"/>\n             </div>"
+      }
+    ],
+    "paths": [
+      "addons/website"
+    ]
+  },
+  {
+    "sha": "7a291d59909b2ee57111ddec35a20a2302291f29",
+    "node_id": "C_kwDOAS1I7NoAKDdhMjkxZDU5OTA5YjJlZTU3MTExZGRlYzM1YTIwYTIzMDIyOTFmMjk",
+    "commit": {
+      "author": {
+        "name": "Guillaume Jacquet",
+        "email": "guja@odoo.com",
+        "date": "2025-10-07T11:35:03Z"
+      },
+      "committer": {
+        "name": "Guillaume Jacquet",
+        "email": "guja@odoo.com",
+        "date": "2025-10-14T06:33:34Z"
+      },
+      "message": "[FIX] website: config dropdown option clicking not working on Safari\n\nProblem\nUsing Safari, in the website configuration wizard,\nwhen selecting a website type or an objective\nby mouse clicking, nothing would get selected,\nand the dropdown would close prematurely.\n\nSteps\n- Using Safari\n- In Odoo with the Website addon installed\n- Create a new website in the website settings\n- Try to select any type of website by mouse clicking\n- Nothing would get selected, and the dropdown closes before pointerUp\n\nCause\nOn Safari, buttons are not focusable by default.\nSo if we want good accessibility on these dropdowns,\na workaround is needed.\n\nFix\nThe fix is to delay focusout actions until a pointerUp\nevent is triggered on the dropdown, if the Safari user uses\nits mouse to choose an option.\n\ntask-5139708\n\nCloses https://github.com/odoo/odoo/pull/226637\n\ncloses odoo/odoo#231301\n\nX-original-commit: 28440be00cb190cf8d63917021d730c214e19f0f\nSigned-off-by: Robin Lejeune (role) <role@odoo.com>",
+      "tree": {
+        "sha": "6790196bf4a6a294a9547029841deaba3d8be546",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/6790196bf4a6a294a9547029841deaba3d8be546"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/7a291d59909b2ee57111ddec35a20a2302291f29",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/7a291d59909b2ee57111ddec35a20a2302291f29",
+    "html_url": "https://github.com/odoo/odoo/commit/7a291d59909b2ee57111ddec35a20a2302291f29",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/7a291d59909b2ee57111ddec35a20a2302291f29/comments",
+    "author": {
+      "login": "guja-odoo",
+      "id": 199114026,
+      "node_id": "U_kgDOC949Kg",
+      "avatar_url": "https://avatars.githubusercontent.com/u/199114026?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/guja-odoo",
+      "html_url": "https://github.com/guja-odoo",
+      "followers_url": "https://api.github.com/users/guja-odoo/followers",
+      "following_url": "https://api.github.com/users/guja-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/guja-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/guja-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/guja-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/guja-odoo/orgs",
+      "repos_url": "https://api.github.com/users/guja-odoo/repos",
+      "events_url": "https://api.github.com/users/guja-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/guja-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "guja-odoo",
+      "id": 199114026,
+      "node_id": "U_kgDOC949Kg",
+      "avatar_url": "https://avatars.githubusercontent.com/u/199114026?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/guja-odoo",
+      "html_url": "https://github.com/guja-odoo",
+      "followers_url": "https://api.github.com/users/guja-odoo/followers",
+      "following_url": "https://api.github.com/users/guja-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/guja-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/guja-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/guja-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/guja-odoo/orgs",
+      "repos_url": "https://api.github.com/users/guja-odoo/repos",
+      "events_url": "https://api.github.com/users/guja-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/guja-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "73a728bade0fb7fa4248af6951793d63715e3071",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/73a728bade0fb7fa4248af6951793d63715e3071",
+        "html_url": "https://github.com/odoo/odoo/commit/73a728bade0fb7fa4248af6951793d63715e3071"
+      }
+    ],
+    "stats": {
+      "total": 32,
+      "additions": 30,
+      "deletions": 2
+    },
+    "files": [
+      {
+        "sha": "dcf640e67192421fd0b8d76ffd11850343ef2a6a",
+        "filename": "addons/website/static/src/client_actions/configurator/configurator.js",
+        "status": "modified",
+        "additions": 24,
+        "deletions": 0,
+        "changes": 24,
+        "blob_url": "https://github.com/odoo/odoo/blob/7a291d59909b2ee57111ddec35a20a2302291f29/addons%2Fwebsite%2Fstatic%2Fsrc%2Fclient_actions%2Fconfigurator%2Fconfigurator.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/7a291d59909b2ee57111ddec35a20a2302291f29/addons%2Fwebsite%2Fstatic%2Fsrc%2Fclient_actions%2Fconfigurator%2Fconfigurator.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fclient_actions%2Fconfigurator%2Fconfigurator.js?ref=7a291d59909b2ee57111ddec35a20a2302291f29",
+        "patch": "@@ -28,6 +28,7 @@ import {\n import { standardActionServiceProps } from \"@web/webclient/actions/action_service\";\n import { addLoadingEffect as addButtonLoadingEffect } from \"@web/core/utils/ui\";\n import { fuzzyLevenshteinLookup } from \"@web/core/utils/search\";\n+import { isBrowserSafari } from \"@web/core/browser/feature_detection\";\n \n export const ROUTES = {\n     descriptionScreen: 2,\n@@ -185,6 +186,8 @@ export class DescriptionScreen extends Component {\n                 this.purposeSelectionRef.el.focus();\n             }\n         }, () => [this.state.selectedType, this.state.selectedIndustry]);\n+\n+        this.dropdownSafariHack = false;\n     }\n \n     onMounted() {\n@@ -362,10 +365,31 @@ export class DescriptionScreen extends Component {\n      * @param {FocusEvent} ev\n      */\n     onDropdownFocusout(ev) {\n+        if (this.dropdownSafariHack) {\n+            return;\n+        }\n         if (ev.relatedTarget?.closest(\".dropdown\") !== ev.currentTarget) {\n             window.Dropdown.getOrCreateInstance(ev.currentTarget).hide();\n         }\n     }\n+    // Because of focus problems with safari on buttons, we need to block the focusout\n+    // until the pointer is up.\n+    onDropdownPointerDown() {\n+        if (isBrowserSafari()) {\n+            this.dropdownSafariHack = true;\n+        }\n+    }\n+    onDropdownPointerUp(ev) {\n+        if (!isBrowserSafari()) {\n+            return;\n+        }\n+        const dropdown = ev.currentTarget;\n+        this.dropdownSafariHack = false;\n+        const active = document.activeElement;\n+        if (!active || !dropdown.contains(active)) {\n+            window.Dropdown.getOrCreateInstance(dropdown).hide();\n+        }\n+    }\n \n     onAutocompleteInput({ inputValue }) {\n         if (!inputValue) {"
+      },
+      {
+        "sha": "d285b034f17d70b78e4754d4ee90e50163b00a11",
+        "filename": "addons/website/static/src/client_actions/configurator/configurator.xml",
+        "status": "modified",
+        "additions": 6,
+        "deletions": 2,
+        "changes": 8,
+        "blob_url": "https://github.com/odoo/odoo/blob/7a291d59909b2ee57111ddec35a20a2302291f29/addons%2Fwebsite%2Fstatic%2Fsrc%2Fclient_actions%2Fconfigurator%2Fconfigurator.xml",
+        "raw_url": "https://github.com/odoo/odoo/raw/7a291d59909b2ee57111ddec35a20a2302291f29/addons%2Fwebsite%2Fstatic%2Fsrc%2Fclient_actions%2Fconfigurator%2Fconfigurator.xml",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fclient_actions%2Fconfigurator%2Fconfigurator.xml?ref=7a291d59909b2ee57111ddec35a20a2302291f29",
+        "patch": "@@ -30,7 +30,9 @@\n                 <div class=\"o_configurator_typing_text d-inline d-md-block mb-md-2 mb-lg-4 o_configurator_show\">\n                     <span>I want </span>\n                     <div t-attf-class=\"dropdown o_configurator_type_dd d-inline-block {{state.selectedType ? 'o_step_completed' : 'o_step_todo show'}}\"\n-                         t-on-focusout=\"onDropdownFocusout\">\n+                         t-on-focusout=\"onDropdownFocusout\"\n+                         t-on-pointerdown=\"onDropdownPointerDown\"\n+                         t-on-pointerup=\"onDropdownPointerUp\">\n                         <button id=\"selectTypeToggle\"\n                                 class=\"o_btn_reset w-100 px-2\"\n                                 data-bs-toggle=\"dropdown\"\n@@ -83,7 +85,9 @@\n                 <div t-if=\"state.selectedType and state.selectedIndustry\" class=\"o_configurator_typing_text d-inline d-md-block mb-md-2 mb-lg-4 o_configurator_show\">\n                     <span>with the main objective to </span>\n                     <div t-attf-class=\"dropdown d-inline-block o_configurator_purpose_dd {{state.selectedPurpose ? 'o_step_completed' : 'o_step_todo'}}\"\n-                         t-on-focusout=\"onDropdownFocusout\">\n+                         t-on-focusout=\"onDropdownFocusout\"\n+                         t-on-pointerdown=\"onDropdownPointerDown\"\n+                         t-on-pointerup=\"onDropdownPointerUp\">\n                         <button id=\"selectPurposeToggle\"\n                                 class=\"o_btn_reset w-100 px-2\"\n                                 data-bs-toggle=\"dropdown\""
+      }
+    ],
+    "paths": [
+      "addons/website"
+    ]
+  },
+  {
+    "sha": "482c4597ca8081e29b7cb41039ef7433ff02ce59",
+    "node_id": "C_kwDOAS1I7NoAKDQ4MmM0NTk3Y2E4MDgxZTI5YjdjYjQxMDM5ZWY3NDMzZmYwMmNlNTk",
+    "commit": {
+      "author": {
+        "name": "Serhii Rubanskyi",
+        "email": "seru@odoo.com",
+        "date": "2025-09-17T15:08:17Z"
+      },
+      "committer": {
+        "name": "Serhii Rubanskyi",
+        "email": "seru@odoo.com",
+        "date": "2025-10-13T17:27:01Z"
+      },
+      "message": "[FIX] html_builder, *: remember last used tab in 'ColorPicker'\n\n*: html_editor, web, website\nBefore this commit, `BuilderColorPicker` had no memory of the last used\ntab and always opened on the first tab, regardless of whether the user\nhad previously selected a color.\n\nAfter this commit, if the user has already done a selection, the color\npicker opens on the tab containing that selection.\n\nHow to reproduce the problem:\n1. Drop a new snippet, e.g. `s_text_block`,\n2. Click on the snippet, then open the \"Background\" color picker\n3. Pick a custom color or a gradient\n4. If the color picker is stil open, press ESC\n5. Open the color picker again\n6. PROBLEM: the color picker is opened on the \"theme\" tab\n\ntask-4367641\n\nCo-authored by alup@odoo.com\n\ncloses odoo/odoo#231195\n\nX-original-commit: 7e0cc5ec686a52b8c1f8270213acac54575ed469\nSigned-off-by: Robin Lejeune (role) <role@odoo.com>\nSigned-off-by: Alessandro Lupo (alup) <alup@odoo.com>",
+      "tree": {
+        "sha": "fdd0a4df5cb584b4d71b7e68faa97a867cfb9944",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/fdd0a4df5cb584b4d71b7e68faa97a867cfb9944"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/482c4597ca8081e29b7cb41039ef7433ff02ce59",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/482c4597ca8081e29b7cb41039ef7433ff02ce59",
+    "html_url": "https://github.com/odoo/odoo/commit/482c4597ca8081e29b7cb41039ef7433ff02ce59",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/482c4597ca8081e29b7cb41039ef7433ff02ce59/comments",
+    "author": {
+      "login": "Syozik",
+      "id": 82968368,
+      "node_id": "MDQ6VXNlcjgyOTY4MzY4",
+      "avatar_url": "https://avatars.githubusercontent.com/u/82968368?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/Syozik",
+      "html_url": "https://github.com/Syozik",
+      "followers_url": "https://api.github.com/users/Syozik/followers",
+      "following_url": "https://api.github.com/users/Syozik/following{/other_user}",
+      "gists_url": "https://api.github.com/users/Syozik/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/Syozik/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/Syozik/subscriptions",
+      "organizations_url": "https://api.github.com/users/Syozik/orgs",
+      "repos_url": "https://api.github.com/users/Syozik/repos",
+      "events_url": "https://api.github.com/users/Syozik/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/Syozik/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "Syozik",
+      "id": 82968368,
+      "node_id": "MDQ6VXNlcjgyOTY4MzY4",
+      "avatar_url": "https://avatars.githubusercontent.com/u/82968368?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/Syozik",
+      "html_url": "https://github.com/Syozik",
+      "followers_url": "https://api.github.com/users/Syozik/followers",
+      "following_url": "https://api.github.com/users/Syozik/following{/other_user}",
+      "gists_url": "https://api.github.com/users/Syozik/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/Syozik/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/Syozik/subscriptions",
+      "organizations_url": "https://api.github.com/users/Syozik/orgs",
+      "repos_url": "https://api.github.com/users/Syozik/repos",
+      "events_url": "https://api.github.com/users/Syozik/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/Syozik/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "6df92ce41681118c15e0c9613a430682f566079d",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/6df92ce41681118c15e0c9613a430682f566079d",
+        "html_url": "https://github.com/odoo/odoo/commit/6df92ce41681118c15e0c9613a430682f566079d"
+      }
+    ],
+    "stats": {
+      "total": 202,
+      "additions": 132,
+      "deletions": 70
+    },
+    "files": [
+      {
+        "sha": "70b1fa08077a65ba2c25c42b912e6f338c47c8f3",
+        "filename": "addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js",
+        "status": "modified",
+        "additions": 41,
+        "deletions": 3,
+        "changes": 44,
+        "blob_url": "https://github.com/odoo/odoo/blob/482c4597ca8081e29b7cb41039ef7433ff02ce59/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fcore%2Fbuilding_blocks%2Fbuilder_colorpicker.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/482c4597ca8081e29b7cb41039ef7433ff02ce59/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fcore%2Fbuilding_blocks%2Fbuilder_colorpicker.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fcore%2Fbuilding_blocks%2Fbuilder_colorpicker.js?ref=482c4597ca8081e29b7cb41039ef7433ff02ce59",
+        "patch": "@@ -1,6 +1,10 @@\n import { ColorSelector } from \"@html_editor/main/font/color_selector\";\n import { Component, useComponent, useRef } from \"@odoo/owl\";\n-import { useColorPicker } from \"@web/core/color_picker/color_picker\";\n+import {\n+    useColorPicker,\n+    DEFAULT_COLORS,\n+    DEFAULT_THEME_COLOR_VARS,\n+} from \"@web/core/color_picker/color_picker\";\n import { BuilderComponent } from \"./builder_component\";\n import {\n     basicContainerBuilderComponentProps,\n@@ -17,6 +21,7 @@ export function useColorPickerBuilderComponent() {\n     const comp = useComponent();\n     const { getAllActions, callOperation } = getAllActionsAndOperations(comp);\n     const getAction = comp.env.editor.shared.builderActions.getAction;\n+    let selectedTab;\n     const state = useDomState(getState);\n     const applyOperation = comp.env.editor.shared.history.makePreviewableAsyncOperation(\n         (applySpecs, isPreviewing) => {\n@@ -47,13 +52,16 @@ export function useColorPickerBuilderComponent() {\n         const { actionId, actionParam } = actionWithGetValue;\n         const actionValue = getAction(actionId).getValue({ editingElement, params: actionParam });\n         return {\n-            mode: actionParam.mainParam || actionId,\n+            // defaultTab is the tab to open if the user has not done a selection yet.\n+            // If the user has already selected a color, the tab of the last selection is opened\n+            defaultTab: comp.props.selectedTab,\n             selectedColor: actionValue || comp.props.defaultColor,\n             selectedColorCombination: comp.env.editor.shared.color.getColorCombination(\n                 editingElement,\n                 actionParam\n             ),\n             getTargetedElements: () => [editingElement],\n+            selectedTab,\n         };\n     }\n     function getColor(colorValue) {\n@@ -65,6 +73,7 @@ export function useColorPickerBuilderComponent() {\n     let previewValue = null;\n     function onApply(colorValue) {\n         previewValue = null;\n+        selectedTab = comp.getCorrespondingColorPickerTab(colorValue);\n         callOperation(applyOperation.commit, { userInputValue: getColor(colorValue) });\n     }\n     let onPreview = (colorValue) => {\n@@ -116,6 +125,7 @@ export class BuilderColorPicker extends Component {\n     static defaultProps = {\n         enabledTabs: [\"theme\", \"gradient\", \"custom\"],\n         defaultColor: \"#FFFFFF00\",\n+        selectedTab: \"theme\",\n     };\n     static components = {\n         ColorSelector: ColorSelector,\n@@ -127,7 +137,6 @@ export class BuilderColorPicker extends Component {\n         const { state, onApply, onPreview, onPreviewRevert } = useColorPickerBuilderComponent();\n         this.colorButton = useRef(\"colorButton\");\n         this.state = state;\n-        this.state.defaultTab = this.props.selectedTab || \"solid\"; // TODO: select the correct tab based on the color\n         useColorPicker(\n             \"colorButton\",\n             {\n@@ -179,4 +188,33 @@ export class BuilderColorPicker extends Component {\n     getUsedCustomColors() {\n         return getAllUsedColors(this.env.editor.editable);\n     }\n+\n+    getCorrespondingColorPickerTab(selectedColor) {\n+        if (!selectedColor) {\n+            return;\n+        }\n+\n+        selectedColor = selectedColor.replace(/color-prefix-/g, \"\");\n+        const isTabEnabled = (tab) => this.props.enabledTabs.includes(tab);\n+\n+        if (isTabEnabled(\"gradient\") && isColorGradient(selectedColor)) {\n+            return \"gradient\";\n+        }\n+\n+        const solidTabColors = [\n+            ...DEFAULT_COLORS.flat(),\n+            ...DEFAULT_THEME_COLOR_VARS.map((color) => color.toUpperCase()),\n+        ];\n+        if (isTabEnabled(\"solid\") && solidTabColors.includes(selectedColor.toUpperCase())) {\n+            return \"solid\";\n+        }\n+\n+        if (isTabEnabled(\"theme\") && /^o_cc\\d+$/.test(selectedColor)) {\n+            return \"theme\";\n+        }\n+\n+        if (isTabEnabled(\"custom\")) {\n+            return \"custom\";\n+        }\n+    }\n }"
+      },
+      {
+        "sha": "428eb5e5440f12783ea00e684650a40cfb8fc64c",
+        "filename": "addons/html_builder/static/tests/custom_tab/builder_components/builder_colorpicker.test.js",
+        "status": "modified",
+        "additions": 36,
+        "deletions": 15,
+        "changes": 51,
+        "blob_url": "https://github.com/odoo/odoo/blob/482c4597ca8081e29b7cb41039ef7433ff02ce59/addons%2Fhtml_builder%2Fstatic%2Ftests%2Fcustom_tab%2Fbuilder_components%2Fbuilder_colorpicker.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/482c4597ca8081e29b7cb41039ef7433ff02ce59/addons%2Fhtml_builder%2Fstatic%2Ftests%2Fcustom_tab%2Fbuilder_components%2Fbuilder_colorpicker.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_builder%2Fstatic%2Ftests%2Fcustom_tab%2Fbuilder_components%2Fbuilder_colorpicker.test.js?ref=482c4597ca8081e29b7cb41039ef7433ff02ce59",
+        "patch": "@@ -173,21 +173,6 @@ test(\"should revert preview on escape\", async () => {\n     expect(\":iframe .test-options-target\").toHaveStyle({ \"background-color\": \"rgba(0, 0, 0, 0)\" });\n });\n \n-test(\"should mark default color as selected when it is selected\", async () => {\n-    addBuilderOption({\n-        selector: \".test-options-target\",\n-        template: xml`<BuilderColorPicker enabledTabs=\"['custom']\" styleAction=\"'background-color'\"/>`,\n-    });\n-    await setupHTMLBuilder(`<div class=\"test-options-target\">b</div>`);\n-    await contains(\":iframe .test-options-target\").click();\n-    expect(\".options-container\").toBeDisplayed();\n-    await contains(\".we-bg-options-container .o_we_color_preview\").click();\n-    await contains(\".o-overlay-item [data-color='900']\").click();\n-    expect(\":iframe .test-options-target\").toHaveClass(\"bg-900\");\n-    await contains(\".we-bg-options-container .o_we_color_preview\").click();\n-    expect(\".o-overlay-item [data-color='900']\").toHaveClass(\"selected\");\n-});\n-\n test(\"should apply transparent color if no color is defined\", async () => {\n     addBuilderAction({\n         customAction: class extends BuilderAction {\n@@ -344,3 +329,39 @@ describe(\"Custom colorpicker: preview and commit\", () => {\n         expect(\":iframe .test-options-target\").toHaveAttribute(\"data-color\");\n     });\n });\n+\n+test(\"should open the last used tab\", async () => {\n+    addBuilderOption({\n+        selector: \".test-options-target\",\n+        template: xml`<BuilderColorPicker styleAction=\"'background-color'\"/>`,\n+    });\n+    await setupHTMLBuilder(`<div class=\"test-options-target\">b</div>`, {\n+        styleContent: \":root { --900: #212527; }\",\n+    });\n+    await contains(\":iframe .test-options-target\").click();\n+    expect(\".options-container\").toBeDisplayed();\n+\n+    await contains(\".we-bg-options-container .o_we_color_preview\").click();\n+    await click(\".theme-tab\");\n+    await animationFrame();\n+    expect(\".theme-tab.active\").toHaveCount(1);\n+\n+    await click(\".custom-tab\");\n+    await animationFrame();\n+    await click(\".o_color_picker_button[data-color='900']\");\n+    await animationFrame();\n+    await contains(\".we-bg-options-container .o_we_color_preview\").click();\n+    expect(\".custom-tab.active\").toHaveCount(1);\n+\n+    await click(\".gradient-tab\");\n+    await animationFrame();\n+    await click(\".o_gradient_color_button\");\n+    await animationFrame();\n+    await contains(\".we-bg-options-container .o_we_color_preview\").click();\n+    expect(\".gradient-tab.active\").toHaveCount(1);\n+\n+    await click(\"button[title='Reset']\");\n+    await animationFrame();\n+    await contains(\".we-bg-options-container .o_we_color_preview\").click();\n+    expect(\".theme-tab.active\").toHaveCount(1);\n+});"
+      },
+      {
+        "sha": "cce084e61606fe2d651da3150524b4070557968b",
+        "filename": "addons/html_editor/static/src/main/font/color_selector.js",
+        "status": "modified",
+        "additions": 2,
+        "deletions": 2,
+        "changes": 4,
+        "blob_url": "https://github.com/odoo/odoo/blob/482c4597ca8081e29b7cb41039ef7433ff02ce59/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fmain%2Ffont%2Fcolor_selector.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/482c4597ca8081e29b7cb41039ef7433ff02ce59/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fmain%2Ffont%2Fcolor_selector.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fmain%2Ffont%2Fcolor_selector.js?ref=482c4597ca8081e29b7cb41039ef7433ff02ce59",
+        "patch": "@@ -48,11 +48,11 @@ export class ColorSelector extends Component {\n         effect(\n             (selectedColors) => {\n                 this.state.selectedColor = selectedColors[this.props.mode];\n-                this.state.defaultTab = this.getCorrespondingColorTab(\n+                this.state.defaultTab = \"solid\";\n+                this.state.selectedTab = this.getCorrespondingColorTab(\n                     selectedColors[this.props.mode]\n                 );\n                 this.state.getTargetedElements = this.props.getTargetedElements;\n-                this.state.mode = this.props.mode;\n             },\n             [this.props.getSelectedColors()]\n         );"
+      },
+      {
+        "sha": "c39c3d910968ae54ee439e5c9f2eb3d4a3de9e4b",
+        "filename": "addons/html_editor/static/src/main/link/link_popover.js",
+        "status": "modified",
+        "additions": 0,
+        "deletions": 3,
+        "changes": 3,
+        "blob_url": "https://github.com/odoo/odoo/blob/482c4597ca8081e29b7cb41039ef7433ff02ce59/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fmain%2Flink%2Flink_popover.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/482c4597ca8081e29b7cb41039ef7433ff02ce59/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fmain%2Flink%2Flink_popover.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fmain%2Flink%2Flink_popover.js?ref=482c4597ca8081e29b7cb41039ef7433ff02ce59",
+        "patch": "@@ -157,7 +157,6 @@ export class LinkPopover extends Component {\n             selectedColor: computedStyle.color || DEFAULT_CUSTOM_TEXT_COLOR,\n             defaultTab: \"solid\",\n             getTargetedElements,\n-            mode: \"color\",\n         });\n         this.customTextResetPreviewColor = this.customTextColorState.selectedColor;\n         this.customFillColorState = useState({\n@@ -169,14 +168,12 @@ export class LinkPopover extends Component {\n                 DEFAULT_CUSTOM_FILL_COLOR,\n             defaultTab: \"solid\",\n             getTargetedElements,\n-            mode: \"background-color\",\n         });\n         this.customFillResetPreviewColor = this.customFillColorState.selectedColor;\n         this.customBorderColorState = useState({\n             selectedColor: computedStyle.borderColor || DEFAULT_CUSTOM_TEXT_COLOR,\n             defaultTab: \"solid\",\n             getTargetedElements,\n-            mode: \"border-color\",\n         });\n         this.customBorderResetPreviewColor = this.customBorderColorState.selectedColor;\n "
+      },
+      {
+        "sha": "fec74fcfdcd01d48952df868d56cced14c0aae76",
+        "filename": "addons/html_editor/static/tests/color_selector.test.js",
+        "status": "modified",
+        "additions": 6,
+        "deletions": 5,
+        "changes": 11,
+        "blob_url": "https://github.com/odoo/odoo/blob/482c4597ca8081e29b7cb41039ef7433ff02ce59/addons%2Fhtml_editor%2Fstatic%2Ftests%2Fcolor_selector.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/482c4597ca8081e29b7cb41039ef7433ff02ce59/addons%2Fhtml_editor%2Fstatic%2Ftests%2Fcolor_selector.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_editor%2Fstatic%2Ftests%2Fcolor_selector.test.js?ref=482c4597ca8081e29b7cb41039ef7433ff02ce59",
+        "patch": "@@ -1,4 +1,3 @@\n-import { getCSSVariableValue, getHtmlStyle } from \"@html_editor/utils/formatting\";\n import { describe, expect, test } from \"@odoo/hoot\";\n import {\n     click,\n@@ -663,6 +662,10 @@ test(\"custom tab color navigation using keys\", async () => {\n     await expandToolbar();\n     await click(\".o-we-toolbar .o-select-color-foreground\");\n     await animationFrame();\n+    await click(\".o_color_button[data-color='#FF0000']\");\n+    await animationFrame();\n+    await click(\".o-we-toolbar .o-select-color-foreground\");\n+    await animationFrame();\n     await press(\"Tab\");\n     expect(getActiveElement()).toBe(queryFirst('.o_font_color_selector button:contains(\"Custom\")'));\n     await press(\"Enter\");\n@@ -671,10 +674,8 @@ test(\"custom tab color navigation using keys\", async () => {\n     await press(\"Tab\");\n     await press(\"Tab\");\n     await press(\"Tab\");\n-    const htmlStyle = getHtmlStyle(document);\n-    const defaultColor = getCSSVariableValue(\"body-color\", htmlStyle);\n     expect(getActiveElement()).toBe(\n-        queryFirst(`.o_font_color_selector button[data-color=\"${defaultColor.toLowerCase()}\"]`)\n+        queryFirst(`.o_font_color_selector button[data-color=\"#ff0000\"]`)\n     );\n     await press(\"ArrowDown\");\n     expect(getActiveElement()).toBe(\n@@ -685,7 +686,7 @@ test(\"custom tab color navigation using keys\", async () => {\n         queryFirst('.o_font_color_selector button[data-color=\"black\"]') // Should do nothing\n     );\n     await press(\"Enter\");\n-    expect(getContent(el)).toBe(`<p><font class=\"text-black\">[test]</font></p>`);\n+    expect(getContent(el)).toBe(`<p><font style=\"\" class=\"text-black\">[test]</font></p>`);\n });\n \n describe.tags(\"desktop\");"
+      },
+      {
+        "sha": "57b0787e9d2a08a6ad1ecb64a67ea8ef00426563",
+        "filename": "addons/web/static/src/core/color_picker/color_picker.js",
+        "status": "modified",
+        "additions": 21,
+        "deletions": 40,
+        "changes": 61,
+        "blob_url": "https://github.com/odoo/odoo/blob/482c4597ca8081e29b7cb41039ef7433ff02ce59/addons%2Fweb%2Fstatic%2Fsrc%2Fcore%2Fcolor_picker%2Fcolor_picker.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/482c4597ca8081e29b7cb41039ef7433ff02ce59/addons%2Fweb%2Fstatic%2Fsrc%2Fcore%2Fcolor_picker%2Fcolor_picker.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fweb%2Fstatic%2Fsrc%2Fcore%2Fcolor_picker%2Fcolor_picker.js?ref=482c4597ca8081e29b7cb41039ef7433ff02ce59",
+        "patch": "@@ -1,7 +1,11 @@\n import { Component, useEffect, useRef, useState } from \"@odoo/owl\";\n import { CustomColorPicker } from \"@web/core/color_picker/custom_color_picker/custom_color_picker\";\n import { usePopover } from \"@web/core/popover/popover_hook\";\n-import { isCSSColor, isColorGradient } from \"@web/core/utils/colors\";\n+import {\n+    isCSSColor,\n+    isColorGradient,\n+    normalizeCSSColor,\n+} from \"@web/core/utils/colors\";\n import { cookie } from \"@web/core/browser/cookie\";\n import { POSITION_BUS } from \"../position/position_hook\";\n import { registry } from \"../registry\";\n@@ -18,7 +22,7 @@ export const DEFAULT_COLORS = [\n     [\"#630000\", \"#7B3900\", \"#846300\", \"#295218\", \"#083139\", \"#003163\", \"#21104A\", \"#4A1031\"],\n ];\n \n-const DEFAULT_GRAYSCALES = {\n+export const DEFAULT_GRAYSCALES = {\n     solid: [\"black\", \"900\", \"800\", \"600\", \"400\", \"200\", \"100\", \"white\"],\n };\n \n@@ -41,7 +45,7 @@ export class ColorPicker extends Component {\n                 selectedColorCombination: { type: String, optional: true },\n                 getTargetedElements: { type: Function, optional: true },\n                 defaultTab: String,\n-                mode: { type: String, optional: true },\n+                selectedTab: { type: String, optional: true },\n             },\n         },\n         getUsedCustomColors: Function,\n@@ -86,7 +90,7 @@ export class ColorPicker extends Component {\n         this.getPreviewColor = () => {};\n \n         this.state = useState({\n-            activeTab: this.getDefaultTab(),\n+            activeTab: this.props.state.selectedTab || this.getDefaultTab(),\n             currentCustomColor: this.props.state.selectedColor,\n             currentColorPreview: undefined,\n             showGradientPicker: false,\n@@ -236,53 +240,30 @@ export class ColorPicker extends Component {\n     }\n \n     getDefaultColorSet() {\n-        if (!this.props.state.getTargetedElements || !this.props.state.mode) {\n+        if (!this.props.state.selectedColor) {\n             return;\n         }\n-        const targetedEls = this.props.state.getTargetedElements();\n         let defaultColors = this.props.enabledTabs.includes(\"solid\")\n             ? this.DEFAULT_THEME_COLOR_VARS\n             : [];\n         for (const grayscale of Object.values(this.grayscales)) {\n             defaultColors = defaultColors.concat(grayscale);\n         }\n \n-        const extractColorFromClasses = (targetedEls, prefix, defaultColors) => {\n-            for (const el of targetedEls) {\n-                for (const className of el.classList) {\n-                    const match = className.match(new RegExp(`^${prefix}-(.+)$`));\n-                    if (match && defaultColors.includes(match[1])) {\n-                        return match[1];\n-                    }\n-                }\n-            }\n-            return false;\n-        };\n-        switch (this.props.state.mode) {\n-            case \"color\":\n-                return extractColorFromClasses(targetedEls, \"text\", defaultColors);\n-            case \"background-color\":\n-            case \"backgroundColor\":\n-                return extractColorFromClasses(targetedEls, \"bg\", defaultColors);\n-            case \"selectFilterColor\": {\n-                const filterEls = targetedEls\n-                    .map((el) => el.querySelector(\".o_we_bg_filter\"))\n-                    .filter((el) => el !== null);\n-                return extractColorFromClasses(filterEls, \"bg\", defaultColors);\n-            }\n-            default: {\n-                for (const el of targetedEls) {\n-                    const color = el.dataset[this.props.state.mode];\n-                    if (\n-                        defaultColors.includes(color) ||\n-                        defaultColors.includes(this.props.state.mode)\n-                    ) {\n-                        return color;\n-                    }\n-                }\n-                return false;\n+        const targetedElement =\n+            this.props.state.getTargetedElements?.()[0] || document.documentElement;\n+        const selectedColor = this.props.state.selectedColor.toUpperCase();\n+        const htmlStyle =\n+            targetedElement.ownerDocument.defaultView.getComputedStyle(targetedElement);\n+\n+        for (const color of defaultColors) {\n+            const cssVar = normalizeCSSColor(htmlStyle.getPropertyValue(`--${color}`));\n+            if (cssVar?.toUpperCase() === selectedColor) {\n+                return color;\n             }\n         }\n+\n+        return false;\n     }\n \n     colorPickerNavigation(ev) {"
+      },
+      {
+        "sha": "9537deae54fd2cd98036b3a539e7269a39cc367d",
+        "filename": "addons/web/static/tests/core/color_picker.test.js",
+        "status": "modified",
+        "additions": 22,
+        "deletions": 0,
+        "changes": 22,
+        "blob_url": "https://github.com/odoo/odoo/blob/482c4597ca8081e29b7cb41039ef7433ff02ce59/addons%2Fweb%2Fstatic%2Ftests%2Fcore%2Fcolor_picker.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/482c4597ca8081e29b7cb41039ef7433ff02ce59/addons%2Fweb%2Fstatic%2Ftests%2Fcore%2Fcolor_picker.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fweb%2Fstatic%2Ftests%2Fcore%2Fcolor_picker.test.js?ref=482c4597ca8081e29b7cb41039ef7433ff02ce59",
+        "patch": "@@ -269,3 +269,25 @@ test(\"can register an extra tab\", async () => {\n     expect(\".o_font_color_selector>p:last-child\").toHaveText(\"Color picker extra tab\");\n     registry.category(\"color_picker_tabs\").remove(\"web.extra\");\n });\n+\n+test(\"should mark default color as selected when it is selected\", async () => {\n+    defineStyle(`\n+        :root {\n+            --900: #212527;\n+        }\n+    `);\n+    await mountWithCleanup(ColorPicker, {\n+        props: {\n+            state: {\n+                selectedColor: \"#212527\",\n+                defaultTab: \"custom\",\n+            },\n+            getUsedCustomColors: () => [],\n+            applyColor() {},\n+            applyColorPreview() {},\n+            applyColorResetPreview() {},\n+            colorPrefix: \"\",\n+        },\n+    });\n+    expect(\".o_color_button[data-color='900']\").toHaveClass(\"selected\");\n+});"
+      },
+      {
+        "sha": "9d80f5c25548004de5162906f299e018b23de361",
+        "filename": "addons/website/static/tests/builder/website_builder/customize_website_color.test.js",
+        "status": "modified",
+        "additions": 2,
+        "deletions": 0,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/482c4597ca8081e29b7cb41039ef7433ff02ce59/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fwebsite_builder%2Fcustomize_website_color.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/482c4597ca8081e29b7cb41039ef7433ff02ce59/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fwebsite_builder%2Fcustomize_website_color.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fwebsite_builder%2Fcustomize_website_color.test.js?ref=482c4597ca8081e29b7cb41039ef7433ff02ce59",
+        "patch": "@@ -76,6 +76,7 @@ test(\"BuilderColorPicker with action \u201ccustomizeWebsiteColor\u201d is correctly di\n     // Setting preset does not impact solid color\n     expect.step(\"set preset on solid color\");\n     await contains(\"button.o_we_color_preview\").click();\n+    await contains(\"button.theme-tab\").click();\n     await contains(\"button[data-color='o_cc3'\").click();\n     // Should wait for 2 ticks (debounced): customizeWebsiteColors, reloadBundles\n     await def;\n@@ -105,6 +106,7 @@ test(\"BuilderColorPicker with action \u201ccustomizeWebsiteColor\u201d is correctly di\n     // Setting preset does not impact gradient\n     expect.step(\"set preset on gradient\");\n     await contains(\"button.o_we_color_preview\").click();\n+    await contains(\"button.theme-tab\").click();\n     await contains(\"button[data-color='o_cc4'\").click();\n     // Should wait for 2 ticks (debounced): customizeWebsiteColors, reloadBundles\n     await def;"
+      },
+      {
+        "sha": "9c61a86bb6daf8baef3cb61539818e84bf8a9294",
+        "filename": "addons/website/static/tests/tours/snippet_background_edition.js",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/482c4597ca8081e29b7cb41039ef7433ff02ce59/addons%2Fwebsite%2Fstatic%2Ftests%2Ftours%2Fsnippet_background_edition.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/482c4597ca8081e29b7cb41039ef7433ff02ce59/addons%2Fwebsite%2Fstatic%2Ftests%2Ftours%2Fsnippet_background_edition.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Ftests%2Ftours%2Fsnippet_background_edition.js?ref=482c4597ca8081e29b7cb41039ef7433ff02ce59",
+        "patch": "@@ -80,7 +80,7 @@ function checkAndUpdateBackgroundColor({\n         changeBackgroundColor(),\n     ];\n \n-    addCheck(steps, checkCC, checkNoCC, 'cc', true);\n+    addCheck(steps, checkCC, checkNoCC, 'cc');\n     addCheck(steps, checkBg, checkNoBg, 'bg');\n     addCheck(steps, checkGradient, checkNoGradient, 'gradient');\n "
+      },
+      {
+        "sha": "ed7cb1a7e9368c5951f1cfeb03c7dbd536ce9b97",
+        "filename": "addons/website/static/tests/tours/website_page_options.js",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/482c4597ca8081e29b7cb41039ef7433ff02ce59/addons%2Fwebsite%2Fstatic%2Ftests%2Ftours%2Fwebsite_page_options.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/482c4597ca8081e29b7cb41039ef7433ff02ce59/addons%2Fwebsite%2Fstatic%2Ftests%2Ftours%2Fwebsite_page_options.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Ftests%2Ftours%2Fwebsite_page_options.js?ref=482c4597ca8081e29b7cb41039ef7433ff02ce59",
+        "patch": "@@ -24,7 +24,7 @@ registerWebsitePreviewTour('website_page_options', {\n     ...clickOnEditAndWaitEditMode(),\n     ...clickOnSnippet({id: 'o_header_standard', name: 'Header'}),\n     {\n-        content: \"Open the color picker to change the backaground color of the header\",\n+        content: \"Open the color picker to change the background color of the header\",\n         trigger:\"div[data-container-title='Header'] .hb-row[data-label='Header Position'] + .hb-row-sublevel-1[data-label='Background'] button\",\n         run: \"click\",\n     },"
+      }
+    ],
+    "paths": [
+      "addons/html_builder",
+      "addons/website"
+    ]
+  },
+  {
+    "sha": "6df92ce41681118c15e0c9613a430682f566079d",
+    "node_id": "C_kwDOAS1I7NoAKDZkZjkyY2U0MTY4MTExOGMxNWUwYzk2MTNhNDMwNjgyZjU2NjA3OWQ",
+    "commit": {
+      "author": {
+        "name": "romo",
+        "email": "romo@odoo.com",
+        "date": "2025-10-08T11:10:58Z"
+      },
+      "committer": {
+        "name": "romo",
+        "email": "romo@odoo.com",
+        "date": "2025-10-13T17:26:58Z"
+      },
+      "message": "[FIX] website: fix carousel id duplication\n\nThe selector used to target the carousel, to generate unique ID,\ndid not include some carousels (s_quotes[...]). This led to issues\nwith the controllers that would not be linked to the correct carousel.\n\nSteps to reproduce the issue:\n- Go to Edit\n- Drop two \"s_quotes_carousel\"\n- Save\n- Click on the \"next\" arrow of the second carousel\n=> The second carousel does not slide, but the first one does.\n\ncloses odoo/odoo#230897\n\nX-original-commit: 719cadefb6af9cf2ad152f2157f52c57ba0ef3fd\nSigned-off-by: Benoit Socias (bso) <bso@odoo.com>\nSigned-off-by: Romaric Moyeuvre (romo) <romo@odoo.com>",
+      "tree": {
+        "sha": "938a6dfee9f0ebdd58b841211ba7c4f7c46b63c0",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/938a6dfee9f0ebdd58b841211ba7c4f7c46b63c0"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/6df92ce41681118c15e0c9613a430682f566079d",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/6df92ce41681118c15e0c9613a430682f566079d",
+    "html_url": "https://github.com/odoo/odoo/commit/6df92ce41681118c15e0c9613a430682f566079d",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/6df92ce41681118c15e0c9613a430682f566079d/comments",
+    "author": {
+      "login": "romo-odoo",
+      "id": 178561061,
+      "node_id": "U_kgDOCqSgJQ",
+      "avatar_url": "https://avatars.githubusercontent.com/u/178561061?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/romo-odoo",
+      "html_url": "https://github.com/romo-odoo",
+      "followers_url": "https://api.github.com/users/romo-odoo/followers",
+      "following_url": "https://api.github.com/users/romo-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/romo-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/romo-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/romo-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/romo-odoo/orgs",
+      "repos_url": "https://api.github.com/users/romo-odoo/repos",
+      "events_url": "https://api.github.com/users/romo-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/romo-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "romo-odoo",
+      "id": 178561061,
+      "node_id": "U_kgDOCqSgJQ",
+      "avatar_url": "https://avatars.githubusercontent.com/u/178561061?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/romo-odoo",
+      "html_url": "https://github.com/romo-odoo",
+      "followers_url": "https://api.github.com/users/romo-odoo/followers",
+      "following_url": "https://api.github.com/users/romo-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/romo-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/romo-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/romo-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/romo-odoo/orgs",
+      "repos_url": "https://api.github.com/users/romo-odoo/repos",
+      "events_url": "https://api.github.com/users/romo-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/romo-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "5cfc5d8ca447831b982a26043cbe2eee7aa249f0",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/5cfc5d8ca447831b982a26043cbe2eee7aa249f0",
+        "html_url": "https://github.com/odoo/odoo/commit/5cfc5d8ca447831b982a26043cbe2eee7aa249f0"
+      }
+    ],
+    "stats": {
+      "total": 2,
+      "additions": 1,
+      "deletions": 1
+    },
+    "files": [
+      {
+        "sha": "c0915c20b520d48657559a83786dfac5d872528d",
+        "filename": "addons/website/static/src/builder/plugins/carousel_option_plugin.js",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/6df92ce41681118c15e0c9613a430682f566079d/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fplugins%2Fcarousel_option_plugin.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/6df92ce41681118c15e0c9613a430682f566079d/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fplugins%2Fcarousel_option_plugin.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fplugins%2Fcarousel_option_plugin.js?ref=6df92ce41681118c15e0c9613a430682f566079d",
+        "patch": "@@ -12,7 +12,7 @@ import { selectElements } from \"@html_editor/utils/dom_traversal\";\n export const CAROUSEL_CARDS_SEQUENCE = between(WEBSITE_BACKGROUND_OPTIONS, BOX_BORDER_SHADOW);\n \n const carouselWrapperSelector =\n-    \".s_carousel_wrapper, .s_carousel_intro_wrapper, .s_carousel_cards_wrapper\";\n+    \".s_carousel_wrapper, .s_carousel_intro_wrapper, .s_carousel_cards_wrapper, .s_quotes_carousel_wrapper\";\n const carouselControlsSelector =\n     \".carousel-control-prev, .carousel-control-next, .carousel-indicators\";\n "
+      }
+    ],
+    "paths": [
+      "addons/website"
+    ]
+  },
+  {
+    "sha": "ef789d3c50869ccb8651b7056c725257eb069759",
+    "node_id": "C_kwDOAS1I7NoAKGVmNzg5ZDNjNTA4NjljY2I4NjUxYjcwNTZjNzI1MjU3ZWIwNjk3NTk",
+    "commit": {
+      "author": {
+        "name": "Krzysztof Magusiak (krma)",
+        "email": "krma@odoo.com",
+        "date": "2025-10-08T14:29:27Z"
+      },
+      "committer": {
+        "name": "Raphael Collet",
+        "email": "rco@odoo.com",
+        "date": "2025-10-13T17:26:51Z"
+      },
+      "message": "[MOV] core: move Query into odoo.orm\n\nIt is already linked to the ORM and will be further integrated.\n\ncloses odoo/odoo#230715\n\nRelated: odoo/enterprise#96699\nSigned-off-by: Raphael Collet <rco@odoo.com>",
+      "tree": {
+        "sha": "6f520169d752592e6db646dd295624f5d23cdb8b",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/6f520169d752592e6db646dd295624f5d23cdb8b"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/ef789d3c50869ccb8651b7056c725257eb069759",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/ef789d3c50869ccb8651b7056c725257eb069759",
+    "html_url": "https://github.com/odoo/odoo/commit/ef789d3c50869ccb8651b7056c725257eb069759",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/ef789d3c50869ccb8651b7056c725257eb069759/comments",
+    "author": {
+      "login": "kmagusiak",
+      "id": 1943198,
+      "node_id": "MDQ6VXNlcjE5NDMxOTg=",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1943198?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/kmagusiak",
+      "html_url": "https://github.com/kmagusiak",
+      "followers_url": "https://api.github.com/users/kmagusiak/followers",
+      "following_url": "https://api.github.com/users/kmagusiak/following{/other_user}",
+      "gists_url": "https://api.github.com/users/kmagusiak/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/kmagusiak/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/kmagusiak/subscriptions",
+      "organizations_url": "https://api.github.com/users/kmagusiak/orgs",
+      "repos_url": "https://api.github.com/users/kmagusiak/repos",
+      "events_url": "https://api.github.com/users/kmagusiak/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/kmagusiak/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "rco-odoo",
+      "id": 7578141,
+      "node_id": "MDQ6VXNlcjc1NzgxNDE=",
+      "avatar_url": "https://avatars.githubusercontent.com/u/7578141?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/rco-odoo",
+      "html_url": "https://github.com/rco-odoo",
+      "followers_url": "https://api.github.com/users/rco-odoo/followers",
+      "following_url": "https://api.github.com/users/rco-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/rco-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/rco-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/rco-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/rco-odoo/orgs",
+      "repos_url": "https://api.github.com/users/rco-odoo/repos",
+      "events_url": "https://api.github.com/users/rco-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/rco-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "df865278ef64aa0e73a2d0e12f2ebccea3b0eb92",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/df865278ef64aa0e73a2d0e12f2ebccea3b0eb92",
+        "html_url": "https://github.com/odoo/odoo/commit/df865278ef64aa0e73a2d0e12f2ebccea3b0eb92"
+      }
+    ],
+    "stats": {
+      "total": 89,
+      "additions": 44,
+      "deletions": 45
+    },
+    "files": [
+      {
+        "sha": "c0cfd3d567748db5965d02f8b65f794447529025",
+        "filename": "addons/account/models/account_account.py",
+        "status": "modified",
+        "additions": 2,
+        "deletions": 1,
+        "changes": 3,
+        "blob_url": "https://github.com/odoo/odoo/blob/ef789d3c50869ccb8651b7056c725257eb069759/addons%2Faccount%2Fmodels%2Faccount_account.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/ef789d3c50869ccb8651b7056c725257eb069759/addons%2Faccount%2Fmodels%2Faccount_account.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Faccount%2Fmodels%2Faccount_account.py?ref=ef789d3c50869ccb8651b7056c725257eb069759",
+        "patch": "@@ -8,7 +8,8 @@\n from odoo import api, fields, models, _, Command\n from odoo.fields import Domain\n from odoo.exceptions import UserError, ValidationError, RedirectWarning\n-from odoo.tools import SQL, Query\n+from odoo.models import Query\n+from odoo.tools import SQL\n \n \n ACCOUNT_REGEX = re.compile(r'(?:(\\S*\\d+\\S*))?(.*)')"
+      },
+      {
+        "sha": "3aa3fe5d56e472b778dd4ed1e3051c074f3ecce3",
+        "filename": "addons/account/models/account_account_tag.py",
+        "status": "modified",
+        "additions": 2,
+        "deletions": 2,
+        "changes": 4,
+        "blob_url": "https://github.com/odoo/odoo/blob/ef789d3c50869ccb8651b7056c725257eb069759/addons%2Faccount%2Fmodels%2Faccount_account_tag.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/ef789d3c50869ccb8651b7056c725257eb069759/addons%2Faccount%2Fmodels%2Faccount_account_tag.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Faccount%2Fmodels%2Faccount_account_tag.py?ref=ef789d3c50869ccb8651b7056c725257eb069759",
+        "patch": "@@ -1,6 +1,6 @@\n from odoo import api, fields, models, _\n from odoo.fields import Domain\n-from odoo.tools import SQL, Query\n+from odoo.tools import SQL\n from odoo.exceptions import UserError\n \n \n@@ -47,7 +47,7 @@ def _compute_report_expression_id(self):\n         for tag in self:\n             tag.report_expression_id, tag.balance_negate = id2expression.get(tag._origin.id, (False, False))\n \n-    def _field_to_sql(self, alias: str, field_expr: str, query: (Query | None) = None) -> SQL:\n+    def _field_to_sql(self, alias: str, field_expr: str, query=None) -> SQL:\n         if field_expr in ('report_expression_id', 'balance_negate'):\n             rhs_alias = query.make_alias(alias, 'expression')\n             if rhs_alias not in query._joins:"
+      },
+      {
+        "sha": "f2c3dcb30a70860c7afce33d20686fdccaeb7178",
+        "filename": "addons/account/models/account_code_mapping.py",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/ef789d3c50869ccb8651b7056c725257eb069759/addons%2Faccount%2Fmodels%2Faccount_code_mapping.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/ef789d3c50869ccb8651b7056c725257eb069759/addons%2Faccount%2Fmodels%2Faccount_code_mapping.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Faccount%2Fmodels%2Faccount_code_mapping.py?ref=ef789d3c50869ccb8651b7056c725257eb069759",
+        "patch": "@@ -1,6 +1,6 @@\n from odoo import fields, models, api\n from odoo.fields import Domain\n-from odoo.tools import Query\n+from odoo.models import Query\n \n COMPANY_OFFSET = 10000\n "
+      },
+      {
+        "sha": "e78f80fbdd9213487d339e05024510951bcc0bfa",
+        "filename": "addons/account/models/account_move_line.py",
+        "status": "modified",
+        "additions": 2,
+        "deletions": 1,
+        "changes": 3,
+        "blob_url": "https://github.com/odoo/odoo/blob/ef789d3c50869ccb8651b7056c725257eb069759/addons%2Faccount%2Fmodels%2Faccount_move_line.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/ef789d3c50869ccb8651b7056c725257eb069759/addons%2Faccount%2Fmodels%2Faccount_move_line.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Faccount%2Fmodels%2Faccount_move_line.py?ref=ef789d3c50869ccb8651b7056c725257eb069759",
+        "patch": "@@ -7,7 +7,8 @@\n from odoo import api, fields, models, _\n from odoo.exceptions import ValidationError, UserError, RedirectWarning\n from odoo.fields import Command, Domain\n-from odoo.tools import frozendict, float_compare, groupby, Query, SQL, OrderedSet\n+from odoo.models import Query\n+from odoo.tools import frozendict, float_compare, groupby, SQL, OrderedSet\n from odoo.addons.web.controllers.utils import clean_action\n \n from odoo.addons.account.models.account_move import MAX_HASH_VERSION"
+      },
+      {
+        "sha": "a4341a327bc1e79fb5db2052bc54e6869d2c909f",
+        "filename": "addons/account/models/account_root.py",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/ef789d3c50869ccb8651b7056c725257eb069759/addons%2Faccount%2Fmodels%2Faccount_root.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/ef789d3c50869ccb8651b7056c725257eb069759/addons%2Faccount%2Fmodels%2Faccount_root.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Faccount%2Fmodels%2Faccount_root.py?ref=ef789d3c50869ccb8651b7056c725257eb069759",
+        "patch": "@@ -3,7 +3,7 @@\n \n from odoo import api, fields, models\n from odoo.exceptions import UserError\n-from odoo.tools import Query\n+from odoo.models import Query\n \n \n class AccountRoot(models.Model):"
+      },
+      {
+        "sha": "5df3500345f2d53491497ab899243a41aa1a403c",
+        "filename": "addons/account/report/account_invoice_report.py",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 5,
+        "changes": 6,
+        "blob_url": "https://github.com/odoo/odoo/blob/ef789d3c50869ccb8651b7056c725257eb069759/addons%2Faccount%2Freport%2Faccount_invoice_report.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/ef789d3c50869ccb8651b7056c725257eb069759/addons%2Faccount%2Freport%2Faccount_invoice_report.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Faccount%2Freport%2Faccount_invoice_report.py?ref=ef789d3c50869ccb8651b7056c725257eb069759",
+        "patch": "@@ -1,12 +1,8 @@\n-# -*- coding: utf-8 -*-\n-\n from odoo import models, fields, api\n+from odoo.models import Query\n from odoo.tools import SQL\n-from odoo.tools.query import Query\n from odoo.addons.account.models.account_move import PAYMENT_STATE_SELECTION\n \n-from functools import lru_cache\n-\n \n class AccountInvoiceReport(models.Model):\n     _name = 'account.invoice.report'"
+      },
+      {
+        "sha": "01c0509c14d445cc792e17bec13ed083a2481b06",
+        "filename": "addons/analytic/models/analytic_mixin.py",
+        "status": "modified",
+        "additions": 2,
+        "deletions": 1,
+        "changes": 3,
+        "blob_url": "https://github.com/odoo/odoo/blob/ef789d3c50869ccb8651b7056c725257eb069759/addons%2Fanalytic%2Fmodels%2Fanalytic_mixin.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/ef789d3c50869ccb8651b7056c725257eb069759/addons%2Fanalytic%2Fmodels%2Fanalytic_mixin.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fanalytic%2Fmodels%2Fanalytic_mixin.py?ref=ef789d3c50869ccb8651b7056c725257eb069759",
+        "patch": "@@ -4,7 +4,8 @@\n from odoo import _, api, fields, models\n from odoo.exceptions import UserError, ValidationError\n from odoo.fields import Domain\n-from odoo.tools import SQL, Query, unique\n+from odoo.models import Query\n+from odoo.tools import SQL, unique\n from odoo.tools.float_utils import float_compare, float_round\n \n "
+      },
+      {
+        "sha": "0290f029aec164d5b0c70754b2e590375eb545c0",
+        "filename": "addons/hr/models/hr_employee.py",
+        "status": "modified",
+        "additions": 2,
+        "deletions": 1,
+        "changes": 3,
+        "blob_url": "https://github.com/odoo/odoo/blob/ef789d3c50869ccb8651b7056c725257eb069759/addons%2Fhr%2Fmodels%2Fhr_employee.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/ef789d3c50869ccb8651b7056c725257eb069759/addons%2Fhr%2Fmodels%2Fhr_employee.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhr%2Fmodels%2Fhr_employee.py?ref=ef789d3c50869ccb8651b7056c725257eb069759",
+        "patch": "@@ -14,7 +14,8 @@\n from odoo import api, fields, models, _, tools\n from odoo.fields import Domain\n from odoo.exceptions import ValidationError, AccessError, RedirectWarning, UserError\n-from odoo.tools import convert, format_time, email_normalize, SQL, Query\n+from odoo.models import Query\n+from odoo.tools import convert, format_time, email_normalize, SQL\n from odoo.tools.intervals import Intervals\n from odoo.addons.hr.models.hr_version import format_date_abbr\n from odoo.addons.mail.tools.discuss import Store"
+      },
+      {
+        "sha": "e4dc846ad18bad7d38f201ace096323150443795",
+        "filename": "addons/mail/models/mail_thread.py",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/ef789d3c50869ccb8651b7056c725257eb069759/addons%2Fmail%2Fmodels%2Fmail_thread.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/ef789d3c50869ccb8651b7056c725257eb069759/addons%2Fmail%2Fmodels%2Fmail_thread.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fmail%2Fmodels%2Fmail_thread.py?ref=ef789d3c50869ccb8651b7056c725257eb069759",
+        "patch": "@@ -35,7 +35,7 @@\n from odoo.fields import Domain\n from odoo.tools import (\n     is_html_empty, html_escape, html2plaintext,\n-    clean_context, split_every, Query, SQL,\n+    clean_context, split_every, SQL,\n     ormcache, is_list_of,\n )\n from odoo.tools.mail import ("
+      },
+      {
+        "sha": "e4e270061c398643a523a3aebc104af0f3ed82d7",
+        "filename": "addons/purchase/report/purchase_report.py",
+        "status": "modified",
+        "additions": 2,
+        "deletions": 3,
+        "changes": 5,
+        "blob_url": "https://github.com/odoo/odoo/blob/ef789d3c50869ccb8651b7056c725257eb069759/addons%2Fpurchase%2Freport%2Fpurchase_report.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/ef789d3c50869ccb8651b7056c725257eb069759/addons%2Fpurchase%2Freport%2Fpurchase_report.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fpurchase%2Freport%2Fpurchase_report.py?ref=ef789d3c50869ccb8651b7056c725257eb069759",
+        "patch": "@@ -1,12 +1,11 @@\n-# -*- coding: utf-8 -*-\n # Part of Odoo. See LICENSE file for full copyright and licensing details.\n \n #\n # Please note that these reports are not multi-currency !!!\n #\n \n-from odoo import fields, models, api\n-from odoo.tools.query import Query\n+from odoo import fields, models\n+from odoo.models import Query\n from odoo.tools.sql import SQL\n \n "
+      },
+      {
+        "sha": "1db19be3b81e4eabde4faaf5488541eb6a665a8a",
+        "filename": "addons/sale_project/models/project_project.py",
+        "status": "modified",
+        "additions": 2,
+        "deletions": 1,
+        "changes": 3,
+        "blob_url": "https://github.com/odoo/odoo/blob/ef789d3c50869ccb8651b7056c725257eb069759/addons%2Fsale_project%2Fmodels%2Fproject_project.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/ef789d3c50869ccb8651b7056c725257eb069759/addons%2Fsale_project%2Fmodels%2Fproject_project.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fsale_project%2Fmodels%2Fproject_project.py?ref=ef789d3c50869ccb8651b7056c725257eb069759",
+        "patch": "@@ -6,7 +6,8 @@\n \n from odoo import api, fields, models\n from odoo.fields import Domain\n-from odoo.tools import Query, SQL\n+from odoo.models import Query\n+from odoo.tools import SQL\n from odoo.tools.misc import unquote\n from odoo.tools.translate import _\n "
+      },
+      {
+        "sha": "bac77707879c5beab7bbac25f084c0c17b36c42d",
+        "filename": "addons/website/models/website.py",
+        "status": "modified",
+        "additions": 2,
+        "deletions": 1,
+        "changes": 3,
+        "blob_url": "https://github.com/odoo/odoo/blob/ef789d3c50869ccb8651b7056c725257eb069759/addons%2Fwebsite%2Fmodels%2Fwebsite.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/ef789d3c50869ccb8651b7056c725257eb069759/addons%2Fwebsite%2Fmodels%2Fwebsite.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fmodels%2Fwebsite.py?ref=ef789d3c50869ccb8651b7056c725257eb069759",
+        "patch": "@@ -25,8 +25,9 @@\n from odoo.exceptions import AccessError, UserError, ValidationError\n from odoo.fields import Domain\n from odoo.http import request\n+from odoo.models import Query\n from odoo.modules.module import get_manifest\n-from odoo.tools import SQL, Query\n+from odoo.tools import SQL\n from odoo.tools.image import image_process\n from odoo.tools.sql import escape_psql\n from odoo.tools.translate import _"
+      },
+      {
+        "sha": "d51a59fb199d39b709c766f3b726dd8c0af3026b",
+        "filename": "odoo/addons/base/tests/test_query.py",
+        "status": "modified",
+        "additions": 2,
+        "deletions": 1,
+        "changes": 3,
+        "blob_url": "https://github.com/odoo/odoo/blob/ef789d3c50869ccb8651b7056c725257eb069759/odoo%2Faddons%2Fbase%2Ftests%2Ftest_query.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/ef789d3c50869ccb8651b7056c725257eb069759/odoo%2Faddons%2Fbase%2Ftests%2Ftest_query.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/odoo%2Faddons%2Fbase%2Ftests%2Ftest_query.py?ref=ef789d3c50869ccb8651b7056c725257eb069759",
+        "patch": "@@ -1,7 +1,8 @@\n # Part of Odoo. See LICENSE file for full copyright and licensing details.\n \n+from odoo.models import Query\n from odoo.tests.common import BaseCase, TransactionCase\n-from odoo.tools import Query, SQL\n+from odoo.tools import SQL\n \n \n class QueryTestCase(BaseCase):"
+      },
+      {
+        "sha": "fa506e0611ac502f6161d86f7324054bd842264a",
+        "filename": "odoo/models/__init__.py",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 0,
+        "changes": 1,
+        "blob_url": "https://github.com/odoo/odoo/blob/ef789d3c50869ccb8651b7056c725257eb069759/odoo%2Fmodels%2F__init__.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/ef789d3c50869ccb8651b7056c725257eb069759/odoo%2Fmodels%2F__init__.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/odoo%2Fmodels%2F__init__.py?ref=ef789d3c50869ccb8651b7056c725257eb069759",
+        "patch": "@@ -22,6 +22,7 @@\n )\n from odoo.orm.model_classes import is_model_class, is_model_definition\n from odoo.orm.models_transient import TransientModel\n+from odoo.orm.query import Query\n from odoo.orm.table_objects import Constraint, Index, UniqueIndex\n from odoo.orm.utils import (\n     READ_GROUP_TIME_GRANULARITY,"
+      },
+      {
+        "sha": "16bda70956e2eff8dda6bb3b39773108625de5a9",
+        "filename": "odoo/orm/domains.py",
+        "status": "modified",
+        "additions": 2,
+        "deletions": 1,
+        "changes": 3,
+        "blob_url": "https://github.com/odoo/odoo/blob/ef789d3c50869ccb8651b7056c725257eb069759/odoo%2Form%2Fdomains.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/ef789d3c50869ccb8651b7056c725257eb069759/odoo%2Form%2Fdomains.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/odoo%2Form%2Fdomains.py?ref=ef789d3c50869ccb8651b7056c725257eb069759",
+        "patch": "@@ -63,9 +63,10 @@\n from datetime import date, datetime, time, timedelta, timezone\n \n from odoo.exceptions import UserError\n-from odoo.tools import SQL, OrderedSet, Query, classproperty, partition, str2bool\n+from odoo.tools import SQL, OrderedSet, classproperty, partition, str2bool\n from odoo.tools.date_utils import parse_date, parse_iso_date\n from .identifiers import NewId\n+from .query import Query\n from .utils import COLLECTION_TYPES, parse_field_expr\n \n if typing.TYPE_CHECKING:"
+      },
+      {
+        "sha": "368f6096ecbdca645cdbafe37fffdfb838663df2",
+        "filename": "odoo/orm/environments.py",
+        "status": "modified",
+        "additions": 2,
+        "deletions": 1,
+        "changes": 3,
+        "blob_url": "https://github.com/odoo/odoo/blob/ef789d3c50869ccb8651b7056c725257eb069759/odoo%2Form%2Fenvironments.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/ef789d3c50869ccb8651b7056c725257eb069759/odoo%2Form%2Fenvironments.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/odoo%2Form%2Fenvironments.py?ref=ef789d3c50869ccb8651b7056c725257eb069759",
+        "patch": "@@ -17,11 +17,12 @@\n \n from odoo.exceptions import AccessError, UserError, CacheMiss\n from odoo.sql_db import BaseCursor\n-from odoo.tools import clean_context, frozendict, reset_cached_properties, OrderedSet, Query, SQL\n+from odoo.tools import clean_context, frozendict, reset_cached_properties, OrderedSet, SQL\n from odoo.tools.translate import get_translation, get_translated_module, LazyGettext\n from odoo.tools.misc import StackMap, SENTINEL\n \n from .registry import Registry\n+from .query import Query\n from .utils import SUPERUSER_ID\n \n if typing.TYPE_CHECKING:"
+      },
+      {
+        "sha": "689c2a9bd858f0085e326984cf64a6089b77d04e",
+        "filename": "odoo/orm/fields.py",
+        "status": "modified",
+        "additions": 2,
+        "deletions": 1,
+        "changes": 3,
+        "blob_url": "https://github.com/odoo/odoo/blob/ef789d3c50869ccb8651b7056c725257eb069759/odoo%2Form%2Ffields.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/ef789d3c50869ccb8651b7056c725257eb069759/odoo%2Form%2Ffields.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/odoo%2Form%2Ffields.py?ref=ef789d3c50869ccb8651b7056c725257eb069759",
+        "patch": "@@ -17,11 +17,12 @@\n from psycopg2.extras import Json as PsycopgJson\n \n from odoo.exceptions import AccessError, MissingError\n-from odoo.tools import Query, SQL, sql\n+from odoo.tools import SQL, sql\n from odoo.tools.constants import PREFETCH_MAX\n from odoo.tools.misc import SENTINEL, ReadonlyDict, Sentinel, unique\n \n from .domains import Domain\n+from .query import Query\n from .utils import COLLECTION_TYPES, SQL_OPERATORS, SUPERUSER_ID, expand_ids\n \n if typing.TYPE_CHECKING:"
+      },
+      {
+        "sha": "1f32950edb62b02678114583242dcf5041145d60",
+        "filename": "odoo/orm/fields_binary.py",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 2,
+        "changes": 3,
+        "blob_url": "https://github.com/odoo/odoo/blob/ef789d3c50869ccb8651b7056c725257eb069759/odoo%2Form%2Ffields_binary.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/ef789d3c50869ccb8651b7056c725257eb069759/odoo%2Form%2Ffields_binary.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/odoo%2Form%2Ffields_binary.py?ref=ef789d3c50869ccb8651b7056c725257eb069759",
+        "patch": "@@ -18,9 +18,8 @@\n from .utils import SQL_OPERATORS\n \n if typing.TYPE_CHECKING:\n-    from odoo.tools import Query\n-\n     from .models import BaseModel\n+    from .query import Query\n \n # http://initd.org/psycopg/docs/usage.html#binary-adaptation\n # Received data is returned as buffer (in Python 2) or memoryview (in Python 3)."
+      },
+      {
+        "sha": "dc73f1a8076d0a05669bbe29155a2c240e015abf",
+        "filename": "odoo/orm/fields_misc.py",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/ef789d3c50869ccb8651b7056c725257eb069759/odoo%2Form%2Ffields_misc.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/ef789d3c50869ccb8651b7056c725257eb069759/odoo%2Form%2Ffields_misc.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/odoo%2Form%2Ffields_misc.py?ref=ef789d3c50869ccb8651b7056c725257eb069759",
+        "patch": "@@ -13,7 +13,7 @@\n \n if typing.TYPE_CHECKING:\n     from .models import BaseModel\n-    from odoo.tools import Query\n+    from .query import Query\n \n # integer needs to be imported before Id because of `type` attribute clash\n from . import fields_numeric  # noqa: F401"
+      },
+      {
+        "sha": "cfb1a68479ebc7710d1869a5b31b078b55a2a09a",
+        "filename": "odoo/orm/fields_properties.py",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/ef789d3c50869ccb8651b7056c725257eb069759/odoo%2Form%2Ffields_properties.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/ef789d3c50869ccb8651b7056c725257eb069759/odoo%2Form%2Ffields_properties.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/odoo%2Form%2Ffields_properties.py?ref=ef789d3c50869ccb8651b7056c725257eb069759",
+        "patch": "@@ -19,7 +19,7 @@\n from .models import BaseModel\n from .utils import COLLECTION_TYPES, SQL_OPERATORS, parse_field_expr, regex_alphanumeric\n if typing.TYPE_CHECKING:\n-    from odoo.tools import Query\n+    from .query import Query\n \n NoneType = type(None)\n "
+      },
+      {
+        "sha": "d2c40d0938a00239f7821e71631d069a3f4eb2dc",
+        "filename": "odoo/orm/fields_relational.py",
+        "status": "modified",
+        "additions": 2,
+        "deletions": 1,
+        "changes": 3,
+        "blob_url": "https://github.com/odoo/odoo/blob/ef789d3c50869ccb8651b7056c725257eb069759/odoo%2Form%2Ffields_relational.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/ef789d3c50869ccb8651b7056c725257eb069759/odoo%2Form%2Ffields_relational.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/odoo%2Form%2Ffields_relational.py?ref=ef789d3c50869ccb8651b7056c725257eb069759",
+        "patch": "@@ -8,7 +8,7 @@\n from operator import attrgetter\n \n from odoo.exceptions import AccessError, MissingError, UserError\n-from odoo.tools import SQL, OrderedSet, Query, sql, unique\n+from odoo.tools import SQL, OrderedSet, sql, unique\n from odoo.tools.constants import PREFETCH_MAX\n from odoo.tools.misc import SENTINEL, Sentinel, unquote\n \n@@ -18,6 +18,7 @@\n from .fields_reference import Many2oneReference\n from .identifiers import NewId\n from .models import BaseModel\n+from .query import Query\n from .utils import COLLECTION_TYPES, SQL_OPERATORS, check_pg_name\n \n if typing.TYPE_CHECKING:"
+      },
+      {
+        "sha": "fbbd377498b190bacb4a0b5a0584703cb1cd9385",
+        "filename": "odoo/orm/fields_temporal.py",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/ef789d3c50869ccb8651b7056c725257eb069759/odoo%2Form%2Ffields_temporal.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/ef789d3c50869ccb8651b7056c725257eb069759/odoo%2Form%2Ffields_temporal.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/odoo%2Form%2Ffields_temporal.py?ref=ef789d3c50869ccb8651b7056c725257eb069759",
+        "patch": "@@ -14,9 +14,9 @@\n \n if typing.TYPE_CHECKING:\n     from collections.abc import Callable\n-    from odoo.tools import Query\n \n     from .models import BaseModel\n+    from .query import Query\n \n T = typing.TypeVar(\"T\")\n "
+      },
+      {
+        "sha": "1f5f8b6d6170a107a745881fc7c8a39f5384574b",
+        "filename": "odoo/orm/fields_textual.py",
+        "status": "modified",
+        "additions": 2,
+        "deletions": 4,
+        "changes": 6,
+        "blob_url": "https://github.com/odoo/odoo/blob/ef789d3c50869ccb8651b7056c725257eb069759/odoo%2Form%2Ffields_textual.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/ef789d3c50869ccb8651b7056c725257eb069759/odoo%2Form%2Ffields_textual.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/odoo%2Form%2Ffields_textual.py?ref=ef789d3c50869ccb8651b7056c725257eb069759",
+        "patch": "@@ -22,12 +22,10 @@\n from .fields import Field, _logger\n from .utils import COLLECTION_TYPES, SQL_OPERATORS\n \n-if typing.TYPE_CHECKING:\n-    from .models import BaseModel\n-    from odoo.tools import Query\n-\n if typing.TYPE_CHECKING:\n     from collections.abc import Callable\n+    from .models import BaseModel\n+    from .query import Query\n \n \n class BaseString(Field[str | typing.Literal[False]]):"
+      },
+      {
+        "sha": "b7dc1e36eab5a8b66a5d0cd26f0c00cd1d595741",
+        "filename": "odoo/orm/models.py",
+        "status": "modified",
+        "additions": 3,
+        "deletions": 7,
+        "changes": 10,
+        "blob_url": "https://github.com/odoo/odoo/blob/ef789d3c50869ccb8651b7056c725257eb069759/odoo%2Form%2Fmodels.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/ef789d3c50869ccb8651b7056c725257eb069759/odoo%2Form%2Fmodels.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/odoo%2Form%2Fmodels.py?ref=ef789d3c50869ccb8651b7056c725257eb069759",
+        "patch": "@@ -23,14 +23,12 @@\n \n import collections\n import contextlib\n-import datetime\n import functools\n import inspect\n import itertools\n import io\n import json\n import logging\n-import pytz\n import re\n import typing\n import uuid\n@@ -40,18 +38,15 @@\n from inspect import getmembers\n from operator import attrgetter, itemgetter\n \n-import babel\n-import babel.dates\n import psycopg2.errors\n import psycopg2.extensions\n from psycopg2.extras import Json\n \n from odoo.exceptions import AccessError, LockError, MissingError, ValidationError, UserError\n from odoo.tools import (\n-    clean_context, date_utils,\n-    DEFAULT_SERVER_DATE_FORMAT, DEFAULT_SERVER_DATETIME_FORMAT, format_list,\n+    clean_context, format_list,\n     frozendict, get_lang, OrderedSet,\n-    ormcache, partition, Query, split_every, unique,\n+    ormcache, partition, split_every, unique,\n     SQL, sql, groupby,\n )\n from odoo.tools.constants import PREFETCH_MAX\n@@ -68,6 +63,7 @@\n from .fields_textual import Char\n \n from .identifiers import NewId\n+from .query import Query\n from .utils import (\n     OriginIds, check_object_name, parse_field_expr,\n     COLLECTION_TYPES, SQL_OPERATORS,"
+      },
+      {
+        "sha": "ca3477814230504a81a4bcd2107c6eff9b2fa9a1",
+        "filename": "odoo/orm/query.py",
+        "status": "renamed",
+        "additions": 4,
+        "deletions": 4,
+        "changes": 8,
+        "blob_url": "https://github.com/odoo/odoo/blob/ef789d3c50869ccb8651b7056c725257eb069759/odoo%2Form%2Fquery.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/ef789d3c50869ccb8651b7056c725257eb069759/odoo%2Form%2Fquery.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/odoo%2Form%2Fquery.py?ref=ef789d3c50869ccb8651b7056c725257eb069759",
+        "patch": "@@ -5,9 +5,9 @@\n \n if TYPE_CHECKING:\n     from collections.abc import Iterable, Iterator\n-    from odoo.orm.models import BaseModel\n+    from .models import BaseModel\n \n-from .sql import SQL, make_identifier\n+from odoo.tools.sql import SQL, make_identifier\n \n \n def _sql_from_table(alias: str, table: SQL) -> SQL:\n@@ -103,7 +103,7 @@ def add_join(self, kind: str, alias: str, table: str | SQL | None, condition: SQ\n \n     def add_where(self, where_clause: str | SQL, where_params=()):\n         \"\"\" Add a condition to the where clause. \"\"\"\n-        self._where_clauses.append(SQL(where_clause, *where_params)) # pylint: disable = sql-injection\n+        self._where_clauses.append(SQL(where_clause, *where_params))  # pylint: disable = sql-injection\n         self._ids = self._ids and None\n \n     def join(self, lhs_alias: str, lhs_column: str, rhs_table: str | SQL, rhs_column: str, link: str) -> str:\n@@ -144,7 +144,7 @@ def order(self) -> SQL | None:\n \n     @order.setter\n     def order(self, value: SQL | str | None):\n-        self._order = SQL(value) if value is not None else None # pylint: disable = sql-injection\n+        self._order = SQL(value) if value is not None else None  # pylint: disable = sql-injection\n \n     @property\n     def table(self) -> str:",
+        "previous_filename": "odoo/tools/query.py"
+      },
+      {
+        "sha": "1879ea35ed61281b5ebf0530c35cf31f6e177fc7",
+        "filename": "odoo/tools/__init__.py",
+        "status": "modified",
+        "additions": 0,
+        "deletions": 1,
+        "changes": 1,
+        "blob_url": "https://github.com/odoo/odoo/blob/ef789d3c50869ccb8651b7056c725257eb069759/odoo%2Ftools%2F__init__.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/ef789d3c50869ccb8651b7056c725257eb069759/odoo%2Ftools%2F__init__.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/odoo%2Ftools%2F__init__.py?ref=ef789d3c50869ccb8651b7056c725257eb069759",
+        "patch": "@@ -12,7 +12,6 @@\n from .json import json_default\n from .mail import *\n from .misc import *\n-from .query import Query\n from .sql import *\n from .translate import _, html_translate, xml_translate, LazyTranslate\n from .xml_utils import cleanup_xml_node, load_xsd_files_from_url, validate_xml_from_attachment"
+      }
+    ],
+    "paths": [
+      "addons/website"
+    ]
+  },
+  {
+    "sha": "2b12fdaa91fba6e6a27818e7ee4f028ef3fa6877",
+    "node_id": "C_kwDOAS1I7NoAKDJiMTJmZGFhOTFmYmE2ZTZhMjc4MThlN2VlNGYwMjhlZjNmYTY4Nzc",
+    "commit": {
+      "author": {
+        "name": "Raphael Collet",
+        "email": "rco@odoo.com",
+        "date": "2025-06-26T12:57:40Z"
+      },
+      "committer": {
+        "name": "Krzysztof Magusiak (krma)",
+        "email": "krma@odoo.com",
+        "date": "2025-10-13T17:26:50Z"
+      },
+      "message": "[IMP] orm: Query(model)\n\nPart-of: odoo/odoo#230715\nRelated: odoo/enterprise#96699\nSigned-off-by: Raphael Collet <rco@odoo.com>",
+      "tree": {
+        "sha": "b72fa53372793bb1c9738567e96c825552f2b56e",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/b72fa53372793bb1c9738567e96c825552f2b56e"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/2b12fdaa91fba6e6a27818e7ee4f028ef3fa6877",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/2b12fdaa91fba6e6a27818e7ee4f028ef3fa6877",
+    "html_url": "https://github.com/odoo/odoo/commit/2b12fdaa91fba6e6a27818e7ee4f028ef3fa6877",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/2b12fdaa91fba6e6a27818e7ee4f028ef3fa6877/comments",
+    "author": {
+      "login": "rco-odoo",
+      "id": 7578141,
+      "node_id": "MDQ6VXNlcjc1NzgxNDE=",
+      "avatar_url": "https://avatars.githubusercontent.com/u/7578141?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/rco-odoo",
+      "html_url": "https://github.com/rco-odoo",
+      "followers_url": "https://api.github.com/users/rco-odoo/followers",
+      "following_url": "https://api.github.com/users/rco-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/rco-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/rco-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/rco-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/rco-odoo/orgs",
+      "repos_url": "https://api.github.com/users/rco-odoo/repos",
+      "events_url": "https://api.github.com/users/rco-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/rco-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "kmagusiak",
+      "id": 1943198,
+      "node_id": "MDQ6VXNlcjE5NDMxOTg=",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1943198?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/kmagusiak",
+      "html_url": "https://github.com/kmagusiak",
+      "followers_url": "https://api.github.com/users/kmagusiak/followers",
+      "following_url": "https://api.github.com/users/kmagusiak/following{/other_user}",
+      "gists_url": "https://api.github.com/users/kmagusiak/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/kmagusiak/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/kmagusiak/subscriptions",
+      "organizations_url": "https://api.github.com/users/kmagusiak/orgs",
+      "repos_url": "https://api.github.com/users/kmagusiak/repos",
+      "events_url": "https://api.github.com/users/kmagusiak/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/kmagusiak/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "48c617517ba65e41eaa3c7e0f9408ca3bb4d06eb",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/48c617517ba65e41eaa3c7e0f9408ca3bb4d06eb",
+        "html_url": "https://github.com/odoo/odoo/commit/48c617517ba65e41eaa3c7e0f9408ca3bb4d06eb"
+      }
+    ],
+    "stats": {
+      "total": 58,
+      "additions": 32,
+      "deletions": 26
+    },
+    "files": [
+      {
+        "sha": "aaa486fee8e7027746056e951260e8565a46572c",
+        "filename": "addons/account/models/account_account.py",
+        "status": "modified",
+        "additions": 2,
+        "deletions": 2,
+        "changes": 4,
+        "blob_url": "https://github.com/odoo/odoo/blob/2b12fdaa91fba6e6a27818e7ee4f028ef3fa6877/addons%2Faccount%2Fmodels%2Faccount_account.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/2b12fdaa91fba6e6a27818e7ee4f028ef3fa6877/addons%2Faccount%2Fmodels%2Faccount_account.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Faccount%2Fmodels%2Faccount_account.py?ref=2b12fdaa91fba6e6a27818e7ee4f028ef3fa6877",
+        "patch": "@@ -409,7 +409,7 @@ def _compute_placeholder_code(self):\n     def _search_placeholder_code(self, operator, value):\n         if operator not in ('=ilike', 'in'):\n             return NotImplemented\n-        query = Query(self.env, 'account_account')\n+        query = Query(self)\n         placeholder_code_sql = self.env['account.account']._field_to_sql('account_account', 'placeholder_code', query)\n         if operator == 'in':\n             query.add_where(SQL(\"%s IN %s\", placeholder_code_sql, tuple(value)))\n@@ -1269,7 +1269,7 @@ def _get_query_company_id(model):\n                 return\n             # We would get a ValueError if the _field_to_sql is not implemented. In that case, we return None.\n             with contextlib.suppress(ValueError):\n-                query = Query(self.env, self.env[model]._table, self.env[model]._table_sql)\n+                query = Query(self.env[model])\n                 return query.select(\n                     SQL('%s AS id', self.env[model]._field_to_sql(query.table, 'id')),\n                     SQL('%s AS company_id', self.env[model]._field_to_sql(query.table, company_id_field, query)),"
+      },
+      {
+        "sha": "4289f96eee9cd4729fa26fa230119c2dac36b9f0",
+        "filename": "addons/sale_project/models/project_project.py",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/2b12fdaa91fba6e6a27818e7ee4f028ef3fa6877/addons%2Fsale_project%2Fmodels%2Fproject_project.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/2b12fdaa91fba6e6a27818e7ee4f028ef3fa6877/addons%2Fsale_project%2Fmodels%2Fproject_project.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fsale_project%2Fmodels%2Fproject_project.py?ref=2b12fdaa91fba6e6a27818e7ee4f028ef3fa6877",
+        "patch": "@@ -444,7 +444,7 @@ def _get_sale_order_items_query(self, domain_per_model=None):\n             f'{SaleOrderLine._table}.id AS sale_line_id',\n         )\n \n-        return Query(self.env, 'project_sale_order_item', SQL('(%s)', SQL(' UNION ').join([\n+        return Query(None, 'project_sale_order_item', SQL('(%s)', SQL(' UNION ').join([\n             project_sql, task_sql, milestone_sql, sale_order_line_sql,\n         ])))\n "
+      },
+      {
+        "sha": "27f2bc61761e5e21aa418c44257e5060b6fb1a0c",
+        "filename": "addons/website/models/website.py",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/2b12fdaa91fba6e6a27818e7ee4f028ef3fa6877/addons%2Fwebsite%2Fmodels%2Fwebsite.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/2b12fdaa91fba6e6a27818e7ee4f028ef3fa6877/addons%2Fwebsite%2Fmodels%2Fwebsite.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fmodels%2Fwebsite.py?ref=2b12fdaa91fba6e6a27818e7ee4f028ef3fa6877",
+        "patch": "@@ -2143,7 +2143,7 @@ def get_similarity_subquery(model, fields, id_column, rel_table='', rel_joinkey=\n             :rel_table: name of the rel table when search_fields in search_details contains a Many2many.\n             :rel_joinkey: name of the column used to join model._table with rel_table.\n             \"\"\"\n-            subquery = Query(self.env.cr, model._table, model._table_query)\n+            subquery = Query(model)\n             unaccent = self.env.registry.unaccent\n             similarity = SQL(\n                 \"GREATEST(%(similarities)s) as similarity\","
+      },
+      {
+        "sha": "cc0cf741f4739fd82fd0ba3599e2314d1330fde5",
+        "filename": "odoo/addons/base/tests/test_query.py",
+        "status": "modified",
+        "additions": 10,
+        "deletions": 10,
+        "changes": 20,
+        "blob_url": "https://github.com/odoo/odoo/blob/2b12fdaa91fba6e6a27818e7ee4f028ef3fa6877/odoo%2Faddons%2Fbase%2Ftests%2Ftest_query.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/2b12fdaa91fba6e6a27818e7ee4f028ef3fa6877/odoo%2Faddons%2Fbase%2Ftests%2Ftest_query.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/odoo%2Faddons%2Fbase%2Ftests%2Ftest_query.py?ref=2b12fdaa91fba6e6a27818e7ee4f028ef3fa6877",
+        "patch": "@@ -7,7 +7,7 @@\n class QueryTestCase(BaseCase):\n \n     def test_basic_query(self):\n-        query = Query(None, 'product_product')\n+        query = Query(None, 'product_product', SQL.identifier('product_product'))\n         query.add_table('product_template')\n         query.add_where(\"product_product.template_id = product_template.id\")\n         # add inner join\n@@ -23,7 +23,7 @@ def test_basic_query(self):\n             \"product_product.template_id = product_template.id\")\n \n     def test_query_chained_explicit_joins(self):\n-        query = Query(None, 'product_product')\n+        query = Query(None, 'product_product', SQL.identifier('product_product'))\n         query.add_table('product_template')\n         query.add_where(\"product_product.template_id = product_template.id\")\n         # add inner join\n@@ -39,7 +39,7 @@ def test_query_chained_explicit_joins(self):\n             \"product_product.template_id = product_template.id\")\n \n     def test_mixed_query_chained_explicit_implicit_joins(self):\n-        query = Query(None, 'product_product')\n+        query = Query(None, 'product_product', SQL.identifier('product_product'))\n         query.add_table('product_template')\n         query.add_where(\"product_product.template_id = product_template.id\")\n         # add inner join\n@@ -58,12 +58,12 @@ def test_mixed_query_chained_explicit_implicit_joins(self):\n             \"product_product.template_id = product_template.id AND product_category.expense_account_id = account_account.id\")\n \n     def test_raise_missing_lhs(self):\n-        query = Query(None, 'product_product')\n+        query = Query(None, 'product_product', SQL.identifier('product_product'))\n         with self.assertRaises(AssertionError):\n             query.join(\"product_template\", \"categ_id\", \"product_category\", \"id\", \"categ_id\")\n \n     def test_long_aliases(self):\n-        query = Query(None, 'product_product')\n+        query = Query(None, 'product_product', SQL.identifier('product_product'))\n         tmp = query.join('product_product', 'product_tmpl_id', 'product_template', 'id', 'product_tmpl_id')\n         self.assertEqual(tmp, 'product_product__product_tmpl_id')\n         # no hashing\n@@ -81,26 +81,26 @@ def test_long_aliases(self):\n         self.assertEqual(tmp_cat_stm_par, 'product_product__product_tmpl_id__product_category_id__00363fdd')\n \n     def test_table_expression(self):\n-        query = Query(None, 'foo')\n+        query = Query(None, 'foo', SQL.identifier('foo'))\n         from_clause = query.from_clause.code\n         self.assertEqual(from_clause, '\"foo\"')\n \n         query = Query(None, 'bar', SQL('(SELECT id FROM foo)'))\n         from_clause = query.from_clause.code\n         self.assertEqual(from_clause, '(SELECT id FROM foo) AS \"bar\"')\n \n-        query = Query(None, 'foo')\n+        query = Query(None, 'foo', SQL.identifier('foo'))\n         query.add_table('bar', SQL('(SELECT id FROM foo)'))\n         from_clause = query.from_clause.code\n         self.assertEqual(from_clause, '\"foo\", (SELECT id FROM foo) AS \"bar\"')\n \n-        query = Query(None, 'foo')\n+        query = Query(None, 'foo', SQL.identifier('foo'))\n         query.join('foo', 'bar_id', SQL('(SELECT id FROM foo)'), 'id', 'bar')\n         from_clause = query.from_clause.code\n         self.assertEqual(from_clause, '\"foo\" JOIN (SELECT id FROM foo) AS \"foo__bar\" ON (\"foo\".\"bar_id\" = \"foo__bar\".\"id\")')\n \n     def test_empty_set_result_ids(self):\n-        query = Query(None, 'foo')\n+        query = Query(None, 'foo', SQL.identifier('foo'))\n         query.set_result_ids([])\n         self.assertEqual(query.get_result_ids(), ())\n         self.assertTrue(query.is_empty())\n@@ -110,7 +110,7 @@ def test_empty_set_result_ids(self):\n         self.assertTrue(query.is_empty(), \"adding where clauses keeps the result empty\")\n \n     def test_set_result_ids(self):\n-        query = Query(None, 'foo')\n+        query = Query(None, 'foo', SQL.identifier('foo'))\n         query.set_result_ids([1, 2, 3])\n         self.assertEqual(query.get_result_ids(), (1, 2, 3))\n         self.assertFalse(query.is_empty())"
+      },
+      {
+        "sha": "21649019fe0eaf8bb4ad8e4937435f6c3feab9d5",
+        "filename": "odoo/orm/environments.py",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/2b12fdaa91fba6e6a27818e7ee4f028ef3fa6877/odoo%2Form%2Fenvironments.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/2b12fdaa91fba6e6a27818e7ee4f028ef3fa6877/odoo%2Form%2Fenvironments.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/odoo%2Form%2Fenvironments.py?ref=2b12fdaa91fba6e6a27818e7ee4f028ef3fa6877",
+        "patch": "@@ -914,7 +914,7 @@ def process(model: BaseModel, field: Field, field_cache):\n                 return\n \n             # select the column for the given ids\n-            query = Query(env, model._table, model._table_sql)\n+            query = Query(model)\n             sql_id = SQL.identifier(model._table, 'id')\n             sql_field = model._field_to_sql(model._table, field.name, query)\n             if field.type == 'binary' and ("
+      },
+      {
+        "sha": "f3ad370d69cbd4d3d79b79d2449a1263d795e870",
+        "filename": "odoo/orm/models.py",
+        "status": "modified",
+        "additions": 5,
+        "deletions": 5,
+        "changes": 10,
+        "blob_url": "https://github.com/odoo/odoo/blob/2b12fdaa91fba6e6a27818e7ee4f028ef3fa6877/odoo%2Form%2Fmodels.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/2b12fdaa91fba6e6a27818e7ee4f028ef3fa6877/odoo%2Form%2Fmodels.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/odoo%2Form%2Fmodels.py?ref=2b12fdaa91fba6e6a27818e7ee4f028ef3fa6877",
+        "patch": "@@ -4694,7 +4694,7 @@ def _search(\n         domain = domain.optimize_full(self)\n         if domain.is_false():\n             return self.browse()._as_query()\n-        query = Query(self.env, self._table, self._table_sql)\n+        query = Query(self)\n         if not domain.is_true():\n             query.add_where(domain._to_sql(self, self._table, query))\n \n@@ -4724,7 +4724,7 @@ def _as_query(self, ordered: bool = True) -> Query:\n \n         :param ordered: whether the recordset order must be enforced by the query\n         \"\"\"\n-        query = Query(self.env, self._table, self._table_sql)\n+        query = Query(self)\n         query.set_result_ids(self._ids, ordered)\n         return query\n \n@@ -4877,7 +4877,7 @@ def exists(self) -> Self:\n         new_ids, ids = partition(lambda i: isinstance(i, NewId), self._ids)\n         if not ids:\n             return self\n-        query = Query(self.env, self._table, self._table_sql)\n+        query = Query(self)\n         query.add_where(SQL(\"%s IN %s\", SQL.identifier(self._table, 'id'), tuple(ids)))\n         real_ids = (id_ for [id_] in self.env.execute_query(query.select()))\n         valid_ids = {*real_ids, *new_ids}\n@@ -4899,7 +4899,7 @@ def lock_for_update(self, *, allow_referencing: bool = False) -> None:\n         ids = {id_ for id_ in self._ids if id_}\n         if not ids:\n             return\n-        query = Query(self.env, self._table, self._table_sql)\n+        query = Query(self)\n         query.add_where(SQL(\"%s IN %s\", SQL.identifier(self._table, 'id'), tuple(ids)))\n         # Use SKIP LOCKED instead of NOWAIT because the later aborts the\n         # transaction and we do not want to use SAVEPOINTS.\n@@ -4931,7 +4931,7 @@ def try_lock_for_update(self, *, allow_referencing: bool = False, limit: int | N\n             query = self.browse(ids)._as_query(ordered=True)\n             query.limit = limit - len(new_ids)\n         else:\n-            query = Query(self.env, self._table, self._table_sql)\n+            query = Query(self)\n             query.add_where(SQL(\"%s IN %s\", SQL.identifier(self._table, 'id'), tuple(ids)))\n         if not ids:\n             return self"
+      },
+      {
+        "sha": "158568461a2aff6dd358cb0a95c3bd5de7608e18",
+        "filename": "odoo/tools/query.py",
+        "status": "modified",
+        "additions": 12,
+        "deletions": 6,
+        "changes": 18,
+        "blob_url": "https://github.com/odoo/odoo/blob/2b12fdaa91fba6e6a27818e7ee4f028ef3fa6877/odoo%2Ftools%2Fquery.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/2b12fdaa91fba6e6a27818e7ee4f028ef3fa6877/odoo%2Ftools%2Fquery.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/odoo%2Ftools%2Fquery.py?ref=2b12fdaa91fba6e6a27818e7ee4f028ef3fa6877",
+        "patch": "@@ -1,6 +1,12 @@\n # Part of Odoo. See LICENSE file for full copyright and licensing details.\n+from __future__ import annotations\n+\n import itertools\n-from collections.abc import Iterable, Iterator\n+from typing import TYPE_CHECKING\n+\n+if TYPE_CHECKING:\n+    from collections.abc import Iterable, Iterator\n+    from odoo.orm.models import BaseModel\n \n from .sql import SQL, make_identifier\n \n@@ -53,12 +59,12 @@ class Query:\n     :param table: a table expression (``str`` or ``SQL`` object), optional\n     \"\"\"\n \n-    def __init__(self, env, alias: str, table: (SQL | None) = None):\n+    def __init__(self, model: BaseModel | None, alias: (str | None) = None, table: (SQL | None) = None):\n         # database cursor\n-        self._env = env\n+        self._model = model\n \n         self._tables: dict[str, SQL] = {\n-            alias: table if table is not None else SQL.identifier(alias),\n+            (alias or model._table): (table or model._table_sql),\n         }\n \n         # joins {alias: (kind(SQL), table(SQL), condition(SQL))}\n@@ -224,7 +230,7 @@ def get_result_ids(self) -> tuple[int, ...]:\n         is memoized for future use, which avoids making the same query twice.\n         \"\"\"\n         if self._ids is None:\n-            self._ids = tuple(id_ for id_, in self._env.execute_query(self.select()))\n+            self._ids = tuple(id_ for id_, in self._model.env.execute_query(self.select()))\n         return self._ids\n \n     def set_result_ids(self, ids: Iterable[int], ordered: bool = True) -> None:\n@@ -269,7 +275,7 @@ def __len__(self) -> int:\n                 sql = SQL(\"SELECT COUNT(*) FROM (%s) t\", self.select(\"\"))\n             else:\n                 sql = self.select('COUNT(*)')\n-            return self._env.execute_query(sql)[0][0]\n+            return self._model.env.execute_query(sql)[0][0]\n         return len(self.get_result_ids())\n \n     def __iter__(self) -> Iterator[int]:"
+      }
+    ],
+    "paths": [
+      "addons/website"
+    ]
+  },
+  {
+    "sha": "82b518e3747d202131534b08df07bbc101124883",
+    "node_id": "C_kwDOAS1I7NoAKDgyYjUxOGUzNzQ3ZDIwMjEzMTUzNGIwOGRmMDdiYmMxMDExMjQ4ODM",
+    "commit": {
+      "author": {
+        "name": "Nicolas Lempereur",
+        "email": "nle@odoo.com",
+        "date": "2025-10-06T17:11:10Z"
+      },
+      "committer": {
+        "name": "Nicolas Lempereur",
+        "email": "nle@odoo.com",
+        "date": "2025-10-13T15:27:10Z"
+      },
+      "message": "[FIX] website: translate deepest nodes\n\nScenario:\n\n- enable second language on website\n- go to /shop/1 and try to translate description_ecommerce\n\nResult: this is not translatable\n\nCause:\n\nSince at least b455ea85853dfc19ed01e33986ad270cf80ee5d6 the\ncontenteditable attribute in ContentEditablePlugin is not set on an\nelement if it has a contenteditable ancestor.\n\nTranslationPlugin disable all editable nodes containing editable nodes.\n\nSo with this combination, if we had a node for example:\n\n```\n<div class=\"oe_editable\" data-oe-model=\"product.template\" data-oe-id=\"1\"\n  data-oe-field=\"description_ecommerce\" data-oe-type=\"html\">\n    <div>\n        <span class=\"oe_editable\" data-oe-model=\"product.template\"\n            data-oe-id=\"1\" data-oe-field=\"description_ecommerce\">\n            test\n        </span>\n    </div>\n</div>\n```\n\nthe contenteditable was added to the parent div.oe_editable, but was\nremoved by TranslationPlugin so the \"test\" text was not translatable.\n\nFix: move the code that adds data-oe-readonly class in the\nafter_setup_editor_handlers so it is run before contenteditable\nattributes are set.\n\nopw-5128618\n\ncloses odoo/odoo#230896\n\nX-original-commit: d4f8aebea8cc7eba1517575302e072e0d5e2e406\nSigned-off-by: Colin Louis (loco) <loco@odoo.com>\nSigned-off-by: Nicolas Lempereur (nle) <nle@odoo.com>",
+      "tree": {
+        "sha": "f7aaf40166cfa8082243948ed78d4ef1f90a4af0",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/f7aaf40166cfa8082243948ed78d4ef1f90a4af0"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/82b518e3747d202131534b08df07bbc101124883",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/82b518e3747d202131534b08df07bbc101124883",
+    "html_url": "https://github.com/odoo/odoo/commit/82b518e3747d202131534b08df07bbc101124883",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/82b518e3747d202131534b08df07bbc101124883/comments",
+    "author": {
+      "login": "nle-odoo",
+      "id": 9977887,
+      "node_id": "MDQ6VXNlcjk5Nzc4ODc=",
+      "avatar_url": "https://avatars.githubusercontent.com/u/9977887?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/nle-odoo",
+      "html_url": "https://github.com/nle-odoo",
+      "followers_url": "https://api.github.com/users/nle-odoo/followers",
+      "following_url": "https://api.github.com/users/nle-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/nle-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/nle-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/nle-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/nle-odoo/orgs",
+      "repos_url": "https://api.github.com/users/nle-odoo/repos",
+      "events_url": "https://api.github.com/users/nle-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/nle-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "nle-odoo",
+      "id": 9977887,
+      "node_id": "MDQ6VXNlcjk5Nzc4ODc=",
+      "avatar_url": "https://avatars.githubusercontent.com/u/9977887?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/nle-odoo",
+      "html_url": "https://github.com/nle-odoo",
+      "followers_url": "https://api.github.com/users/nle-odoo/followers",
+      "following_url": "https://api.github.com/users/nle-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/nle-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/nle-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/nle-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/nle-odoo/orgs",
+      "repos_url": "https://api.github.com/users/nle-odoo/repos",
+      "events_url": "https://api.github.com/users/nle-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/nle-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "a35f834df59b75adaa7d845bc89bc3a1946fc2b7",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/a35f834df59b75adaa7d845bc89bc3a1946fc2b7",
+        "html_url": "https://github.com/odoo/odoo/commit/a35f834df59b75adaa7d845bc89bc3a1946fc2b7"
+      }
+    ],
+    "stats": {
+      "total": 33,
+      "additions": 21,
+      "deletions": 12
+    },
+    "files": [
+      {
+        "sha": "97bd0ec019ea5834fa8fe6b810c02bce2bd71078",
+        "filename": "addons/website/static/src/builder/plugins/translation_plugin.js",
+        "status": "modified",
+        "additions": 11,
+        "deletions": 12,
+        "changes": 23,
+        "blob_url": "https://github.com/odoo/odoo/blob/82b518e3747d202131534b08df07bbc101124883/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fplugins%2Ftranslation_plugin.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/82b518e3747d202131534b08df07bbc101124883/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fplugins%2Ftranslation_plugin.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fplugins%2Ftranslation_plugin.js?ref=82b518e3747d202131534b08df07bbc101124883",
+        "patch": "@@ -60,6 +60,17 @@ export class TranslationPlugin extends Plugin {\n             for (const translationSavableEl of translationSavableEls) {\n                 translationSavableEl.classList.add(\"o_editable_attribute\");\n             }\n+            // Apply data-oe-readonly on wrapping editor\n+            const editableElSelector = \".o_editable, .o_editable_attribute\";\n+            const editableEls = [\n+                ...translationSavableEls,\n+                ...this.services.website.pageDocument.querySelectorAll(\".o_editable\"),\n+            ];\n+            for (const editableEl of editableEls) {\n+                if (editableEl.querySelectorAll(editableElSelector).length) {\n+                    editableEl.setAttribute(\"data-oe-readonly\", \"true\");\n+                }\n+            }\n             return true;\n         },\n         start_edition_handlers: withSequence(5, () => {\n@@ -103,18 +114,6 @@ export class TranslationPlugin extends Plugin {\n             this.dialogService.add(TranslatorInfoDialog);\n         }\n \n-        // Apply data-oe-readonly on nested data\n-        const translatableElSelector = \".o_editable, .o_editable_attribute\";\n-        const translationSavableEls = [\n-            ...this.websiteService.pageDocument.querySelectorAll(translatableElSelector),\n-        ];\n-        for (const translationSavableEl of translationSavableEls) {\n-            if (translationSavableEl.querySelectorAll(translatableElSelector).length) {\n-                translationSavableEl.setAttribute(\"data-oe-readonly\", \"true\");\n-                translationSavableEl.removeAttribute(\"contenteditable\");\n-            }\n-        }\n-\n         const showNotification = (ev) => {\n             // Prevent duplicate notifications for the same click but allow the\n             // event to bubble (i.e. for carousel sliding)"
+      },
+      {
+        "sha": "4f977595c341a9a1d86b4037bd02d93eb41f1287",
+        "filename": "addons/website/static/tests/builder/translation.test.js",
+        "status": "modified",
+        "additions": 10,
+        "deletions": 0,
+        "changes": 10,
+        "blob_url": "https://github.com/odoo/odoo/blob/82b518e3747d202131534b08df07bbc101124883/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Ftranslation.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/82b518e3747d202131534b08df07bbc101124883/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Ftranslation.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Ftranslation.test.js?ref=82b518e3747d202131534b08df07bbc101124883",
+        "patch": "@@ -117,6 +117,16 @@ test(\"add text in translate mode do not split\", async () => {\n     expect(\":iframe .s_allow_columns p\").toHaveCount(1);\n });\n \n+test(\"only have translation editors on deepest nodes\", async () => {\n+    await setupSidebarBuilderForTranslation({\n+        websiteContent: getTranslateEditable({\n+            inWrap: getTranslateEditable({ inWrap: \"Hello\" }).match(/<span.*<\\/span>/)[0],\n+        }),\n+    });\n+    expect(\":iframe .o_editable:has(.o_editable)\").not.toHaveAttribute(\"contenteditable\");\n+    expect(\":iframe .o_editable .o_editable\").toHaveAttribute(\"contenteditable\", \"true\");\n+});\n+\n test(\"404 page in translate mode\", async () => {\n     patchWithCleanup(EditWebsiteSystrayItem.prototype, {\n         setup() {"
+      }
+    ],
+    "paths": [
+      "addons/website"
+    ]
+  },
+  {
+    "sha": "a35f834df59b75adaa7d845bc89bc3a1946fc2b7",
+    "node_id": "C_kwDOAS1I7NoAKGEzNWY4MzRkZjU5Yjc1YWRhYTdkODQ1YmM4OWJjM2ExOTQ2ZmMyYjc",
+    "commit": {
+      "author": {
+        "name": "Garvish Panchal",
+        "email": "gppa@odoo.com",
+        "date": "2025-08-01T10:18:21Z"
+      },
+      "committer": {
+        "name": "Garvish Panchal",
+        "email": "gppa@odoo.com",
+        "date": "2025-10-13T15:27:08Z"
+      },
+      "message": "[FIX] website: prevent ecommerce installation with events page\n\nSteps to reproduce:\n1. Install website module\n2. Select events in configurator\n3. Build website.\n\n=> Ecommerce is installed, which should not as it does not make sense\n   with only the events.\n\nAfter this commit:\n- Ecommerce will no longer be installed when the events is configured.\n\ntask-4922600\n\ncloses odoo/odoo#231174\n\nX-original-commit: 80422454fc9cb6045c6a4b50e7f0ce7b3a411c59\nSigned-off-by: Benoit Socias (bso) <bso@odoo.com>\nSigned-off-by: Garvish Pramodbhai Panchal (gppa) <gppa@odoo.com>",
+      "tree": {
+        "sha": "887e556e8304e9c5b7611f5c25362ed8ff52cbdc",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/887e556e8304e9c5b7611f5c25362ed8ff52cbdc"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/a35f834df59b75adaa7d845bc89bc3a1946fc2b7",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/a35f834df59b75adaa7d845bc89bc3a1946fc2b7",
+    "html_url": "https://github.com/odoo/odoo/commit/a35f834df59b75adaa7d845bc89bc3a1946fc2b7",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/a35f834df59b75adaa7d845bc89bc3a1946fc2b7/comments",
+    "author": {
+      "login": "gppa-odoo",
+      "id": 195764804,
+      "node_id": "U_kgDOC6siRA",
+      "avatar_url": "https://avatars.githubusercontent.com/u/195764804?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/gppa-odoo",
+      "html_url": "https://github.com/gppa-odoo",
+      "followers_url": "https://api.github.com/users/gppa-odoo/followers",
+      "following_url": "https://api.github.com/users/gppa-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/gppa-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/gppa-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/gppa-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/gppa-odoo/orgs",
+      "repos_url": "https://api.github.com/users/gppa-odoo/repos",
+      "events_url": "https://api.github.com/users/gppa-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/gppa-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "gppa-odoo",
+      "id": 195764804,
+      "node_id": "U_kgDOC6siRA",
+      "avatar_url": "https://avatars.githubusercontent.com/u/195764804?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/gppa-odoo",
+      "html_url": "https://github.com/gppa-odoo",
+      "followers_url": "https://api.github.com/users/gppa-odoo/followers",
+      "following_url": "https://api.github.com/users/gppa-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/gppa-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/gppa-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/gppa-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/gppa-odoo/orgs",
+      "repos_url": "https://api.github.com/users/gppa-odoo/repos",
+      "events_url": "https://api.github.com/users/gppa-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/gppa-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "e973a7fdf939c2ab3ba7c62f1129201948c020bf",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/e973a7fdf939c2ab3ba7c62f1129201948c020bf",
+        "html_url": "https://github.com/odoo/odoo/commit/e973a7fdf939c2ab3ba7c62f1129201948c020bf"
+      }
+    ],
+    "stats": {
+      "total": 2,
+      "additions": 1,
+      "deletions": 1
+    },
+    "files": [
+      {
+        "sha": "db46dbb1886af3bdd2dcac2c8230c3d084d00b25",
+        "filename": "addons/website/data/website_data.xml",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/a35f834df59b75adaa7d845bc89bc3a1946fc2b7/addons%2Fwebsite%2Fdata%2Fwebsite_data.xml",
+        "raw_url": "https://github.com/odoo/odoo/raw/a35f834df59b75adaa7d845bc89bc3a1946fc2b7/addons%2Fwebsite%2Fdata%2Fwebsite_data.xml",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fdata%2Fwebsite_data.xml?ref=a35f834df59b75adaa7d845bc89bc3a1946fc2b7",
+        "patch": "@@ -436,7 +436,7 @@\n         <field name=\"description\">Publish on-site and online events</field>\n         <field name=\"sequence\">10</field>\n         <field name=\"website_config_preselection\">event</field>\n-        <field name=\"module_id\" ref=\"base.module_website_event_sale\"/>\n+        <field name=\"module_id\" ref=\"base.module_website_event\"/>\n         <field name=\"icon\">fa-ticket</field>\n         <field name=\"menu_sequence\">20</field>\n         <field name=\"feature_url\">/event</field>"
+      }
+    ],
+    "paths": [
+      "addons/website"
+    ]
+  },
+  {
+    "sha": "fe1c0e1b3b588d765f2cc570fd8e57e15a326799",
+    "node_id": "C_kwDOAS1I7NoAKGZlMWMwZTFiM2I1ODhkNzY1ZjJjYzU3MGZkOGU1N2UxNWEzMjY3OTk",
+    "commit": {
+      "author": {
+        "name": "qsm-odoo",
+        "email": "qsm@odoo.com",
+        "date": "2025-09-25T14:31:34Z"
+      },
+      "committer": {
+        "name": "David Monjoie",
+        "email": "dmo@odoo.com",
+        "date": "2025-10-13T13:13:16Z"
+      },
+      "message": "[IMP] html_editor,website: review media and void utilities\n\nThe editor utilities contain 3 functions:\n- isMediaElement\n- isArtificialVoidElement\n- isNotAllowedContent\n\nTheir notion was kinda blurry/strange especially in the way they were\nused: this commit tries to fix that. This is done in master as nothing\ncritical should be buggy because of this in stable (and it would be more\n\"risky\" trying to change it for no apparent critical bug). It could be\nbackported (even partially) if the need arises.\n\n- `isMediaElement` did not include images which is strange and actually\n  forced developers to often do `isMediaElement or image`. On the other\n  hand, the use cases where images were not considered were \"naturally\"\n  working but it does not hurt for images to be checked there too (it\n  could actually improve a few cases).\n\n- `isArtificialVoidElement` was used for finding nodes that should\nreceive the `contenteditable=\"false\"` attribute automatically, but\nmarking `<hr>` nodes with `contenteditable=\"false\"` seems useless (if\nnot, why not do that for all `isNotAllowedContent` nodes, which `<hr>`\nnodes are)\n  => DMO: I have removed the function which was no longer useful since\n          the only difference with `isMediaElement` was including the\n          `<hr>` node but you're right that it was useless\n\n- `isNotAllowedContent`: still includes the nodes which are media\n  elements in addition to the real browser void elements (like HR).\n\nOriginal PR on web_editor with more details since some of them were\nnot relevant to html_editor anymore: https://github.com/odoo/odoo/pull/131357\n\nRelated to task-3226172\n\nPart-of: odoo/odoo#228728\nSigned-off-by: David Monjoie (dmo) <dmo@odoo.com>\nCo-authored-by: David Monjoie <dmo@odoo.com>",
+      "tree": {
+        "sha": "f39063c05441c4efdbd8e86d3fe73a9f02f69288",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/f39063c05441c4efdbd8e86d3fe73a9f02f69288"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/fe1c0e1b3b588d765f2cc570fd8e57e15a326799",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/fe1c0e1b3b588d765f2cc570fd8e57e15a326799",
+    "html_url": "https://github.com/odoo/odoo/commit/fe1c0e1b3b588d765f2cc570fd8e57e15a326799",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/fe1c0e1b3b588d765f2cc570fd8e57e15a326799/comments",
+    "author": {
+      "login": "qsm-odoo",
+      "id": 10338094,
+      "node_id": "MDQ6VXNlcjEwMzM4MDk0",
+      "avatar_url": "https://avatars.githubusercontent.com/u/10338094?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/qsm-odoo",
+      "html_url": "https://github.com/qsm-odoo",
+      "followers_url": "https://api.github.com/users/qsm-odoo/followers",
+      "following_url": "https://api.github.com/users/qsm-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/qsm-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/qsm-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/qsm-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/qsm-odoo/orgs",
+      "repos_url": "https://api.github.com/users/qsm-odoo/repos",
+      "events_url": "https://api.github.com/users/qsm-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/qsm-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "dmo-odoo",
+      "id": 8427726,
+      "node_id": "MDQ6VXNlcjg0Mjc3MjY=",
+      "avatar_url": "https://avatars.githubusercontent.com/u/8427726?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/dmo-odoo",
+      "html_url": "https://github.com/dmo-odoo",
+      "followers_url": "https://api.github.com/users/dmo-odoo/followers",
+      "following_url": "https://api.github.com/users/dmo-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/dmo-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/dmo-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/dmo-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/dmo-odoo/orgs",
+      "repos_url": "https://api.github.com/users/dmo-odoo/repos",
+      "events_url": "https://api.github.com/users/dmo-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/dmo-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "f0720c80f71a70bb90df6583527bb1f3f3b79a12",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/f0720c80f71a70bb90df6583527bb1f3f3b79a12",
+        "html_url": "https://github.com/odoo/odoo/commit/f0720c80f71a70bb90df6583527bb1f3f3b79a12"
+      }
+    ],
+    "stats": {
+      "total": 21,
+      "additions": 6,
+      "deletions": 15
+    },
+    "files": [
+      {
+        "sha": "ca56ea7bc3660aef01fcd2e3dcfb4486700c32ee",
+        "filename": "addons/html_editor/static/src/core/content_editable_plugin.js",
+        "status": "modified",
+        "additions": 2,
+        "deletions": 5,
+        "changes": 7,
+        "blob_url": "https://github.com/odoo/odoo/blob/fe1c0e1b3b588d765f2cc570fd8e57e15a326799/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fcore%2Fcontent_editable_plugin.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/fe1c0e1b3b588d765f2cc570fd8e57e15a326799/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fcore%2Fcontent_editable_plugin.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fcore%2Fcontent_editable_plugin.js?ref=fe1c0e1b3b588d765f2cc570fd8e57e15a326799",
+        "patch": "@@ -1,5 +1,5 @@\n-import { isArtificialVoidElement } from \"@html_editor/core/selection_plugin\";\n import { Plugin } from \"@html_editor/plugin\";\n+import { isMediaElement } from \"@html_editor/utils/dom_info\";\n import { selectElements } from \"@html_editor/utils/dom_traversal\";\n import { withSequence } from \"@html_editor/utils/resource\";\n \n@@ -40,10 +40,7 @@ export class ContentEditablePlugin extends Plugin {\n             ...extraContentEditableEls,\n         ]) {\n             if (!contentEditableEl.isContentEditable) {\n-                if (\n-                    isArtificialVoidElement(contentEditableEl) ||\n-                    contentEditableEl.nodeName === \"IMG\"\n-                ) {\n+                if (isMediaElement(contentEditableEl)) {\n                     contentEditableEl.classList.add(\"o_editable_media\");\n                     continue;\n                 }"
+      },
+      {
+        "sha": "d4f27f47e7bc436bc0bcd3803ae540a66c47b7e6",
+        "filename": "addons/html_editor/static/src/core/selection_plugin.js",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 5,
+        "changes": 6,
+        "blob_url": "https://github.com/odoo/odoo/blob/fe1c0e1b3b588d765f2cc570fd8e57e15a326799/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fcore%2Fselection_plugin.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/fe1c0e1b3b588d765f2cc570fd8e57e15a326799/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fcore%2Fselection_plugin.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fcore%2Fselection_plugin.js?ref=fe1c0e1b3b588d765f2cc570fd8e57e15a326799",
+        "patch": "@@ -87,12 +87,8 @@ const VOID_ELEMENT_NAMES = [\n     \"WBR\",\n ];\n \n-export function isArtificialVoidElement(node) {\n-    return isMediaElement(node) || node.nodeName === \"HR\";\n-}\n-\n export function isNotAllowedContent(node) {\n-    return isArtificialVoidElement(node) || VOID_ELEMENT_NAMES.includes(node.nodeName);\n+    return isMediaElement(node) || VOID_ELEMENT_NAMES.includes(node.nodeName);\n }\n \n export const isHtmlContentSupported = weakMemoize("
+      },
+      {
+        "sha": "8fd5baff042fc7220ae1cd603bf52782872cbea0",
+        "filename": "addons/html_editor/static/src/main/media/media_plugin.js",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 4,
+        "changes": 5,
+        "blob_url": "https://github.com/odoo/odoo/blob/fe1c0e1b3b588d765f2cc570fd8e57e15a326799/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fmain%2Fmedia%2Fmedia_plugin.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/fe1c0e1b3b588d765f2cc570fd8e57e15a326799/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fmain%2Fmedia%2Fmedia_plugin.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fmain%2Fmedia%2Fmedia_plugin.js?ref=fe1c0e1b3b588d765f2cc570fd8e57e15a326799",
+        "patch": "@@ -110,10 +110,7 @@ export class MediaPlugin extends Plugin {\n     }\n \n     isEditableMediaElement(node) {\n-        return (\n-            (isMediaElement(node) || node.nodeName === \"IMG\") &&\n-            node.classList.contains(EDITABLE_MEDIA_CLASS)\n-        );\n+        return isMediaElement(node) && node.classList.contains(EDITABLE_MEDIA_CLASS);\n     }\n \n     replaceImage() {"
+      },
+      {
+        "sha": "acb8794bf922878a0ea17014aac8f641ad5bea44",
+        "filename": "addons/html_editor/static/src/utils/dom_info.js",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 0,
+        "changes": 1,
+        "blob_url": "https://github.com/odoo/odoo/blob/fe1c0e1b3b588d765f2cc570fd8e57e15a326799/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Futils%2Fdom_info.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/fe1c0e1b3b588d765f2cc570fd8e57e15a326799/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Futils%2Fdom_info.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Futils%2Fdom_info.js?ref=fe1c0e1b3b588d765f2cc570fd8e57e15a326799",
+        "patch": "@@ -342,6 +342,7 @@ export function isIconElement(node) {\n // @todo @phoenix: move the specific part in a proper plugin.\n export function isMediaElement(node) {\n     return (\n+        node.nodeName === \"IMG\" ||\n         isIconElement(node) ||\n         (node.classList &&\n             (node.classList.contains(\"o_image\") ||"
+      },
+      {
+        "sha": "962c05552ae07bb3539758d74be525bc1ae81bdc",
+        "filename": "addons/website/static/src/builder/plugins/company_team_plugin.js",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/fe1c0e1b3b588d765f2cc570fd8e57e15a326799/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fplugins%2Fcompany_team_plugin.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/fe1c0e1b3b588d765f2cc570fd8e57e15a326799/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fplugins%2Fcompany_team_plugin.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fplugins%2Fcompany_team_plugin.js?ref=fe1c0e1b3b588d765f2cc570fd8e57e15a326799",
+        "patch": "@@ -15,7 +15,7 @@ class CompanyTeamPlugin extends Plugin {\n                 ...filteredContentEditableEl.querySelectorAll(\".s_company_team .o_not_editable *\"),\n             ]\n         );\n-        return extraContentEditableEls.filter((el) => isMediaElement(el) || el.tagName === \"IMG\");\n+        return extraContentEditableEls.filter((el) => isMediaElement(el));\n     }\n }\n "
+      }
+    ],
+    "paths": [
+      "addons/website"
+    ]
+  },
+  {
+    "sha": "f56528cecfa81cc5e3b239b7fbe2c9ea5fe13ca6",
+    "node_id": "C_kwDOAS1I7NoAKGY1NjUyOGNlY2ZhODFjYzVlM2IyMzliN2ZiZTJjOWVhNWZlMTNjYTY",
+    "commit": {
+      "author": {
+        "name": "sben-odoo",
+        "email": "sben@odoo.com",
+        "date": "2025-09-29T09:30:41Z"
+      },
+      "committer": {
+        "name": "sben-odoo",
+        "email": "sben@odoo.com",
+        "date": "2025-10-11T16:40:43Z"
+      },
+      "message": "[FIX] website: ensure video container fills available width\n\nTo reproduce:\n=============\n1- In Website edit mode, drop the \"Masonry\" snippet.\n2- Add a video in one of the text blocks.\n-> It will appear smaller than expected, with no way to make it larger\n\nWhy:\n====\nThe child iframe already had `width: 100%`,\nbut it can only stretch to 100% of its parent container.\nIf the parent container `(.media_iframe_video)` doesn't have an explicit\n`width`, it defaults to its minimum content size.\nThis issue happens specifically in blocks where the columns are\n`display: flex`. As a result, the iframe ends up being too narrow\ndespite having `width: 100%`.\n\nSolution:\n=========\nBy adding `width: 100%` to the container itself,\nit now fills the grid cell, and the iframe inside fills the container.\n\nopw-5104640\n\ncloses odoo/odoo#231054\n\nX-original-commit: 2289cd9d1c319caee7edfa0d406d7187c43a06d2\nSigned-off-by: Souk\u00e9ina Bojabza (sobo) <sobo@odoo.com>\nSigned-off-by: Saif Allah Ben Khalil (sben) <sben@odoo.com>",
+      "tree": {
+        "sha": "0ac85ded0a6a8c1ab371fd3bc6dc4a20e193f123",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/0ac85ded0a6a8c1ab371fd3bc6dc4a20e193f123"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/f56528cecfa81cc5e3b239b7fbe2c9ea5fe13ca6",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/f56528cecfa81cc5e3b239b7fbe2c9ea5fe13ca6",
+    "html_url": "https://github.com/odoo/odoo/commit/f56528cecfa81cc5e3b239b7fbe2c9ea5fe13ca6",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/f56528cecfa81cc5e3b239b7fbe2c9ea5fe13ca6/comments",
+    "author": {
+      "login": "sben-odoo",
+      "id": 208037942,
+      "node_id": "U_kgDODGZoNg",
+      "avatar_url": "https://avatars.githubusercontent.com/u/208037942?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/sben-odoo",
+      "html_url": "https://github.com/sben-odoo",
+      "followers_url": "https://api.github.com/users/sben-odoo/followers",
+      "following_url": "https://api.github.com/users/sben-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/sben-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/sben-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/sben-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/sben-odoo/orgs",
+      "repos_url": "https://api.github.com/users/sben-odoo/repos",
+      "events_url": "https://api.github.com/users/sben-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/sben-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "sben-odoo",
+      "id": 208037942,
+      "node_id": "U_kgDODGZoNg",
+      "avatar_url": "https://avatars.githubusercontent.com/u/208037942?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/sben-odoo",
+      "html_url": "https://github.com/sben-odoo",
+      "followers_url": "https://api.github.com/users/sben-odoo/followers",
+      "following_url": "https://api.github.com/users/sben-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/sben-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/sben-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/sben-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/sben-odoo/orgs",
+      "repos_url": "https://api.github.com/users/sben-odoo/repos",
+      "events_url": "https://api.github.com/users/sben-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/sben-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "d9befeff3d53f2d7cc541004a7d3591b1c9190c6",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/d9befeff3d53f2d7cc541004a7d3591b1c9190c6",
+        "html_url": "https://github.com/odoo/odoo/commit/d9befeff3d53f2d7cc541004a7d3591b1c9190c6"
+      }
+    ],
+    "stats": {
+      "total": 4,
+      "additions": 4,
+      "deletions": 0
+    },
+    "files": [
+      {
+        "sha": "d7dc981f35a6b17176b47a356d0e46f81de0d907",
+        "filename": "addons/website/static/src/scss/website.scss",
+        "status": "modified",
+        "additions": 4,
+        "deletions": 0,
+        "changes": 4,
+        "blob_url": "https://github.com/odoo/odoo/blob/f56528cecfa81cc5e3b239b7fbe2c9ea5fe13ca6/addons%2Fwebsite%2Fstatic%2Fsrc%2Fscss%2Fwebsite.scss",
+        "raw_url": "https://github.com/odoo/odoo/raw/f56528cecfa81cc5e3b239b7fbe2c9ea5fe13ca6/addons%2Fwebsite%2Fstatic%2Fsrc%2Fscss%2Fwebsite.scss",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fscss%2Fwebsite.scss?ref=f56528cecfa81cc5e3b239b7fbe2c9ea5fe13ca6",
+        "patch": "@@ -3187,4 +3187,8 @@ input[value*=\"data-oe-translation-source-sha\"] {\n     display: flex;\n     flex-direction: column;\n     justify-content: center;\n+\n+    div.media_iframe_video {\n+      width: 100%;\n+    }\n }"
+      }
+    ],
+    "paths": [
+      "addons/website"
+    ]
+  },
+  {
+    "sha": "7450ed30ddb54b74993885d4d9b98a26f9e2a85b",
+    "node_id": "C_kwDOAS1I7NoAKDc0NTBlZDMwZGRiNTRiNzQ5OTM4ODVkNGQ5Yjk4YTI2ZjllMmE4NWI",
+    "commit": {
+      "author": {
+        "name": "S\u00e9bastien (blse)",
+        "email": "blse@odoo.com",
+        "date": "2025-09-11T08:59:43Z"
+      },
+      "committer": {
+        "name": "S\u00e9bastien (blse)",
+        "email": "blse@odoo.com",
+        "date": "2025-10-11T09:21:44Z"
+      },
+      "message": "[IMP] website: replace helper `waitDomUpdate` with `waitSidebarUpdated`\n\nThe helper `waitDomUpdated` only waited for the components that use\n`useDomState` to be patched. It did not waited for the components that\nuse `useDomState` to be mounted, and also did not waited on the async\noperations to be completed.\n\nThe new helper `waitSidebarUpdated` waits for all of that. And it is\nused to replace all usage of `waitDomUpdated`, and `waitFor` that wait\nfor an element of the sidebar to appear.\n\ntask-4367641\n\ncloses odoo/odoo#231090\n\nSigned-off-by: Francois Georis (fge) <fge@odoo.com>\nSigned-off-by: S\u00e9bastien Blondiau (blse) <blse@odoo.com>",
+      "tree": {
+        "sha": "f0a9a710d378d0f9dc1b0672f51bb55aab70004f",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/f0a9a710d378d0f9dc1b0672f51bb55aab70004f"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/7450ed30ddb54b74993885d4d9b98a26f9e2a85b",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/7450ed30ddb54b74993885d4d9b98a26f9e2a85b",
+    "html_url": "https://github.com/odoo/odoo/commit/7450ed30ddb54b74993885d4d9b98a26f9e2a85b",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/7450ed30ddb54b74993885d4d9b98a26f9e2a85b/comments",
+    "author": {
+      "login": "blse-odoo",
+      "id": 199113637,
+      "node_id": "U_kgDOC947pQ",
+      "avatar_url": "https://avatars.githubusercontent.com/u/199113637?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/blse-odoo",
+      "html_url": "https://github.com/blse-odoo",
+      "followers_url": "https://api.github.com/users/blse-odoo/followers",
+      "following_url": "https://api.github.com/users/blse-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/blse-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/blse-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/blse-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/blse-odoo/orgs",
+      "repos_url": "https://api.github.com/users/blse-odoo/repos",
+      "events_url": "https://api.github.com/users/blse-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/blse-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "blse-odoo",
+      "id": 199113637,
+      "node_id": "U_kgDOC947pQ",
+      "avatar_url": "https://avatars.githubusercontent.com/u/199113637?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/blse-odoo",
+      "html_url": "https://github.com/blse-odoo",
+      "followers_url": "https://api.github.com/users/blse-odoo/followers",
+      "following_url": "https://api.github.com/users/blse-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/blse-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/blse-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/blse-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/blse-odoo/orgs",
+      "repos_url": "https://api.github.com/users/blse-odoo/repos",
+      "events_url": "https://api.github.com/users/blse-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/blse-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "7dab639bdb1e1168c3c3be0c23e660049d04194f",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/7dab639bdb1e1168c3c3be0c23e660049d04194f",
+        "html_url": "https://github.com/odoo/odoo/commit/7dab639bdb1e1168c3c3be0c23e660049d04194f"
+      }
+    ],
+    "stats": {
+      "total": 292,
+      "additions": 204,
+      "deletions": 88
+    },
+    "files": [
+      {
+        "sha": "e42721def000fba73733cc6a958d3c737ad1cff8",
+        "filename": "addons/html_builder/static/tests/contenteditable.test.js",
+        "status": "modified",
+        "additions": 2,
+        "deletions": 2,
+        "changes": 4,
+        "blob_url": "https://github.com/odoo/odoo/blob/7450ed30ddb54b74993885d4d9b98a26f9e2a85b/addons%2Fhtml_builder%2Fstatic%2Ftests%2Fcontenteditable.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/7450ed30ddb54b74993885d4d9b98a26f9e2a85b/addons%2Fhtml_builder%2Fstatic%2Ftests%2Fcontenteditable.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_builder%2Fstatic%2Ftests%2Fcontenteditable.test.js?ref=7450ed30ddb54b74993885d4d9b98a26f9e2a85b",
+        "patch": "@@ -64,15 +64,15 @@ test(\"clone of editable media inside not editable area should be editable\", asyn\n         selector: \"img\",\n         template: xml`<BuilderButton classAction=\"'test'\">Test Image</BuilderButton>`,\n     });\n-    const { waitDomUpdated } = await setupHTMLBuilder(`\n+    const { waitSidebarUpdated } = await setupHTMLBuilder(`\n         <section>\n             <div class=\"o_not_editable\">\n                 <img class=\"o_editable_media\" src=\"${dummyBase64Img}\"/>\n             </div>\n         </section>\n     `);\n     await contains(\":iframe img\").click();\n-    await waitDomUpdated();\n+    await waitSidebarUpdated();\n     expect(\".options-container[data-container-title='Image']\").toBeDisplayed();\n     await contains(\".oe_snippet_clone\").click();\n     await contains(\":iframe section:last-of-type img\").click();"
+      },
+      {
+        "sha": "ba35031eb37338d6d1cb4b26558a91236b0313eb",
+        "filename": "addons/html_builder/static/tests/helpers.js",
+        "status": "modified",
+        "additions": 6,
+        "deletions": 3,
+        "changes": 9,
+        "blob_url": "https://github.com/odoo/odoo/blob/7450ed30ddb54b74993885d4d9b98a26f9e2a85b/addons%2Fhtml_builder%2Fstatic%2Ftests%2Fhelpers.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/7450ed30ddb54b74993885d4d9b98a26f9e2a85b/addons%2Fhtml_builder%2Fstatic%2Ftests%2Fhelpers.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_builder%2Fstatic%2Ftests%2Fhelpers.js?ref=7450ed30ddb54b74993885d4d9b98a26f9e2a85b",
+        "patch": "@@ -18,6 +18,7 @@ import {\n     models,\n     mountWithCleanup,\n     patchWithCleanup,\n+    waitUntilIdle,\n } from \"@web/../tests/web_test_helpers\";\n import { loadBundle } from \"@web/core/assets\";\n import { isBrowserFirefox } from \"@web/core/browser/feature_detection\";\n@@ -181,7 +182,7 @@ class IrUiView extends models.Model {\n  * getEditableContent: () => HTMLElement,\n  * contentEl: HTMLElement,\n  * builderEl: HTMLElement,\n- * waitDomUpdated: () => Promise<void>\n+ * waitSidebarUpdated: () => Promise<void>\n  * }>}\n }}\n  */\n@@ -246,11 +247,13 @@ export async function setupHTMLBuilder(\n     Plugins.push(...BuilderPlugins);\n \n     let lastUpdatePromise;\n-    const waitDomUpdated = async () => {\n+    const waitSidebarUpdated = async () => {\n+        await attachedEditor.shared.operation.next();\n         // The tick ensures that lastUpdatePromise has correctly been assigned\n         await tick();\n         await lastUpdatePromise;\n         await animationFrame();\n+        await waitUntilIdle([comp.__owl__.app]);\n     };\n     patchWithCleanup(Builder.prototype, {\n         setup() {\n@@ -310,7 +313,7 @@ export async function setupHTMLBuilder(\n         getEditableContent: () => editableContent,\n         contentEl: comp.iframeRef.el.contentDocument.body.firstChild.firstChild,\n         builderEl: comp.env.builderRef.el.querySelector(\".o-website-builder_sidebar\"),\n-        waitDomUpdated,\n+        waitSidebarUpdated,\n     };\n }\n "
+      },
+      {
+        "sha": "8693b1239320346fb2a98bf61d98a43bf8be1927",
+        "filename": "addons/html_builder/static/tests/utils.test.js",
+        "status": "modified",
+        "additions": 102,
+        "deletions": 2,
+        "changes": 104,
+        "blob_url": "https://github.com/odoo/odoo/blob/7450ed30ddb54b74993885d4d9b98a26f9e2a85b/addons%2Fhtml_builder%2Fstatic%2Ftests%2Futils.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/7450ed30ddb54b74993885d4d9b98a26f9e2a85b/addons%2Fhtml_builder%2Fstatic%2Ftests%2Futils.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_builder%2Fstatic%2Ftests%2Futils.test.js?ref=7450ed30ddb54b74993885d4d9b98a26f9e2a85b",
+        "patch": "@@ -1,7 +1,12 @@\n-import { addBuilderOption, setupHTMLBuilder } from \"@html_builder/../tests/helpers\";\n+import {\n+    addBuilderAction,\n+    addBuilderOption,\n+    setupHTMLBuilder,\n+} from \"@html_builder/../tests/helpers\";\n+import { BuilderAction } from \"@html_builder/core/builder_action\";\n import { BaseOptionComponent, useDomState } from \"@html_builder/core/utils\";\n import { describe, expect, test } from \"@odoo/hoot\";\n-import { animationFrame } from \"@odoo/hoot-dom\";\n+import { animationFrame, Deferred, delay } from \"@odoo/hoot-dom\";\n import { xml } from \"@odoo/owl\";\n import { contains } from \"@web/../tests/web_test_helpers\";\n \n@@ -53,3 +58,98 @@ describe(\"useDomState\", () => {\n         expect.verifySteps([\"state: x\", \"state: z\"]);\n     });\n });\n+\n+describe(\"waitSidebarUpdated\", () => {\n+    test(\"wait for the operations to end, the async useDomState to be updated, and the new component with async useDomState to be mounted\", async () => {\n+        const delayAmount = 42;\n+        let deferred;\n+        addBuilderAction({\n+            testAction: class extends BuilderAction {\n+                static id = \"testAction\";\n+                isApplied({ editingElement, value }) {\n+                    return editingElement.dataset.value == value;\n+                }\n+                async apply({ editingElement, value }) {\n+                    await delay(delayAmount);\n+                    await deferred;\n+                    editingElement.dataset.value = value;\n+                }\n+            },\n+        });\n+        class TestSubComponent extends BaseOptionComponent {\n+            static template = xml`\n+                <div class=\"test-value-sub\">\n+                    <t t-out=\"state.value\"/>\n+                </div>\n+            `;\n+            setup() {\n+                super.setup();\n+                this.state = useDomState(async (el) => {\n+                    await delay(delayAmount);\n+                    await deferred;\n+                    return { value: el.dataset.value };\n+                });\n+            }\n+        }\n+        class TestOptionComponent extends BaseOptionComponent {\n+            static template = xml`\n+                <div class=\"test-value-parent\">\n+                    <t t-out=\"state.value\"/>\n+                </div>\n+                <div class=\"test-button-1\">\n+                    <BuilderButton action=\"'testAction'\" actionValue=\"'b'\">b</BuilderButton>\n+                </div>\n+                <div class=\"test-button-2\">\n+                    <BuilderButton id=\"'button_2_opt'\" action=\"'testAction'\" actionValue=\"'c'\">c</BuilderButton>\n+                </div>\n+                <t t-if=\"state.showOther and isActiveItem('button_2_opt')\">\n+                    <TestSubComponent/>\n+                </t>\n+            `;\n+            static components = { TestSubComponent };\n+            setup() {\n+                super.setup();\n+                this.state = useDomState(async (el) => {\n+                    await delay(delayAmount);\n+                    await deferred;\n+                    return { value: el.dataset.value, showOther: el.dataset.value === \"c\" };\n+                });\n+            }\n+        }\n+        addBuilderOption({\n+            selector: \"div.test\",\n+            Component: TestOptionComponent,\n+        });\n+        const { waitSidebarUpdated } = await setupHTMLBuilder(\n+            `<div class=\"test\" data-value=\"a\">a</div>`\n+        );\n+\n+        deferred = new Deferred();\n+        await contains(\":iframe div.test\").click();\n+        expect(\".test-value-parent\").toHaveCount(0);\n+        deferred.resolve();\n+\n+        await waitSidebarUpdated();\n+        expect(\".test-value-parent\").toHaveText(\"a\");\n+\n+        deferred = new Deferred();\n+        await contains(\".test-button-1 button\").click();\n+        expect(\".test-value-parent\").toHaveText(\"a\");\n+        expect(\".test-button-3\").toHaveCount(0);\n+        deferred.resolve();\n+\n+        await waitSidebarUpdated();\n+        expect(\".test-value-parent\").toHaveText(\"b\");\n+        expect(\".test-value-sub\").toHaveCount(0);\n+\n+        deferred = new Deferred();\n+        await contains(\".test-button-2 button\").click();\n+        expect(\".test-value-parent\").toHaveText(\"b\");\n+        expect(\".test-value-sub\").toHaveCount(0);\n+        deferred.resolve();\n+\n+        await waitSidebarUpdated();\n+        expect(\".test-value-parent\").toHaveText(\"c\");\n+        expect(\".test-value-sub\").toHaveText(\"c\");\n+    });\n+});"
+      },
+      {
+        "sha": "7ee6abc9b082caf74bbe60c9b59bfd37aee94cf7",
+        "filename": "addons/web/static/tests/_framework/component_test_helpers.js",
+        "status": "modified",
+        "additions": 29,
+        "deletions": 0,
+        "changes": 29,
+        "blob_url": "https://github.com/odoo/odoo/blob/7450ed30ddb54b74993885d4d9b98a26f9e2a85b/addons%2Fweb%2Fstatic%2Ftests%2F_framework%2Fcomponent_test_helpers.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/7450ed30ddb54b74993885d4d9b98a26f9e2a85b/addons%2Fweb%2Fstatic%2Ftests%2F_framework%2Fcomponent_test_helpers.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fweb%2Fstatic%2Ftests%2F_framework%2Fcomponent_test_helpers.js?ref=7450ed30ddb54b74993885d4d9b98a26f9e2a85b",
+        "patch": "@@ -183,3 +183,32 @@ export async function mountWithCleanup(ComponentClass, options) {\n \n     return component;\n }\n+\n+export async function waitUntilIdle(apps = [...App.apps]) {\n+    const isOwlIdle = () => apps.every((app) => app.scheduler.tasks.size === 0);\n+\n+    if (isOwlIdle()) {\n+        return Promise.resolve();\n+    }\n+\n+    return new Promise((resolve) => {\n+        function cleanup() {\n+            for (const cb of unpatch) {\n+                cb();\n+            }\n+            unpatch = [];\n+        }\n+        after(cleanup);\n+        let unpatch = apps.map((app) =>\n+            patch(app.scheduler, {\n+                processTasks() {\n+                    super.processTasks();\n+                    if (isOwlIdle()) {\n+                        cleanup();\n+                        resolve();\n+                    }\n+                },\n+            })\n+        );\n+    });\n+}"
+      },
+      {
+        "sha": "3a30d87c261bb9fa655d2e3481454fc8db47af94",
+        "filename": "addons/web/static/tests/web_test_helpers.js",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 0,
+        "changes": 1,
+        "blob_url": "https://github.com/odoo/odoo/blob/7450ed30ddb54b74993885d4d9b98a26f9e2a85b/addons%2Fweb%2Fstatic%2Ftests%2Fweb_test_helpers.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/7450ed30ddb54b74993885d4d9b98a26f9e2a85b/addons%2Fweb%2Fstatic%2Ftests%2Fweb_test_helpers.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fweb%2Fstatic%2Ftests%2Fweb_test_helpers.js?ref=7450ed30ddb54b74993885d4d9b98a26f9e2a85b",
+        "patch": "@@ -44,6 +44,7 @@ export {\n     findComponent,\n     getDropdownMenu,\n     mountWithCleanup,\n+    waitUntilIdle,\n } from \"./_framework/component_test_helpers\";\n export { contains, defineStyle, editAce, sortableDrag } from \"./_framework/dom_test_helpers\";\n export {"
+      },
+      {
+        "sha": "52c811e7492353a549607cb7bad7fbabcad5ddbe",
+        "filename": "addons/website/static/tests/builder/image_shape.test.js",
+        "status": "modified",
+        "additions": 5,
+        "deletions": 13,
+        "changes": 18,
+        "blob_url": "https://github.com/odoo/odoo/blob/7450ed30ddb54b74993885d4d9b98a26f9e2a85b/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fimage_shape.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/7450ed30ddb54b74993885d4d9b98a26f9e2a85b/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fimage_shape.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fimage_shape.test.js?ref=7450ed30ddb54b74993885d4d9b98a26f9e2a85b",
+        "patch": "@@ -45,22 +45,19 @@ test(\"Should set a shape on an image\", async () => {\n     expect(\":iframe .test-options-target img\").toHaveAttribute(\"data-shape-colors\", \";;;;\");\n });\n test(\"Should change the shape color of an image\", async () => {\n-    const { getEditor, waitDomUpdated } = await setupWebsiteBuilder(\n+    const { waitSidebarUpdated } = await setupWebsiteBuilder(\n         `<div class=\"test-options-target\">\n             ${testImg}\n         </div>`,\n         {\n             loadIframeBundles: true,\n         }\n     );\n-    const editor = getEditor();\n     await contains(\":iframe .test-options-target img\").click();\n \n     await contains(\"[data-label='Shape'] .dropdown\").click();\n     await contains(\"[data-action-value='html_builder/pattern/pattern_wave_4']\").click();\n-    // ensure the shape action has been applied\n-    await editor.shared.operation.next(() => {});\n-    await waitDomUpdated();\n+    await waitSidebarUpdated();\n \n     await waitFor(`[data-label=\"Colors\"] .o_we_color_preview`);\n \n@@ -95,9 +92,7 @@ test(\"Should change the shape color of an image\", async () => {\n     await contains(`[data-label=\"Colors\"] .o_we_color_preview:nth-child(1)`).click();\n     await contains(`.o_font_color_selector [data-color=\"#FF0000\"]`).click();\n \n-    // ensure the shape action has been applied\n-    await editor.shared.operation.next(() => {});\n-    await waitDomUpdated();\n+    await waitSidebarUpdated();\n \n     expect(`[data-label=\"Colors\"] .o_we_color_preview:nth-child(1)`).toHaveAttribute(\n         \"style\",\n@@ -109,7 +104,7 @@ test(\"Should change the shape color of an image\", async () => {\n     );\n });\n test(\"Should change the shape color of an image with a class color\", async () => {\n-    const { getEditor, waitDomUpdated } = await setupWebsiteBuilder(\n+    const { getEditor, waitSidebarUpdated } = await setupWebsiteBuilder(\n         `<div class=\"test-options-target\">\n             ${testImg}\n         </div>`,\n@@ -158,10 +153,7 @@ test(\"Should change the shape color of an image with a class color\", async () =>\n     await contains(`[data-label=\"Colors\"] .o_we_color_preview:nth-child(1)`).click();\n     await contains(`.o_font_color_selector [data-color=\"o-color-2\"]`).click();\n \n-    // ensure the shape action has been applied\n-    await editor.shared.operation.next(() => {});\n-    // wait for owl to update the dom\n-    await waitDomUpdated();\n+    await waitSidebarUpdated();\n \n     expect(`[data-label=\"Colors\"] .o_we_color_preview:nth-child(1)`).toHaveAttribute(\n         \"style\","
+      },
+      {
+        "sha": "b49e15042c33bc9e6ad61602403faf5b3538c235",
+        "filename": "addons/website/static/tests/builder/image_size.test.js",
+        "status": "modified",
+        "additions": 8,
+        "deletions": 8,
+        "changes": 16,
+        "blob_url": "https://github.com/odoo/odoo/blob/7450ed30ddb54b74993885d4d9b98a26f9e2a85b/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fimage_size.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/7450ed30ddb54b74993885d4d9b98a26f9e2a85b/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fimage_size.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fimage_size.test.js?ref=7450ed30ddb54b74993885d4d9b98a26f9e2a85b",
+        "patch": "@@ -7,27 +7,27 @@ import { testImg, testImgSrc, testGifImg, testGifImgSrc } from \"./image_test_hel\n defineWebsiteModels();\n \n test(\"the image should show its size\", async () => {\n-    const { waitDomUpdated } = await setupWebsiteBuilder(`\n+    const { waitSidebarUpdated } = await setupWebsiteBuilder(`\n         <div class=\"test-options-target\">\n             ${testImg}\n         </div>\n     `);\n     await contains(\":iframe .test-options-target img\").click();\n-    await waitDomUpdated();\n+    await waitSidebarUpdated();\n     const selector = `[data-container-title=\"Image\"] [title=\"Size\"]`;\n     await waitFor(selector);\n     const size = parseFloat(document.querySelector(selector).innerHTML);\n     expectAround(size, 20.1);\n });\n \n test(\"the background image should show its size\", async () => {\n-    const { waitDomUpdated } = await setupWebsiteBuilder(`\n+    const { waitSidebarUpdated } = await setupWebsiteBuilder(`\n         <div class=\"test-options-target\">\n             <section style=\"background-image: url(${testImgSrc});\">text</section>\n         </div>\n     `);\n     await contains(\":iframe .test-options-target section\").click();\n-    await waitDomUpdated();\n+    await waitSidebarUpdated();\n     const selector = `[data-label=\"Image\"] [title=\"Size\"]`;\n     await waitFor(selector);\n     const size = parseFloat(document.querySelector(selector).innerHTML);\n@@ -40,23 +40,23 @@ function expectAround(value, expected, delta = 0.2) {\n }\n \n test(\"the GIF image should NOT show its size\", async () => {\n-    const { waitDomUpdated } = await setupWebsiteBuilder(`\n+    const { waitSidebarUpdated } = await setupWebsiteBuilder(`\n         <div class=\"test-options-target\">\n             ${testGifImg}\n         </div>\n     `);\n     await contains(\":iframe .test-options-target img\").click();\n-    await waitDomUpdated();\n+    await waitSidebarUpdated();\n     expect(`[data-label=\"Image\"] [title=\"Size\"]`).toHaveCount(0);\n });\n \n test(\"the GIF background image should NOT show its size\", async () => {\n-    const { waitDomUpdated } = await setupWebsiteBuilder(`\n+    const { waitSidebarUpdated } = await setupWebsiteBuilder(`\n         <div class=\"test-options-target\">\n             <section style=\"background-image: url(${testGifImgSrc});\">text</section>\n         </div>\n     `);\n     await contains(\":iframe .test-options-target section\").click();\n-    await waitDomUpdated();\n+    await waitSidebarUpdated();\n     expect(`[data-label=\"Image\"] [title=\"Size\"]`).toHaveCount(0);\n });"
+      },
+      {
+        "sha": "13b129c024e7af7621f662b94e35b42caaa345c6",
+        "filename": "addons/website/static/tests/builder/website_builder/animate_option.test.js",
+        "status": "modified",
+        "additions": 25,
+        "deletions": 32,
+        "changes": 57,
+        "blob_url": "https://github.com/odoo/odoo/blob/7450ed30ddb54b74993885d4d9b98a26f9e2a85b/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fwebsite_builder%2Fanimate_option.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/7450ed30ddb54b74993885d4d9b98a26f9e2a85b/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fwebsite_builder%2Fanimate_option.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fwebsite_builder%2Fanimate_option.test.js?ref=7450ed30ddb54b74993885d4d9b98a26f9e2a85b",
+        "patch": "@@ -7,7 +7,6 @@ import {\n     setupWebsiteBuilder,\n } from \"@website/../tests/builder/website_helpers\";\n import { setSelection } from \"@html_editor/../tests/_helpers/selection\";\n-import { waitForEndOfOperation } from \"@html_builder/../tests/helpers\";\n \n defineWebsiteModels();\n \n@@ -41,7 +40,7 @@ test(\"visibility of animation animation=none\", async () => {\n });\n describe(\"onAppearance\", () => {\n     test(\"visibility of animation animation=onAppearance\", async () => {\n-        const { waitDomUpdated } = await setupWebsiteBuilder(\n+        const { waitSidebarUpdated } = await setupWebsiteBuilder(\n             `\n                 <div class=\"test-options-target\">\n                     ${testImg}\n@@ -53,7 +52,7 @@ describe(\"onAppearance\", () => {\n \n         await contains(\".options-container [data-label='Animation'] .dropdown-toggle\").click();\n         await contains(\".o-dropdown--menu [data-action-value='onAppearance']\").click();\n-        await waitDomUpdated();\n+        await waitSidebarUpdated();\n         expect(\".options-container [data-label='Animation'] .o-dropdown\").toHaveText(\n             \"On Appearance\"\n         );\n@@ -69,7 +68,7 @@ describe(\"onAppearance\", () => {\n         expect(\".options-container [data-label='Duration'] input\").toHaveValue(\"1\");\n     });\n     test(\"visibility of animation animation=onAppearance effect=slide\", async () => {\n-        const { waitDomUpdated } = await setupWebsiteBuilder(\n+        const { waitSidebarUpdated } = await setupWebsiteBuilder(\n             `\n                 <div class=\"test-options-target\">\n                     ${testImg}\n@@ -84,7 +83,7 @@ describe(\"onAppearance\", () => {\n \n         await contains(\".options-container [data-label='Effect'] .dropdown-toggle\").click();\n         await contains(\".o-dropdown--menu [data-action-value='o_anim_slide_in']\").click();\n-        await waitDomUpdated();\n+        await waitSidebarUpdated();\n         expect(\".options-container [data-label='Effect'] .o-dropdown\").toHaveText(\"Slide\");\n \n         expect(\".options-container [data-label='Direction'] .o-dropdown\").toHaveText(\"From right\");\n@@ -97,7 +96,7 @@ describe(\"onAppearance\", () => {\n         expect(\".options-container [data-label='Duration'] input\").toHaveValue(\"1\");\n     });\n     test(\"visibility of animation animation=onAppearance effect=bounce\", async () => {\n-        const { waitDomUpdated } = await setupWebsiteBuilder(\n+        const { waitSidebarUpdated } = await setupWebsiteBuilder(\n             `\n                 <div class=\"test-options-target\">\n                     ${testImg}\n@@ -112,7 +111,7 @@ describe(\"onAppearance\", () => {\n \n         await contains(\".options-container [data-label='Effect'] .dropdown-toggle\").click();\n         await contains(\".o-dropdown--menu [data-action-value='o_anim_bounce_in']\").click();\n-        await waitDomUpdated();\n+        await waitSidebarUpdated();\n         expect(\".options-container [data-label='Effect'] .o-dropdown\").toHaveText(\"Bounce\");\n \n         expect(\".options-container [data-label='Direction'] .o-dropdown\").toHaveText(\"In place\");\n@@ -125,7 +124,7 @@ describe(\"onAppearance\", () => {\n         expect(\".options-container [data-label='Duration'] input\").toHaveValue(\"1\");\n     });\n     test(\"visibility of animation animation=onAppearance effect=flash\", async () => {\n-        const { waitDomUpdated } = await setupWebsiteBuilder(\n+        const { waitSidebarUpdated } = await setupWebsiteBuilder(\n             `\n                 <div class=\"test-options-target\">\n                     ${testImg}\n@@ -140,7 +139,7 @@ describe(\"onAppearance\", () => {\n \n         await contains(\".options-container [data-label='Effect'] .dropdown-toggle\").click();\n         await contains(\".o-dropdown--menu [data-action-value='o_anim_flash']\").click();\n-        await waitDomUpdated();\n+        await waitSidebarUpdated();\n         expect(\".options-container [data-label='Effect'] .o-dropdown\").toHaveText(\"Flash\");\n \n         expect(\".options-container [data-label='Direction']\").not.toHaveCount();\n@@ -154,7 +153,7 @@ describe(\"onAppearance\", () => {\n     });\n });\n test(\"visibility of animation animation=onScroll\", async () => {\n-    const { waitDomUpdated } = await setupWebsiteBuilder(`\n+    const { waitSidebarUpdated } = await setupWebsiteBuilder(`\n         <div class=\"test-options-target\">\n             ${testImg}\n         </div>\n@@ -163,7 +162,7 @@ test(\"visibility of animation animation=onScroll\", async () => {\n \n     await contains(\".options-container [data-label='Animation'] .dropdown-toggle\").click();\n     await contains(\".o-dropdown--menu [data-action-value='onScroll']\").click();\n-    await waitDomUpdated();\n+    await waitSidebarUpdated();\n     expect(\".options-container [data-label='Animation'] .o-dropdown\").toHaveText(\"On Scroll\");\n \n     expect(\".options-container [data-label='Effect'] .o-dropdown\").toHaveText(\"Fade\");\n@@ -177,7 +176,7 @@ test(\"visibility of animation animation=onScroll\", async () => {\n     expect(\".options-container [data-label='Scroll Zone']\").toBeVisible();\n });\n test(\"animation=onScroll should not be visible when the animation is limited\", async () => {\n-    const { waitDomUpdated } = await setupWebsiteBuilder(\n+    const { waitSidebarUpdated } = await setupWebsiteBuilder(\n         `\n                 <div class=\"test-options-target\">\n                     ${testImg}\n@@ -192,7 +191,7 @@ test(\"animation=onScroll should not be visible when the animation is limited\", a\n \n     await contains(\".options-container [data-label='Effect'] .dropdown-toggle\").click();\n     await contains(\".o-dropdown--menu [data-action-value='o_anim_flash']\").click();\n-    await waitDomUpdated();\n+    await waitSidebarUpdated();\n     expect(\".options-container [data-label='Effect'] .o-dropdown\").toHaveText(\"Flash\");\n \n     await contains(\".options-container [data-label='Animation'] .dropdown-toggle\").click();\n@@ -227,51 +226,45 @@ test.skip(\"visibility of animation animation=onHover\", async () => {\n         }\n     }\n \n-    const { waitDomUpdated } = await setupWebsiteBuilder(`\n+    const { waitSidebarUpdated } = await setupWebsiteBuilder(`\n         <div class=\"test-options-target\">\n             ${testImg}\n         </div>\n     `);\n     await contains(\":iframe .test-options-target img\").click();\n \n-    // NOTE: we use waitDomUpdated and waitForEndOfOperation because setting the\n-    // hover effect may take some time (and setting \"On Hover\" sets a default)\n+    // NOTE: we use waitSidebarUpdated because setting the hover effect may\n+    // take some time (and setting \"On Hover\" sets a default)\n \n     await contains(\".options-container [data-label='Animation'] .dropdown-toggle\").click();\n     await contains(\".o-dropdown--menu [data-action-value='onHover']\").click();\n-    await waitForEndOfOperation();\n-    await waitDomUpdated();\n+    await waitSidebarUpdated();\n     expect(\".options-container [data-label='Animation'] .o-dropdown\").toHaveText(\"On Hover\");\n     expectOnHoverOptions({ Effect: \"Overlay\", Color: 1 });\n \n     await contains(\".options-container [data-label='Effect'] .dropdown-toggle\").click();\n     await contains(\".o-dropdown--menu [data-action-value='image_zoom_in']\").click();\n-    await waitForEndOfOperation();\n-    await waitDomUpdated();\n+    await waitSidebarUpdated();\n     expectOnHoverOptions({ Effect: \"Zoom In\", Intensity: 1, Overlay: 1 });\n \n     await contains(\".options-container [data-label='Effect'] .dropdown-toggle\").click();\n     await contains(\".o-dropdown--menu [data-action-value='image_zoom_out']\").click();\n-    await waitForEndOfOperation();\n-    await waitDomUpdated();\n+    await waitSidebarUpdated();\n     expectOnHoverOptions({ Effect: \"Zoom Out\", Intensity: 1, Overlay: 1 });\n \n     await contains(\".options-container [data-label='Effect'] .dropdown-toggle\").click();\n     await contains(\".o-dropdown--menu [data-action-value='dolly_zoom']\").click();\n-    await waitForEndOfOperation();\n-    await waitDomUpdated();\n+    await waitSidebarUpdated();\n     expectOnHoverOptions({ Effect: \"Dolly Zoom\", Intensity: 1, Overlay: 1 });\n \n     await contains(\".options-container [data-label='Effect'] .dropdown-toggle\").click();\n     await contains(\".o-dropdown--menu [data-action-value='outline']\").click();\n-    await waitForEndOfOperation();\n-    await waitDomUpdated();\n+    await waitSidebarUpdated();\n     expectOnHoverOptions({ Effect: \"Outline\", Color: 1, \"Stroke Width\": 1 });\n \n     await contains(\".options-container [data-label='Effect'] .dropdown-toggle\").click();\n     await contains(\".o-dropdown--menu [data-action-value='image_mirror_blur']\").click();\n-    await waitForEndOfOperation();\n-    await waitDomUpdated();\n+    await waitSidebarUpdated();\n     expectOnHoverOptions({ Effect: \"Mirror Blur\", Intensity: 1 });\n });\n test(\"animation=onHover should not be visible when the image is a device shape\", async () => {\n@@ -358,7 +351,7 @@ test(\"image should not be lazy onAppearance\", async () => {\n });\n \n test(\"should not show the animation options if the image has a parent [data-oe-type='image']\", async () => {\n-    const { getEditor, waitDomUpdated } = await setupWebsiteBuilder(`\n+    const { getEditor, waitSidebarUpdated } = await setupWebsiteBuilder(`\n         <div class=\"test-options-target\">\n             ${testImg}\n         </div>\n@@ -371,12 +364,12 @@ test(\"should not show the animation options if the image has a parent [data-oe-t\n     const optionTarget = queryFirst(\":iframe .test-options-target\");\n     optionTarget.setAttribute(\"data-oe-type\", \"image\");\n     editor.shared.history.addStep();\n-    await waitDomUpdated();\n+    await waitSidebarUpdated();\n     expect(\".options-container [data-label='Animation'] .dropdown-toggle\").not.toHaveCount();\n });\n \n test(\"should not show the animation options if the image has is [data-oe-xpath]\", async () => {\n-    const { getEditor, waitDomUpdated } = await setupWebsiteBuilder(`\n+    const { getEditor, waitSidebarUpdated } = await setupWebsiteBuilder(`\n         <div class=\"test-options-target\">\n             ${testImg}\n         </div>\n@@ -389,7 +382,7 @@ test(\"should not show the animation options if the image has is [data-oe-xpath]\"\n     const optionTarget = queryFirst(\":iframe .test-options-target img\");\n     optionTarget.setAttribute(\"data-oe-xpath\", \"/foo/bar\");\n     editor.shared.history.addStep();\n-    await waitDomUpdated();\n+    await waitSidebarUpdated();\n     expect(\".options-container [data-label='Animation'] .dropdown-toggle\").not.toHaveCount();\n });\n "
+      },
+      {
+        "sha": "b9311d126282a3d6135f5af9e65d816a02bb6231",
+        "filename": "addons/website/static/tests/builder/website_builder/background_option.test.js",
+        "status": "modified",
+        "additions": 13,
+        "deletions": 15,
+        "changes": 28,
+        "blob_url": "https://github.com/odoo/odoo/blob/7450ed30ddb54b74993885d4d9b98a26f9e2a85b/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fwebsite_builder%2Fbackground_option.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/7450ed30ddb54b74993885d4d9b98a26f9e2a85b/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fwebsite_builder%2Fbackground_option.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fwebsite_builder%2Fbackground_option.test.js?ref=7450ed30ddb54b74993885d4d9b98a26f9e2a85b",
+        "patch": "@@ -114,7 +114,7 @@ test(\"Change the background position and click out of the iframe\", async () => {\n test(\"Background position overlay layout\", async () => {\n     expect.assertions(18);\n \n-    const { getEditor, waitDomUpdated } = await setupWebsiteBuilder(\n+    const { getEditor, waitSidebarUpdated } = await setupWebsiteBuilder(\n         `<section>\n             <div class=\"container\">\n                 <section style=\"background-image: url('/web/image/123/transparent.png'); width: 500px; height: 500px\">\n@@ -138,7 +138,7 @@ test(\"Background position overlay layout\", async () => {\n             const iframeContainer = queryOne(\".o_website_preview.o_is_mobile .o_iframe_container\");\n             iframeContainer.style.transform = `translate(-50%, -50%) scale(${iframeContainerScale})`;\n         }\n-        await openBgPositionOverlay(section, waitDomUpdated);\n+        await openBgPositionOverlay(section, waitSidebarUpdated);\n \n         // The overlay should cover exactly the iframe\n         const iframeRect = iframe.getBoundingClientRect();\n@@ -200,7 +200,7 @@ test(\"Background position overlay behavior\", async () => {\n         };\n     };\n \n-    const { getEditor, waitDomUpdated } = await setupWebsiteBuilder(\n+    const { getEditor, waitSidebarUpdated } = await setupWebsiteBuilder(\n         `<section>\n             <div class=\"container\">\n                 <section style=\"background-image: url('/web/image/123/transparent.png'); width: 500px;\">\n@@ -228,7 +228,7 @@ test(\"Background position overlay behavior\", async () => {\n     // Make sure we can scroll\n     section.style.height = \"1000px\";\n \n-    await openBgPositionOverlay(section, waitDomUpdated);\n+    await openBgPositionOverlay(section, waitSidebarUpdated);\n \n     // Scrolling on the overlay should scroll the iframe\n     await scroll(queryOne(\".o_we_background_position_overlay\"), { y: 50 }, { scrollable: false });\n@@ -237,7 +237,7 @@ test(\"Background position overlay behavior\", async () => {\n \n     // The Scroll Effect should be set to \"None\"\n     expect(\"[data-label='Scroll Effect'] button\").toHaveText(\"None\");\n-    await openBgPositionOverlay(section, waitDomUpdated);\n+    await openBgPositionOverlay(section, waitSidebarUpdated);\n     expect(section).toHaveClass(\"o_we_background_positioning\");\n \n     // Drag and check that the background moves properly\n@@ -258,7 +258,7 @@ test(\"Background position overlay behavior\", async () => {\n     // Set Scroll Effect to \"Fixed\"\n     await contains(\"[data-label='Scroll Effect'] button\").click();\n     await contains(\"[data-action-value='fixed']\").click();\n-    await openBgPositionOverlay(section, waitDomUpdated);\n+    await openBgPositionOverlay(section, waitSidebarUpdated);\n     // The element with the background is not the section when the Scroll Effect is not \"None\".\n     // However the section (i.e. its parent element) needs to have this class set to hide its content.\n     expect(section).toHaveClass(\"o_we_background_positioning\");\n@@ -280,12 +280,10 @@ test(\"Background position overlay behavior\", async () => {\n     );\n });\n \n-async function openBgPositionOverlay(editingElement, waitDomUpdated) {\n+async function openBgPositionOverlay(editingElement, waitSidebarUpdated) {\n     await contains(editingElement).click();\n-    await waitDomUpdated();\n-    // TODO: Remove the timeouts when waitDomUpdated is fixed\n-    await contains(\"button[data-action-id='backgroundPositionOverlay']\", { timeout: 2000 }).click();\n-    await waitDomUpdated();\n+    await waitSidebarUpdated();\n+    await contains(\"button[data-action-id='backgroundPositionOverlay']\").click();\n     await waitFor(\".o-overlay-container .o_we_background_dragger\", { timeout: 2000 });\n }\n \n@@ -309,13 +307,13 @@ function patchDragBackground(el, from, to) {\n }\n \n async function dragAndDropBgImage() {\n-    const { waitDomUpdated } = await setupWebsiteBuilder(`\n+    const { waitSidebarUpdated } = await setupWebsiteBuilder(`\n         <section style=\"background-image: url('/web/image/123/transparent.png'); width: 500px; height:500px\">\n             <div class=\"o_we_shape o_html_builder_Connections_01\">\n                 AAAA\n             </div>\n         </section>`);\n-    await openBgPositionOverlay(\":iframe section\", waitDomUpdated);\n+    await openBgPositionOverlay(\":iframe section\", waitSidebarUpdated);\n     const { startDrag, endDrag } = patchDragBackground(\n         \".o-overlay-container .o_we_background_dragger\",\n         { x: 199, y: 199 },\n@@ -365,7 +363,7 @@ test(\"open the media dialog to toggle the image background but do not choose an\n });\n \n test(\"remove the background image of a snippet\", async () => {\n-    const { waitDomUpdated } = await setupWebsiteBuilder(`\n+    const { waitSidebarUpdated } = await setupWebsiteBuilder(`\n         <section style=\"background-image: url('/web/image/123/transparent.png'); width: 500px; height:500px\">\n             <div class=\"o_we_shape o_html_builder_Connections_01\">\n                 AAAA\n@@ -374,7 +372,7 @@ test(\"remove the background image of a snippet\", async () => {\n     await contains(\":iframe section\").click();\n     expect(\":iframe section\").toHaveStyle(\"backgroundImage\");\n     await contains(\"[data-action-id='toggleBgImage']\").click();\n-    await waitDomUpdated();\n+    await waitSidebarUpdated();\n     expect(\":iframe section\").not.toHaveStyle(\"backgroundImage\", { inline: true });\n });\n "
+      },
+      {
+        "sha": "745f8085a0ce6ee8eef9bc89e378079698cf7133",
+        "filename": "addons/website/static/tests/builder/website_builder/image_gallery.test.js",
+        "status": "modified",
+        "additions": 2,
+        "deletions": 3,
+        "changes": 5,
+        "blob_url": "https://github.com/odoo/odoo/blob/7450ed30ddb54b74993885d4d9b98a26f9e2a85b/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fwebsite_builder%2Fimage_gallery.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/7450ed30ddb54b74993885d4d9b98a26f9e2a85b/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fwebsite_builder%2Fimage_gallery.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fwebsite_builder%2Fimage_gallery.test.js?ref=7450ed30ddb54b74993885d4d9b98a26f9e2a85b",
+        "patch": "@@ -36,7 +36,7 @@ test(\"Add image in gallery\", async () => {\n         { pure: true }\n     );\n \n-    const { waitDomUpdated } = await setupWebsiteBuilder(\n+    await setupWebsiteBuilder(\n         `\n         <section class=\"s_image_gallery o_masonry\" data-columns=\"2\">\n             <div class=\"container\">\n@@ -73,8 +73,7 @@ test(\"Add image in gallery\", async () => {\n     // We use \"click\" instead of contains.click because contains wait for the image to be visible.\n     // In this test we don't want to wait ~800ms for the image to be visible but we can still click on it\n     await click(\".o_existing_attachment_cell .o_button_area\");\n-    await waitDomUpdated();\n-    await contains(\".modal-footer button\").click();\n+    await contains(\".modal-footer button:not([disabled]):contains(Add)\").click();\n     await waitFor(\":iframe .o_masonry_col img[data-index='6']\");\n \n     const columns = queryAll(\":iframe .o_masonry_col\");"
+      },
+      {
+        "sha": "d53450aab3ea6a1f68ffedfa53af9bda845837dc",
+        "filename": "addons/website/static/tests/builder/website_builder/parallax_option.test.js",
+        "status": "modified",
+        "additions": 2,
+        "deletions": 3,
+        "changes": 5,
+        "blob_url": "https://github.com/odoo/odoo/blob/7450ed30ddb54b74993885d4d9b98a26f9e2a85b/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fwebsite_builder%2Fparallax_option.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/7450ed30ddb54b74993885d4d9b98a26f9e2a85b/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fwebsite_builder%2Fparallax_option.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fwebsite_builder%2Fparallax_option.test.js?ref=7450ed30ddb54b74993885d4d9b98a26f9e2a85b",
+        "patch": "@@ -111,8 +111,7 @@ async function setupWebsiteAndOpenParallaxOptions({ editingElClasses = \"\" } = {}\n         <section ${editingElClass} style=\"background-image: ${backgroundImageUrl}; width: 500px; height:500px\">\n         </section>`);\n     await contains(\":iframe section\").click();\n-    // Timeout: Images are fetched from the network for some values in the\n-    // options, the normal timeout is sometimes too short\n-    await contains(\"[data-label='Scroll Effect'] button.o-dropdown\", { timeout: 1000 }).click();\n+    await websiteBuilder.waitSidebarUpdated();\n+    await contains(\"[data-label='Scroll Effect'] button.o-dropdown\").click();\n     return websiteBuilder;\n }"
+      },
+      {
+        "sha": "152c037dd50e247d0f015ddb9b5eb39ae46f3cac",
+        "filename": "addons/website/static/tests/builder/website_helpers.js",
+        "status": "modified",
+        "additions": 6,
+        "deletions": 3,
+        "changes": 9,
+        "blob_url": "https://github.com/odoo/odoo/blob/7450ed30ddb54b74993885d4d9b98a26f9e2a85b/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fwebsite_helpers.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/7450ed30ddb54b74993885d4d9b98a26f9e2a85b/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fwebsite_helpers.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fwebsite_helpers.js?ref=7450ed30ddb54b74993885d4d9b98a26f9e2a85b",
+        "patch": "@@ -21,6 +21,7 @@ import {\n     mountWithCleanup,\n     onRpc,\n     patchWithCleanup,\n+    waitUntilIdle,\n } from \"@web/../tests/web_test_helpers\";\n import { loadBundle } from \"@web/core/assets\";\n import { isBrowserFirefox } from \"@web/core/browser/feature_detection\";\n@@ -100,7 +101,7 @@ export async function setupWebsiteBuilder(\n     registry.category(\"services\").remove(\"website_edit\");\n     let editor;\n     let editableContent;\n-    await mountWithCleanup(WebClient);\n+    const comp = await mountWithCleanup(WebClient);\n     let originalIframeLoaded;\n     let resolveIframeLoaded = () => {};\n     const bodyHTML = `${beforeWrapwrapContent}\n@@ -195,11 +196,13 @@ export async function setupWebsiteBuilder(\n     });\n \n     let lastUpdatePromise;\n-    const waitDomUpdated = async () => {\n+    const waitSidebarUpdated = async () => {\n+        await editor.shared.operation.next();\n         // The tick ensures that lastUpdatePromise has correctly been assigned\n         await tick();\n         await lastUpdatePromise;\n         await animationFrame();\n+        await waitUntilIdle([comp.__owl__.app]);\n     };\n     patchWithCleanup(Builder.prototype, {\n         setup() {\n@@ -258,7 +261,7 @@ export async function setupWebsiteBuilder(\n         getEditor: () => editor,\n         getEditableContent: () => editableContent,\n         openBuilderSidebar: async () => await openBuilderSidebar(editAssetsLoaded),\n-        waitDomUpdated,\n+        waitSidebarUpdated,\n     };\n }\n "
+      },
+      {
+        "sha": "6419d83c51a962d388ad5868b84310747a2b26d1",
+        "filename": "addons/website_sale/static/tests/builder/product_page_option.test.js",
+        "status": "modified",
+        "additions": 3,
+        "deletions": 4,
+        "changes": 7,
+        "blob_url": "https://github.com/odoo/odoo/blob/7450ed30ddb54b74993885d4d9b98a26f9e2a85b/addons%2Fwebsite_sale%2Fstatic%2Ftests%2Fbuilder%2Fproduct_page_option.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/7450ed30ddb54b74993885d4d9b98a26f9e2a85b/addons%2Fwebsite_sale%2Fstatic%2Ftests%2Fbuilder%2Fproduct_page_option.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite_sale%2Fstatic%2Ftests%2Fbuilder%2Fproduct_page_option.test.js?ref=7450ed30ddb54b74993885d4d9b98a26f9e2a85b",
+        "patch": "@@ -1,4 +1,3 @@\n-import { waitForEndOfOperation } from \"@html_builder/../tests/helpers\";\n import { expect, test } from \"@odoo/hoot\";\n import { waitForNone } from \"@odoo/hoot-dom\";\n import { contains, dataURItoBlob, defineModels, models, onRpc } from \"@web/../tests/web_test_helpers\";\n@@ -15,7 +14,7 @@ defineWebsiteModels();\n defineModels([ProductRibbon]);\n \n test(\"Product page options\", async () => {\n-    await setupWebsiteBuilder(`\n+    const { waitSidebarUpdated } = await setupWebsiteBuilder(`\n         <main>\n             <div class=\"o_wsale_product_page\">\n                 <section\n@@ -107,12 +106,12 @@ test(\"Product page options\", async () => {\n     await contains(\"button#o_wsale_image_width\").click();\n     // Avoid selecting the first option to prevent the image layout option from disappearing\n     await contains(\"[data-action-id=productPageImageWidth][data-action-value='50_pc']\").click();\n-    await waitForEndOfOperation();\n+    await waitSidebarUpdated();\n     expect.verifySteps([\"config\"]);\n \n     await contains(\"button#o_wsale_image_layout\").click();\n     await contains(\"[data-action-id=productPageImageLayout]\").click();\n-    await waitForEndOfOperation();\n+    await waitSidebarUpdated();\n     expect.verifySteps([\n         // Activate the carousel view and change the shop config\n         \"config\","
+      }
+    ],
+    "paths": [
+      "addons/html_builder",
+      "addons/website"
+    ]
+  },
+  {
+    "sha": "80942fa5162cd069037065f85abc574732d14b7c",
+    "node_id": "C_kwDOAS1I7NoAKDgwOTQyZmE1MTYyY2QwNjkwMzcwNjVmODVhYmM1NzQ3MzJkMTRiN2M",
+    "commit": {
+      "author": {
+        "name": "Serge Bayet (seba)",
+        "email": "seba@odoo.com",
+        "date": "2025-09-29T13:30:03Z"
+      },
+      "committer": {
+        "name": "Serge Bayet",
+        "email": "seba@odoo.com",
+        "date": "2025-10-10T20:01:52Z"
+      },
+      "message": "[IMP] website: inline new content access checks\n\nSince [1], a TODO was pending to remove a dedicated controller route\nused only to filter elements in the \"New Content\" modal per user.\nThis commit addresses it by moving the filtering logic to existing\nclient-side services and relying on the generic has_access RPC provided\nby the user service, instead of an ad-hoc controller.\n\nThis removes the temporary route and avoids an extra RPC call for\nnon-restricted editors.\n\n[1]: https://github.com/odoo/odoo/commit/1ebcdb00231aa1854f6366c61055e2543cf94a51\n\ncloses odoo/odoo#229068\n\nSigned-off-by: Souk\u00e9ina Bojabza (sobo) <sobo@odoo.com>",
+      "tree": {
+        "sha": "85c0e598fa8f98bc669b04f733b2a4543a405b00",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/85c0e598fa8f98bc669b04f733b2a4543a405b00"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/80942fa5162cd069037065f85abc574732d14b7c",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/80942fa5162cd069037065f85abc574732d14b7c",
+    "html_url": "https://github.com/odoo/odoo/commit/80942fa5162cd069037065f85abc574732d14b7c",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/80942fa5162cd069037065f85abc574732d14b7c/comments",
+    "author": {
+      "login": "SergeBayet",
+      "id": 22252071,
+      "node_id": "MDQ6VXNlcjIyMjUyMDcx",
+      "avatar_url": "https://avatars.githubusercontent.com/u/22252071?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/SergeBayet",
+      "html_url": "https://github.com/SergeBayet",
+      "followers_url": "https://api.github.com/users/SergeBayet/followers",
+      "following_url": "https://api.github.com/users/SergeBayet/following{/other_user}",
+      "gists_url": "https://api.github.com/users/SergeBayet/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/SergeBayet/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/SergeBayet/subscriptions",
+      "organizations_url": "https://api.github.com/users/SergeBayet/orgs",
+      "repos_url": "https://api.github.com/users/SergeBayet/repos",
+      "events_url": "https://api.github.com/users/SergeBayet/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/SergeBayet/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "SergeBayet",
+      "id": 22252071,
+      "node_id": "MDQ6VXNlcjIyMjUyMDcx",
+      "avatar_url": "https://avatars.githubusercontent.com/u/22252071?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/SergeBayet",
+      "html_url": "https://github.com/SergeBayet",
+      "followers_url": "https://api.github.com/users/SergeBayet/followers",
+      "following_url": "https://api.github.com/users/SergeBayet/following{/other_user}",
+      "gists_url": "https://api.github.com/users/SergeBayet/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/SergeBayet/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/SergeBayet/subscriptions",
+      "organizations_url": "https://api.github.com/users/SergeBayet/orgs",
+      "repos_url": "https://api.github.com/users/SergeBayet/repos",
+      "events_url": "https://api.github.com/users/SergeBayet/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/SergeBayet/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "52892ae9a5440636ad4e9cbb196eda247a3b82f1",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/52892ae9a5440636ad4e9cbb196eda247a3b82f1",
+        "html_url": "https://github.com/odoo/odoo/commit/52892ae9a5440636ad4e9cbb196eda247a3b82f1"
+      }
+    ],
+    "stats": {
+      "total": 54,
+      "additions": 25,
+      "deletions": 29
+    },
+    "files": [
+      {
+        "sha": "c74ce67c5fc3ca46977afdec312b0dd4c4c66384",
+        "filename": "addons/website/controllers/backend.py",
+        "status": "modified",
+        "additions": 0,
+        "deletions": 19,
+        "changes": 19,
+        "blob_url": "https://github.com/odoo/odoo/blob/80942fa5162cd069037065f85abc574732d14b7c/addons%2Fwebsite%2Fcontrollers%2Fbackend.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/80942fa5162cd069037065f85abc574732d14b7c/addons%2Fwebsite%2Fcontrollers%2Fbackend.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fcontrollers%2Fbackend.py?ref=80942fa5162cd069037065f85abc574732d14b7c",
+        "patch": "@@ -1,7 +1,5 @@\n # Part of Odoo. See LICENSE file for full copyright and licensing details.\n \n-import werkzeug\n-\n from odoo import http\n from odoo.http import request\n \n@@ -37,23 +35,6 @@ def fetch_dashboard_data(self, website_id):\n     def get_iframe_fallback(self):\n         return request.render('website.iframefallback')\n \n-    @http.route('/website/check_new_content_access_rights', type=\"jsonrpc\", auth='user', readonly=True)\n-    def check_create_access_rights(self, models):\n-        \"\"\"\n-        TODO: In master, remove this route and method and find a better way\n-        to do this. This route is only here to ensure that the \"New Content\"\n-        modal displays the correct elements for each user, and there might be\n-        a way to do it with the framework rather than having a dedicated\n-        controller route. (maybe by using a template or a JS util)\n-        \"\"\"\n-        if not request.env.user.has_group('website.group_website_restricted_editor'):\n-            raise werkzeug.exceptions.Forbidden()\n-\n-        return {\n-            model: request.env[model].has_access('create')\n-            for model in models\n-        }\n-\n     @http.route('/website/track_installing_modules', type='jsonrpc', auth='user', readonly=True)\n     def website_track_installing_modules(self, selected_features, total_features=None):\n         \"\"\""
+      },
+      {
+        "sha": "d0a5faf7d1090f57b17a87d1f0b225313ecd234a",
+        "filename": "addons/website/static/src/client_actions/website_preview/new_content_systray_item.js",
+        "status": "modified",
+        "additions": 14,
+        "deletions": 4,
+        "changes": 18,
+        "blob_url": "https://github.com/odoo/odoo/blob/80942fa5162cd069037065f85abc574732d14b7c/addons%2Fwebsite%2Fstatic%2Fsrc%2Fclient_actions%2Fwebsite_preview%2Fnew_content_systray_item.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/80942fa5162cd069037065f85abc574732d14b7c/addons%2Fwebsite%2Fstatic%2Fsrc%2Fclient_actions%2Fwebsite_preview%2Fnew_content_systray_item.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fclient_actions%2Fwebsite_preview%2Fnew_content_systray_item.js?ref=80942fa5162cd069037065f85abc574732d14b7c",
+        "patch": "@@ -128,6 +128,10 @@ export class NewContentSystrayItem extends Component {\n     }\n \n     async toggleDropdown() {\n+        if (!this.website.isRestrictedEditor) {\n+            return;\n+        }\n+\n         if (this.dropdownWasAlreadyOpened) {\n             this.dropdown.isOpen = !this.dropdown.isOpen;\n             return;\n@@ -162,10 +166,16 @@ export class NewContentSystrayItem extends Component {\n                     elementsToUpdate[element.model] = element;\n                 }\n             }\n-            const accesses = await rpc(\"/website/check_new_content_access_rights\", {\n-                models: modelsToCheck,\n-            }, { cache: true });\n-            for (const [model, access] of Object.entries(accesses)) {\n+            if (!modelsToCheck.length) {\n+                return;\n+            }\n+            const accesses = await Promise.all(\n+                modelsToCheck.map(async (model) => [\n+                    model,\n+                    await user.checkAccessRight(model, \"create\")\n+                ])\n+            );\n+            for (const [model, access] of accesses) {\n                 elementsToUpdate[model].isDisplayed = access;\n             }\n         })());"
+      },
+      {
+        "sha": "3d9372ed53e4f89205f69dce962945650df7055a",
+        "filename": "addons/website/static/tests/new_content_systray_item.test.js",
+        "status": "modified",
+        "additions": 11,
+        "deletions": 6,
+        "changes": 17,
+        "blob_url": "https://github.com/odoo/odoo/blob/80942fa5162cd069037065f85abc574732d14b7c/addons%2Fwebsite%2Fstatic%2Ftests%2Fnew_content_systray_item.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/80942fa5162cd069037065f85abc574732d14b7c/addons%2Fwebsite%2Fstatic%2Ftests%2Fnew_content_systray_item.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Ftests%2Fnew_content_systray_item.test.js?ref=80942fa5162cd069037065f85abc574732d14b7c",
+        "patch": "@@ -1,19 +1,25 @@\n import { expect, test } from \"@odoo/hoot\";\n-import { mountWithCleanup, onRpc, contains } from \"@web/../tests/web_test_helpers\";\n+import {\n+    mountWithCleanup,\n+    onRpc,\n+    contains,\n+    mockService,\n+} from \"@web/../tests/web_test_helpers\";\n import { NewContentSystrayItem } from \"@website/client_actions/website_preview/new_content_systray_item\";\n import { defineWebsiteModels } from \"./builder/website_helpers\";\n \n defineWebsiteModels();\n \n function setupTest() {\n+    mockService(\"website\", {\n+        get isRestrictedEditor() {\n+            return true;\n+        },\n+    });\n     onRpc(\"/web/dataset/call_kw/ir.module.module/search_read\", () => {\n         expect.step(\"/web/dataset/call_kw/ir.module.module/search_read\");\n         return [];\n     });\n-    onRpc(\"/website/check_new_content_access_rights\", () => {\n-        expect.step(\"/website/check_new_content_access_rights\");\n-        return [];\n-    });\n     onRpc(\"/website/get_new_page_templates\", () => {\n         expect.step(\"/website/get_new_page_templates\");\n         return [];\n@@ -35,7 +41,6 @@ test(\"can display a newcontent modal\", async () => {\n     expect(\"div.o_new_content_menu_choices\").toHaveCount(1);\n     expect.verifySteps([\n         \"/web/dataset/call_kw/ir.module.module/search_read\",\n-        \"/website/check_new_content_access_rights\",\n         \"/website/get_new_page_templates\",\n     ]);\n });"
+      }
+    ],
+    "paths": [
+      "addons/website"
+    ]
+  },
+  {
+    "sha": "cf30344a3af56b187f7de15ee1b3e543ae0066a5",
+    "node_id": "C_kwDOAS1I7NoAKGNmMzAzNDRhM2FmNTZiMTg3ZjdkZTE1ZWUxYjNlNTQzYWUwMDY2YTU",
+    "commit": {
+      "author": {
+        "name": "KAEI",
+        "email": "kaei@odoo.com",
+        "date": "2025-08-05T15:20:27Z"
+      },
+      "committer": {
+        "name": "kareem",
+        "email": "kaei@odoo.com",
+        "date": "2025-10-10T17:43:43Z"
+      },
+      "message": "[FIX] referral: job offer change to job opportunity in multiple places\n\ncloses odoo/odoo#221946\n\nRelated: odoo/enterprise#91734\nSigned-off-by: Jurgen Gjini (jugj) <jugj@odoo.com>",
+      "tree": {
+        "sha": "983e5ae26e9022eb7911b3e167760b7c163bb4af",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/983e5ae26e9022eb7911b3e167760b7c163bb4af"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/cf30344a3af56b187f7de15ee1b3e543ae0066a5",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/cf30344a3af56b187f7de15ee1b3e543ae0066a5",
+    "html_url": "https://github.com/odoo/odoo/commit/cf30344a3af56b187f7de15ee1b3e543ae0066a5",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/cf30344a3af56b187f7de15ee1b3e543ae0066a5/comments",
+    "author": null,
+    "committer": null,
+    "parents": [
+      {
+        "sha": "9466c72cfa2270b474044253a63f6f064f778b26",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/9466c72cfa2270b474044253a63f6f064f778b26",
+        "html_url": "https://github.com/odoo/odoo/commit/9466c72cfa2270b474044253a63f6f064f778b26"
+      }
+    ],
+    "stats": {
+      "total": 14,
+      "additions": 7,
+      "deletions": 7
+    },
+    "files": [
+      {
+        "sha": "f9981f7a6a3303e3c3652909835d7e8d643377b2",
+        "filename": "addons/hr_recruitment/data/hr_recruitment_tour.xml",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/cf30344a3af56b187f7de15ee1b3e543ae0066a5/addons%2Fhr_recruitment%2Fdata%2Fhr_recruitment_tour.xml",
+        "raw_url": "https://github.com/odoo/odoo/raw/cf30344a3af56b187f7de15ee1b3e543ae0066a5/addons%2Fhr_recruitment%2Fdata%2Fhr_recruitment_tour.xml",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhr_recruitment%2Fdata%2Fhr_recruitment_tour.xml?ref=cf30344a3af56b187f7de15ee1b3e543ae0066a5",
+        "patch": "@@ -4,7 +4,7 @@\n         <field name=\"name\">hr_recruitment_tour</field>\n         <field name=\"sequence\">230</field>\n         <field name=\"rainbow_man_message\"><![CDATA[\n-            <div>Great job! You hired a new colleague!</div><div>Try the Website app to publish job offers online.</div>\n+            <div>Great job! You hired a new colleague!</div><div>Try the Website app to publish job opportunities online.</div>\n         ]]></field>\n     </record>\n </odoo>"
+      },
+      {
+        "sha": "855a6d501b71c71cfd62194f775a814a35d05a8b",
+        "filename": "addons/hr_recruitment/views/hr_job_views.xml",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/cf30344a3af56b187f7de15ee1b3e543ae0066a5/addons%2Fhr_recruitment%2Fviews%2Fhr_job_views.xml",
+        "raw_url": "https://github.com/odoo/odoo/raw/cf30344a3af56b187f7de15ee1b3e543ae0066a5/addons%2Fhr_recruitment%2Fviews%2Fhr_job_views.xml",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhr_recruitment%2Fviews%2Fhr_job_views.xml?ref=cf30344a3af56b187f7de15ee1b3e543ae0066a5",
+        "patch": "@@ -250,7 +250,7 @@\n                             <field name=\"alias_domain_id\" class=\"oe_inline\" placeholder=\"e.g. mycompany.com\"\n                                    options=\"{'no_create': True, 'no_open': True}\"/>\n                         </div>\n-                        <div class=\"text-muted\">Incoming emails create applications automatically. Use it for direct applications or when posting job offers on LinkedIn, Monster, etc.</div>\n+                        <div class=\"text-muted\">Incoming emails create applications automatically. Use it for direct applications or when posting job opportunities on LinkedIn, Monster, etc.</div>\n                     </div>\n                 </group>\n                 <footer>"
+      },
+      {
+        "sha": "00f703de1e369f25402370b793dfa571bf0014c3",
+        "filename": "addons/hr_recruitment/views/res_config_settings_views.xml",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/cf30344a3af56b187f7de15ee1b3e543ae0066a5/addons%2Fhr_recruitment%2Fviews%2Fres_config_settings_views.xml",
+        "raw_url": "https://github.com/odoo/odoo/raw/cf30344a3af56b187f7de15ee1b3e543ae0066a5/addons%2Fhr_recruitment%2Fviews%2Fres_config_settings_views.xml",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhr_recruitment%2Fviews%2Fres_config_settings_views.xml?ref=cf30344a3af56b187f7de15ee1b3e543ae0066a5",
+        "patch": "@@ -10,7 +10,7 @@\n                 <xpath expr=\"//form\" position=\"inside\">\n                     <app data-string=\"Recruitment\" string=\"Recruitment\" name=\"hr_recruitment\" groups=\"hr_recruitment.group_hr_recruitment_manager\">\n                         <block title=\"Job Posting\" name=\"online_posting_setting_container\">\n-                            <setting id=\"publish_available_jobs_setting\" string=\"Online Posting\" help=\"Publish job offers on your website\">\n+                            <setting id=\"publish_available_jobs_setting\" string=\"Online Posting\" help=\"Publish job opportunities on your website\">\n                                 <field name=\"module_website_hr_recruitment\"/>\n                             </setting>\n                         </block>"
+      },
+      {
+        "sha": "07368c6327817b4d3c143d4172b9835ff0c03625",
+        "filename": "addons/website/data/website_data.xml",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/cf30344a3af56b187f7de15ee1b3e543ae0066a5/addons%2Fwebsite%2Fdata%2Fwebsite_data.xml",
+        "raw_url": "https://github.com/odoo/odoo/raw/cf30344a3af56b187f7de15ee1b3e543ae0066a5/addons%2Fwebsite%2Fdata%2Fwebsite_data.xml",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fdata%2Fwebsite_data.xml?ref=cf30344a3af56b187f7de15ee1b3e543ae0066a5",
+        "patch": "@@ -416,7 +416,7 @@\n     </record>\n     <record id=\"feature_module_career\" model=\"website.configurator.feature\">\n         <field name=\"name\">Career</field>\n-        <field name=\"description\">Publish job offers</field>\n+        <field name=\"description\">Publish job opportunities</field>\n         <field name=\"sequence\">8</field>\n         <field name=\"module_id\" ref=\"base.module_website_hr_recruitment\"/>\n         <field name=\"icon\">fa-address-card</field>"
+      },
+      {
+        "sha": "5bd6efd59f453330c73b3191f63f589f2e780e67",
+        "filename": "addons/website_hr_recruitment/models/hr_applicant.py",
+        "status": "modified",
+        "additions": 2,
+        "deletions": 2,
+        "changes": 4,
+        "blob_url": "https://github.com/odoo/odoo/blob/cf30344a3af56b187f7de15ee1b3e543ae0066a5/addons%2Fwebsite_hr_recruitment%2Fmodels%2Fhr_applicant.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/cf30344a3af56b187f7de15ee1b3e543ae0066a5/addons%2Fwebsite_hr_recruitment%2Fmodels%2Fhr_applicant.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite_hr_recruitment%2Fmodels%2Fhr_applicant.py?ref=cf30344a3af56b187f7de15ee1b3e543ae0066a5",
+        "patch": "@@ -1,7 +1,7 @@\n # -*- coding: utf-8 -*-\n # Part of Odoo. See LICENSE file for full copyright and licensing details.\n \n-from odoo import models, _\n+from odoo import models\n from odoo.exceptions import UserError\n \n \n@@ -12,7 +12,7 @@ def website_form_input_filter(self, request, values):\n         if values.get('job_id'):\n             job = self.env['hr.job'].browse(values.get('job_id'))\n             if not job.sudo().active:\n-                raise UserError(_(\"The job offer has been closed.\"))\n+                raise UserError(self.env._(\"The job opportunity has been closed.\"))\n             stage = self.env['hr.recruitment.stage'].sudo().search([\n                 ('fold', '=', False),\n                 '|', ('job_ids', '=', False), ('job_ids', '=', values['job_id']),"
+      },
+      {
+        "sha": "b33591478eac7c6c4aaeffc95be1eabef364b1ff",
+        "filename": "addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/cf30344a3af56b187f7de15ee1b3e543ae0066a5/addons%2Fwebsite_hr_recruitment%2Fviews%2Fwebsite_hr_recruitment_templates.xml",
+        "raw_url": "https://github.com/odoo/odoo/raw/cf30344a3af56b187f7de15ee1b3e543ae0066a5/addons%2Fwebsite_hr_recruitment%2Fviews%2Fwebsite_hr_recruitment_templates.xml",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite_hr_recruitment%2Fviews%2Fwebsite_hr_recruitment_templates.xml?ref=cf30344a3af56b187f7de15ee1b3e543ae0066a5",
+        "patch": "@@ -11,7 +11,7 @@\n             <div class=\"container oe_website_jobs\">\n                 <!-- Topbar -->\n                 <section class=\"o_wevent_index_topbar_filters d-flex d-print-none align-items-center justify-content-lg-end flex-wrap gap-2 mt-4 mb-3\">\n-                    <h1 class=\"me-auto mb-0 h4\">Our Job Offers</h1>\n+                    <h1 class=\"me-auto mb-0 h4\">Our Job Opportunities</h1>\n                     <!-- Customizations -->\n                     <t t-call=\"website_hr_recruitment.topbar_customizations\"/>\n                 </section>"
+      }
+    ],
+    "paths": [
+      "addons/website"
+    ]
+  },
+  {
+    "sha": "be0d11b9b8a9b9a077221e9f3a4aef94636fd571",
+    "node_id": "C_kwDOAS1I7NoAKGJlMGQxMWI5YjhhOWI5YTA3NzIyMWU5ZjNhNGFlZjk0NjM2ZmQ1NzE",
+    "commit": {
+      "author": {
+        "name": "Arib Ansari",
+        "email": "aans@odoo.com",
+        "date": "2025-10-08T11:37:48Z"
+      },
+      "committer": {
+        "name": "Arib Ansari",
+        "email": "aans@odoo.com",
+        "date": "2025-10-10T12:38:40Z"
+      },
+      "message": "[FIX] website: use tour helper to switch website\n\n`snippet_translation_switching_website` was previously using custom\nsteps to switch the website. Though it worked, it was not very\ndeterministic and broke the tour in a few runbot builds.\n\nThis commit updates the `snippet_translation_switching_website` tour to\nuse the `testSwitchWebsite` helper function instead of custom steps,\nproviding a more reliable and deterministic way to switch websites.\n\nrunbot-229696\n\ncloses odoo/odoo#230898\n\nX-original-commit: ac077b0cb3127f0b4a01d3aeae53dc02f774fbbc\nSigned-off-by: Francois Georis (fge) <fge@odoo.com>",
+      "tree": {
+        "sha": "07a8b03f422b8c4ada77215fde75a6b575daf7d4",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/07a8b03f422b8c4ada77215fde75a6b575daf7d4"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/be0d11b9b8a9b9a077221e9f3a4aef94636fd571",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/be0d11b9b8a9b9a077221e9f3a4aef94636fd571",
+    "html_url": "https://github.com/odoo/odoo/commit/be0d11b9b8a9b9a077221e9f3a4aef94636fd571",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/be0d11b9b8a9b9a077221e9f3a4aef94636fd571/comments",
+    "author": {
+      "login": "aans-odoo",
+      "id": 179816151,
+      "node_id": "U_kgDOCrfG1w",
+      "avatar_url": "https://avatars.githubusercontent.com/u/179816151?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/aans-odoo",
+      "html_url": "https://github.com/aans-odoo",
+      "followers_url": "https://api.github.com/users/aans-odoo/followers",
+      "following_url": "https://api.github.com/users/aans-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/aans-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/aans-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/aans-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/aans-odoo/orgs",
+      "repos_url": "https://api.github.com/users/aans-odoo/repos",
+      "events_url": "https://api.github.com/users/aans-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/aans-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "aans-odoo",
+      "id": 179816151,
+      "node_id": "U_kgDOCrfG1w",
+      "avatar_url": "https://avatars.githubusercontent.com/u/179816151?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/aans-odoo",
+      "html_url": "https://github.com/aans-odoo",
+      "followers_url": "https://api.github.com/users/aans-odoo/followers",
+      "following_url": "https://api.github.com/users/aans-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/aans-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/aans-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/aans-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/aans-odoo/orgs",
+      "repos_url": "https://api.github.com/users/aans-odoo/repos",
+      "events_url": "https://api.github.com/users/aans-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/aans-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "af291ad69a5a7befe0878d8314b81aa96e0a1a35",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/af291ad69a5a7befe0878d8314b81aa96e0a1a35",
+        "html_url": "https://github.com/odoo/odoo/commit/af291ad69a5a7befe0878d8314b81aa96e0a1a35"
+      }
+    ],
+    "stats": {
+      "total": 22,
+      "additions": 6,
+      "deletions": 16
+    },
+    "files": [
+      {
+        "sha": "6c60b470931c89fb1f6eacabfcc8000ac800d247",
+        "filename": "addons/website/static/tests/tours/snippet_translation.js",
+        "status": "modified",
+        "additions": 2,
+        "deletions": 14,
+        "changes": 16,
+        "blob_url": "https://github.com/odoo/odoo/blob/be0d11b9b8a9b9a077221e9f3a4aef94636fd571/addons%2Fwebsite%2Fstatic%2Ftests%2Ftours%2Fsnippet_translation.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/be0d11b9b8a9b9a077221e9f3a4aef94636fd571/addons%2Fwebsite%2Fstatic%2Ftests%2Ftours%2Fsnippet_translation.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Ftests%2Ftours%2Fsnippet_translation.js?ref=be0d11b9b8a9b9a077221e9f3a4aef94636fd571",
+        "patch": "@@ -6,6 +6,7 @@ import {\n     clickOnSave,\n     insertSnippet,\n     registerWebsitePreviewTour,\n+    testSwitchWebsite,\n } from '@website/js/tours/tour_utils';\n import { stepUtils } from \"@web_tour/tour_utils\";\n \n@@ -103,20 +104,7 @@ registerWebsitePreviewTour(\n                 \":iframe .s_cover .btn-outline-secondary:contains('Contact us in Parseltongue')\",\n         },\n         ...clickOnSave(),\n-        {\n-            content: \"Open website switcher dropdown\",\n-            trigger: \".o_website_switcher_container button\",\n-            run: \"click\",\n-        },\n-        {\n-            content: \"Switch to website fu_GB\",\n-            trigger: \".o-dropdown--menu .o-dropdown-item:contains('website fu_GB')\",\n-            run: \"click\",\n-        },\n-        {\n-            content: \"Wait for website fu_GB\",\n-            trigger: \":iframe .o_homepage_editor_welcome_message\",\n-        },\n+        ...testSwitchWebsite(\"website fu_GB\"),\n         ...clickOnEditAndWaitEditMode(),\n         ...insertSnippet({ id: \"s_cover\", name: \"Cover\", groupName: \"Intro\" }),\n         {"
+      },
+      {
+        "sha": "e46553f069cfbebe761ee2bc1ae0a039e0a03d36",
+        "filename": "addons/website/tests/test_ui.py",
+        "status": "modified",
+        "additions": 4,
+        "deletions": 2,
+        "changes": 6,
+        "blob_url": "https://github.com/odoo/odoo/blob/be0d11b9b8a9b9a077221e9f3a4aef94636fd571/addons%2Fwebsite%2Ftests%2Ftest_ui.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/be0d11b9b8a9b9a077221e9f3a4aef94636fd571/addons%2Fwebsite%2Ftests%2Ftest_ui.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Ftests%2Ftest_ui.py?ref=be0d11b9b8a9b9a077221e9f3a4aef94636fd571",
+        "patch": "@@ -283,15 +283,17 @@ def test_snippet_translation(self):\n             'language_ids': [(6, 0, [self.env.ref('base.lang_en').id, parseltongue.id])],\n             'default_lang_id': parseltongue.id,\n         })\n-        self.env['website'].create({\n+        website_3 = self.env['website'].create({\n             'name': 'website fu_GB',\n             'language_ids': [Command.set([fake_user_lang.id])],\n             'default_lang_id': fake_user_lang.id,\n         })\n \n         self.start_tour(f\"/website/force/{website.id}\", 'snippet_translation', login='admin')\n         self.start_tour(f\"/website/force/{website_2.id}\", 'snippet_translation_changing_lang', login='admin')\n-        self.start_tour(f\"/website/force/{website_2.id}\", 'snippet_translation_switching_website', login='admin')\n+        self.start_tour(f\"/website/force/{website_2.id}\", 'snippet_translation_switching_website', login='admin', cookies={\n+            'websiteIdMapping': json.dumps({website_3.name: website_3.id})\n+        })\n         self.start_tour(f\"/website/force/{website.id}\", 'snippet_dialog_rtl', login='admin')\n \n "
+      }
+    ],
+    "paths": [
+      "addons/website"
+    ]
+  },
+  {
+    "sha": "af291ad69a5a7befe0878d8314b81aa96e0a1a35",
+    "node_id": "C_kwDOAS1I7NoAKGFmMjkxYWQ2OWE1YTdiZWZlMDg3OGQ4MzE0YjgxYWE5NmUwYTFhMzU",
+    "commit": {
+      "author": {
+        "name": "sben-odoo",
+        "email": "sben@odoo.com",
+        "date": "2025-10-07T11:49:23Z"
+      },
+      "committer": {
+        "name": "sben-odoo",
+        "email": "sben@odoo.com",
+        "date": "2025-10-10T12:38:38Z"
+      },
+      "message": "[FIX] website: limit SVG width in highlighted text to prevent overflow\n\nSteps to reproduce:\n====================\n1. Open Website Builder and switch to mobile screen\n2. Select any word of a text\n3. Apply highlight and animation\n\nBug:\n- Page becomes scrollable to the right\n\nCause:\n=======\nSVG elements default to a `300px` `width`, which can overflow on\nsmaller screens (e.g. mobile). This commit sets a `width` to\nprevent horizontal overflow. This is the link for the same issue but\nfor vertical overflow.\nhttps://github.com/odoo/odoo/pull/215826\n\nReference:\nhttps://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/width\n\nopw-5120678\n\ncloses odoo/odoo#230900\n\nX-original-commit: 69ef0a2a35c84da0635da55099ead3832e2cc474\nSigned-off-by: Outagant Mehdi (mou) <mou@odoo.com>\nSigned-off-by: Saif Allah Ben Khalil (sben) <sben@odoo.com>",
+      "tree": {
+        "sha": "e6dcd98a2d1f4c61c673fb511821f6c8dc00b799",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/e6dcd98a2d1f4c61c673fb511821f6c8dc00b799"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/af291ad69a5a7befe0878d8314b81aa96e0a1a35",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/af291ad69a5a7befe0878d8314b81aa96e0a1a35",
+    "html_url": "https://github.com/odoo/odoo/commit/af291ad69a5a7befe0878d8314b81aa96e0a1a35",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/af291ad69a5a7befe0878d8314b81aa96e0a1a35/comments",
+    "author": {
+      "login": "sben-odoo",
+      "id": 208037942,
+      "node_id": "U_kgDODGZoNg",
+      "avatar_url": "https://avatars.githubusercontent.com/u/208037942?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/sben-odoo",
+      "html_url": "https://github.com/sben-odoo",
+      "followers_url": "https://api.github.com/users/sben-odoo/followers",
+      "following_url": "https://api.github.com/users/sben-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/sben-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/sben-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/sben-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/sben-odoo/orgs",
+      "repos_url": "https://api.github.com/users/sben-odoo/repos",
+      "events_url": "https://api.github.com/users/sben-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/sben-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "sben-odoo",
+      "id": 208037942,
+      "node_id": "U_kgDODGZoNg",
+      "avatar_url": "https://avatars.githubusercontent.com/u/208037942?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/sben-odoo",
+      "html_url": "https://github.com/sben-odoo",
+      "followers_url": "https://api.github.com/users/sben-odoo/followers",
+      "following_url": "https://api.github.com/users/sben-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/sben-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/sben-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/sben-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/sben-odoo/orgs",
+      "repos_url": "https://api.github.com/users/sben-odoo/repos",
+      "events_url": "https://api.github.com/users/sben-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/sben-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "1098d6b925cc4f647d0676f1e5e24801891d3105",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/1098d6b925cc4f647d0676f1e5e24801891d3105",
+        "html_url": "https://github.com/odoo/odoo/commit/1098d6b925cc4f647d0676f1e5e24801891d3105"
+      }
+    ],
+    "stats": {
+      "total": 1,
+      "additions": 1,
+      "deletions": 0
+    },
+    "files": [
+      {
+        "sha": "354e15d26faa6533807dae614a4270886eb19bf8",
+        "filename": "addons/website/static/src/scss/website_common.scss",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 0,
+        "changes": 1,
+        "blob_url": "https://github.com/odoo/odoo/blob/af291ad69a5a7befe0878d8314b81aa96e0a1a35/addons%2Fwebsite%2Fstatic%2Fsrc%2Fscss%2Fwebsite_common.scss",
+        "raw_url": "https://github.com/odoo/odoo/raw/af291ad69a5a7befe0878d8314b81aa96e0a1a35/addons%2Fwebsite%2Fstatic%2Fsrc%2Fscss%2Fwebsite_common.scss",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fscss%2Fwebsite_common.scss?ref=af291ad69a5a7befe0878d8314b81aa96e0a1a35",
+        "patch": "@@ -13,5 +13,6 @@\n     svg {\n         z-index: -1;\n         height: 1px;\n+        width: 1px;\n     }\n }"
+      }
+    ],
+    "paths": [
+      "addons/website"
+    ]
+  },
+  {
+    "sha": "4f87601c5c81df6cdcbbfc9d9364f684ecc1cfae",
+    "node_id": "C_kwDOAS1I7NoAKDRmODc2MDFjNWM4MWRmNmNkY2JiZmM5ZDkzNjRmNjg0ZWNjMWNmYWU",
+    "commit": {
+      "author": {
+        "name": "Jinjiu Liu",
+        "email": "jili@odoo.com",
+        "date": "2025-08-20T08:27:40Z"
+      },
+      "committer": {
+        "name": "Jinjiu Liu",
+        "email": "jili@odoo.com",
+        "date": "2025-10-10T08:58:02Z"
+      },
+      "message": "[FIX] website: prefix frontend url only when in website\n\nBefore this commit: we have the function in website to prefix a frontend url\nwith `@` when clicking on the url in linkpopover. However, this function is\nusually used inside website. It also affects places where the url is an\ninternal redirecting url like `/knowledge/article/33` and prefixing will lead\nto the website homepage.\n\nAfter this commit: we also check if the current url of the browser is also a\nfrontend url, which means the user is inside the website app. Frontend links\nwill not be prefixed in the backend pages, e.g. in all other apps except for\nwebsite. The website patch doesn't influence public users as they won't have\naccess to the website app anyways.\n\ntask-5048403\n\ncloses odoo/odoo#230899\n\nX-original-commit: f1427707e67c769adae403bcb0335ec3c2ffcadd\nSigned-off-by: Benoit Socias (bso) <bso@odoo.com>\nSigned-off-by: Jinjiu Liu (jili) <jili@odoo.com>",
+      "tree": {
+        "sha": "f3ed5ccc350c8a73da31109cbcecf2b790ed32af",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/f3ed5ccc350c8a73da31109cbcecf2b790ed32af"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/4f87601c5c81df6cdcbbfc9d9364f684ecc1cfae",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/4f87601c5c81df6cdcbbfc9d9364f684ecc1cfae",
+    "html_url": "https://github.com/odoo/odoo/commit/4f87601c5c81df6cdcbbfc9d9364f684ecc1cfae",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/4f87601c5c81df6cdcbbfc9d9364f684ecc1cfae/comments",
+    "author": {
+      "login": "Jinjiu96",
+      "id": 23055668,
+      "node_id": "MDQ6VXNlcjIzMDU1NjY4",
+      "avatar_url": "https://avatars.githubusercontent.com/u/23055668?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/Jinjiu96",
+      "html_url": "https://github.com/Jinjiu96",
+      "followers_url": "https://api.github.com/users/Jinjiu96/followers",
+      "following_url": "https://api.github.com/users/Jinjiu96/following{/other_user}",
+      "gists_url": "https://api.github.com/users/Jinjiu96/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/Jinjiu96/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/Jinjiu96/subscriptions",
+      "organizations_url": "https://api.github.com/users/Jinjiu96/orgs",
+      "repos_url": "https://api.github.com/users/Jinjiu96/repos",
+      "events_url": "https://api.github.com/users/Jinjiu96/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/Jinjiu96/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "Jinjiu96",
+      "id": 23055668,
+      "node_id": "MDQ6VXNlcjIzMDU1NjY4",
+      "avatar_url": "https://avatars.githubusercontent.com/u/23055668?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/Jinjiu96",
+      "html_url": "https://github.com/Jinjiu96",
+      "followers_url": "https://api.github.com/users/Jinjiu96/followers",
+      "following_url": "https://api.github.com/users/Jinjiu96/following{/other_user}",
+      "gists_url": "https://api.github.com/users/Jinjiu96/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/Jinjiu96/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/Jinjiu96/subscriptions",
+      "organizations_url": "https://api.github.com/users/Jinjiu96/orgs",
+      "repos_url": "https://api.github.com/users/Jinjiu96/repos",
+      "events_url": "https://api.github.com/users/Jinjiu96/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/Jinjiu96/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "d12da17dd16a22e140b7c1bd3e028a8d90ab8534",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/d12da17dd16a22e140b7c1bd3e028a8d90ab8534",
+        "html_url": "https://github.com/odoo/odoo/commit/d12da17dd16a22e140b7c1bd3e028a8d90ab8534"
+      }
+    ],
+    "stats": {
+      "total": 42,
+      "additions": 38,
+      "deletions": 4
+    },
+    "files": [
+      {
+        "sha": "77bb5b92d2b907ebcffee5991ab07b74d88f8a43",
+        "filename": "addons/website/static/src/js/editor/html_editor.js",
+        "status": "modified",
+        "additions": 15,
+        "deletions": 4,
+        "changes": 19,
+        "blob_url": "https://github.com/odoo/odoo/blob/4f87601c5c81df6cdcbbfc9d9364f684ecc1cfae/addons%2Fwebsite%2Fstatic%2Fsrc%2Fjs%2Feditor%2Fhtml_editor.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/4f87601c5c81df6cdcbbfc9d9364f684ecc1cfae/addons%2Fwebsite%2Fstatic%2Fsrc%2Fjs%2Feditor%2Fhtml_editor.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fjs%2Feditor%2Fhtml_editor.js?ref=4f87601c5c81df6cdcbbfc9d9364f684ecc1cfae",
+        "patch": "@@ -7,6 +7,7 @@ import { useChildRef } from \"@web/core/utils/hooks\";\n import wUtils from \"@website/js/utils\";\n import { useEffect } from \"@odoo/owl\";\n import { browser } from \"@web/core/browser/browser\";\n+import { session } from \"@web/session\";\n \n /**\n  * The goal of this patch is to handle the URL autocomplete in the LinkPopover\n@@ -139,14 +140,24 @@ patch(LinkPopover.prototype, {\n             this.onChange();\n         }\n     },\n+    isFrontendUrl(url) {\n+        const parsedUrl = new URL(url);\n+        return (\n+            (browser.location.hostname === parsedUrl.hostname ||\n+                // Also check if the odoo-hosted domain is the current domain of the url\n+                new RegExp(`^https?://${session.db}\\\\.odoo\\\\.com(/.*)?$`).test(parsedUrl.origin)) &&\n+            !parsedUrl.pathname.startsWith(\"/odoo\") &&\n+            !parsedUrl.pathname.startsWith(\"/web\") &&\n+            !parsedUrl.pathname.startsWith(\"/@/\")\n+        );\n+    },\n     onClickForcePreviewMode(ev) {\n         if (this.props.linkElement.href) {\n             const currentUrl = new URL(this.props.linkElement.href);\n+            // only when we are on a frontend page (in website builder) and the link is also a frontend link\n             if (\n-                browser.location.hostname === currentUrl.hostname &&\n-                !currentUrl.pathname.startsWith(\"/odoo\") &&\n-                !currentUrl.pathname.startsWith(\"/web\") &&\n-                !currentUrl.pathname.startsWith(\"/@/\")\n+                this.isFrontendUrl(browser.location.href) &&\n+                this.isFrontendUrl(this.props.linkElement.href)\n             ) {\n                 ev.preventDefault();\n                 currentUrl.pathname = `/@${currentUrl.pathname}`;"
+      },
+      {
+        "sha": "571cf70d836e14012ed206e4a841334e8f88ffe2",
+        "filename": "addons/website/static/tests/builder/linkpopover_website.test.js",
+        "status": "modified",
+        "additions": 23,
+        "deletions": 0,
+        "changes": 23,
+        "blob_url": "https://github.com/odoo/odoo/blob/4f87601c5c81df6cdcbbfc9d9364f684ecc1cfae/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Flinkpopover_website.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/4f87601c5c81df6cdcbbfc9d9364f684ecc1cfae/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Flinkpopover_website.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Flinkpopover_website.test.js?ref=4f87601c5c81df6cdcbbfc9d9364f684ecc1cfae",
+        "patch": "@@ -218,3 +218,26 @@ test(\"link redirection should be prefixed for url of website pages only\", async\n     await click(\".o-we-linkpopover a\");\n     expect.verifySteps([]);\n });\n+\n+test(\"link redirection should not be prefixed when the current page is not a website page\", async () => {\n+    patchWithCleanup(browser, {\n+        open(url) {\n+            expect.step(\"website page url prefixed\");\n+            expect(url.pathname.startsWith(\"/@\")).toBe(true);\n+        },\n+        location: {\n+            // simulating being on a non-website page (eg. backend) by using /odoo/ URL\n+            href: browser.location.origin + \"/odoo/contactus\",\n+            hostname: browser.location.hostname,\n+        },\n+    });\n+    onRpc(\"/html_editor/link_preview_internal\", () => ({}));\n+    onRpc(\"/contactus\", () => ({}));\n+\n+    // website pages should not be prefixed with /@\n+    await setupEditor('<p>this is a <a href=\"/contactus\">li[]nk</a></p>');\n+    await waitFor(\".o-we-linkpopover\");\n+    await click(\".o-we-linkpopover a\");\n+    // the open method should not be called from onClickForcePreviewMode\n+    expect.verifySteps([]);\n+});"
+      }
+    ],
+    "paths": [
+      "addons/website"
+    ]
+  },
+  {
+    "sha": "a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8",
+    "node_id": "C_kwDOAS1I7NoAKGE1YzAyZGE1YzI0YmZjODViM2JiYjdkMTQxMGQ0ODlkM2M3MTg1Yjg",
+    "commit": {
+      "author": {
+        "name": "qsm-odoo",
+        "email": "qsm@odoo.com",
+        "date": "2025-09-05T15:14:27Z"
+      },
+      "committer": {
+        "name": "Benoit Socias (bso)",
+        "email": "bso@odoo.com",
+        "date": "2025-10-09T20:33:51Z"
+      },
+      "message": "[IMP] base, web, *: introduce binary asset bundle for font-faces\n\n*: test_website, tools, website\n\nBy default, static content has a one week expiration (`STATIC_CACHE`),\nbut if identified through unique URLs, that expiration is one year\n(`STATIC_CACHE_LONG`).\nBecause of this, fonts which are referenced through URLs such as\n`/web/static/src/libs/fontawesome/fonts/fontawesome-webfont.woff2`\ndo expire every week.\n\nThe goal of this commit is to make such static fonts published through\nan asset bundle so that the URL becomes unique according the binary\nfile content, and therefore expires only after one year, or right away\nif the binary changed.\n(e.g.`/web/assets/1/17f9647/web.fonts_fontawesome2.min.woff2`)\n\nTo achieve this, this commit does the following:\n- support binaries inside asset bundles - which for the time being can\n  only be woff or woff2 - maximum one of each.\n- when binaries are defined before css in a bundle, their path is\n  replaced inside the css.\n- `t-call-asset` support `binary=\"True\"` which return the first defined\n  binary file inside the asset bundle (as a `<link rel=\"preload\">`).\n\nThe feature is enabled for font-awesome and odoo_ui_icons, regrouped in\none bundle (note that [1] actually recently make some FA classes use\nour odoo_ui_icons font, so it makes even more sense).\nAlthough, as a first step, this commit only takes profit of the feature\nfor those icon fonts only for the frontend assets bundle. A follow-up PR\nwill be made to do it for all assets (see [2]).\n\nNote that with the addition of two non-private fonts assets bundles in\n`web.assets_backend`, new cache entries are added when generating it.\nTests had to be adapted to the expected counts.\n\n[1]: https://github.com/odoo/odoo/commit/23ffe210a3307db3d0dd642744a9e13cab732222\n[2]: https://github.com/odoo/odoo/pull/225760\n\ntask-5046274\n\ncloses odoo/odoo#224663\n\nSigned-off-by: Quentin Smetz (qsm) <qsm@odoo.com>",
+      "tree": {
+        "sha": "239f3602e5cc1893948c9194d34d5e36f5e1e4f3",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/239f3602e5cc1893948c9194d34d5e36f5e1e4f3"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8",
+      "comment_count": 1,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8",
+    "html_url": "https://github.com/odoo/odoo/commit/a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8/comments",
+    "author": {
+      "login": "qsm-odoo",
+      "id": 10338094,
+      "node_id": "MDQ6VXNlcjEwMzM4MDk0",
+      "avatar_url": "https://avatars.githubusercontent.com/u/10338094?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/qsm-odoo",
+      "html_url": "https://github.com/qsm-odoo",
+      "followers_url": "https://api.github.com/users/qsm-odoo/followers",
+      "following_url": "https://api.github.com/users/qsm-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/qsm-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/qsm-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/qsm-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/qsm-odoo/orgs",
+      "repos_url": "https://api.github.com/users/qsm-odoo/repos",
+      "events_url": "https://api.github.com/users/qsm-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/qsm-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "bso-odoo",
+      "id": 71644421,
+      "node_id": "MDQ6VXNlcjcxNjQ0NDIx",
+      "avatar_url": "https://avatars.githubusercontent.com/u/71644421?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/bso-odoo",
+      "html_url": "https://github.com/bso-odoo",
+      "followers_url": "https://api.github.com/users/bso-odoo/followers",
+      "following_url": "https://api.github.com/users/bso-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/bso-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/bso-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/bso-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/bso-odoo/orgs",
+      "repos_url": "https://api.github.com/users/bso-odoo/repos",
+      "events_url": "https://api.github.com/users/bso-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/bso-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "ceee33f59606f767cff1dc32581f57353c5df6fe",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/ceee33f59606f767cff1dc32581f57353c5df6fe",
+        "html_url": "https://github.com/odoo/odoo/commit/ceee33f59606f767cff1dc32581f57353c5df6fe"
+      }
+    ],
+    "stats": {
+      "total": 254,
+      "additions": 211,
+      "deletions": 43
+    },
+    "files": [
+      {
+        "sha": "d78ca02a9f86112b9b41f180d3ec3a8911d5aa8a",
+        "filename": "addons/test_website/__manifest__.py",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8/addons%2Ftest_website%2F__manifest__.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8/addons%2Ftest_website%2F__manifest__.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Ftest_website%2F__manifest__.py?ref=a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8",
+        "patch": "@@ -32,7 +32,7 @@\n     'assets': {\n         'test_website.test_bundle': [\n             'http://test.external.link/javascript1.js',\n-            '/web/static/src/libs/fontawesome/css/font-awesome.css',\n+            ('include', 'web.icons_fonts'),\n             'http://test.external.link/style1.css',\n             '/web/static/src/module_loader.js',\n             'http://test.external.link/javascript2.js',"
+      },
+      {
+        "sha": "f434a49c2982670965ad77e05b36c0f732db4d6c",
+        "filename": "addons/web/__manifest__.py",
+        "status": "modified",
+        "additions": 19,
+        "deletions": 3,
+        "changes": 22,
+        "blob_url": "https://github.com/odoo/odoo/blob/a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8/addons%2Fweb%2F__manifest__.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8/addons%2Fweb%2F__manifest__.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fweb%2F__manifest__.py?ref=a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8",
+        "patch": "@@ -179,12 +179,10 @@\n \n             ('include', 'web._assets_bootstrap_frontend'),\n \n-            'web/static/src/libs/fontawesome/css/font-awesome.css',\n-            'web/static/lib/odoo_ui_icons/*',\n+            ('include', 'web.icons_fonts'),\n             'web/static/src/webclient/navbar/navbar.scss',\n             'web/static/src/scss/animation.scss',\n             'web/static/src/scss/base_frontend.scss',\n-            'web/static/src/scss/fontawesome_overridden.scss',\n             'web/static/src/scss/mimetypes.scss',\n             'web/static/src/scss/ui.scss',\n             'web/static/src/views/fields/translation_dialog.scss',\n@@ -535,6 +533,24 @@\n             '/web/static/lib/fullcalendar/timegrid/index.global.js',\n             '/web/static/lib/fullcalendar/list/index.global.js',\n         ],\n+        # Icons bundles: font-awesome, odoo_ui_icons and both combined. Only the\n+        # combination should probably be used. But it is split to allow FA\n+        # preload on the frontend.\n+        'web.fontawesome': [\n+            '/web/static/src/libs/fontawesome/fonts/fontawesome-webfont.woff2',\n+            '/web/static/src/libs/fontawesome/fonts/fontawesome-webfont.woff',\n+            '/web/static/src/libs/fontawesome/css/font-awesome.css',\n+        ],\n+        'web.odoo_ui_icons': [\n+            '/web/static/lib/odoo_ui_icons/fonts/odoo_ui_icons.woff2',\n+            '/web/static/lib/odoo_ui_icons/fonts/odoo_ui_icons.woff',\n+            '/web/static/lib/odoo_ui_icons/style.css',\n+        ],\n+        'web.icons_fonts': [\n+            ('include', 'web.fontawesome'),\n+            ('include', 'web.odoo_ui_icons'),\n+            'web/static/src/scss/fontawesome_overridden.scss',  # some are fa classes... but using odoo_ui_icons font\n+        ],\n     },\n     'bootstrap': True,  # load translations for login screen,\n     'author': 'Odoo S.A.',"
+      },
+      {
+        "sha": "f20f7c0fd5403824b71f251fdc108d2b367e71a7",
+        "filename": "addons/web/controllers/binary.py",
+        "status": "modified",
+        "additions": 7,
+        "deletions": 1,
+        "changes": 8,
+        "blob_url": "https://github.com/odoo/odoo/blob/a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8/addons%2Fweb%2Fcontrollers%2Fbinary.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8/addons%2Fweb%2Fcontrollers%2Fbinary.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fweb%2Fcontrollers%2Fbinary.py?ref=a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8",
+        "patch": "@@ -126,22 +126,28 @@ def content_assets(self, filename=None, unique=ANY_UNIQUE, nocache=False, assets\n                     bundle_name, rtl, asset_type, autoprefix = rw_env['ir.asset']._parse_bundle_name(filename, debug_assets)\n                     css = asset_type == 'css'\n                     js = asset_type == 'js'\n+                    binary = asset_type == 'binary'\n+                    extension = '' if '.' not in filename else filename.split('.')[-1]\n                     bundle = rw_env['ir.qweb']._get_asset_bundle(\n                         bundle_name,\n                         css=css,\n                         js=js,\n+                        binary=binary,\n                         debug_assets=debug_assets,\n                         rtl=rtl,\n                         autoprefix=autoprefix,\n                         assets_params=assets_params,\n                     )\n                     # check if the version matches. If not, redirect to the last version\n-                    if not debug_assets and unique != ANY_UNIQUE and unique != bundle.get_version(asset_type):\n+                    if not debug_assets and unique != ANY_UNIQUE \\\n+                            and unique != bundle.get_version(extension if binary else asset_type):\n                         return request.redirect(bundle.get_link(asset_type))\n                     if css and bundle.stylesheets:\n                         attachment = env['ir.attachment'].sudo().browse(bundle.css().id)\n                     elif js and bundle.javascripts:\n                         attachment = env['ir.attachment'].sudo().browse(bundle.js().id)\n+                    elif binary and bundle.binaries:\n+                        attachment = env['ir.attachment'].sudo().browse(bundle.bin(extension).id)\n                 except ValueError as e:\n                     _logger.warning(\"Parsing asset bundle %s has failed: %s\", filename, e)\n                     raise request.not_found() from e"
+      },
+      {
+        "sha": "96320e4a9cbcc23e57718d93793e6e7b01ae6b54",
+        "filename": "addons/web/static/lib/odoo_ui_icons/style.css",
+        "status": "modified",
+        "additions": 3,
+        "deletions": 1,
+        "changes": 4,
+        "blob_url": "https://github.com/odoo/odoo/blob/a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8/addons%2Fweb%2Fstatic%2Flib%2Fodoo_ui_icons%2Fstyle.css",
+        "raw_url": "https://github.com/odoo/odoo/raw/a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8/addons%2Fweb%2Fstatic%2Flib%2Fodoo_ui_icons%2Fstyle.css",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fweb%2Fstatic%2Flib%2Fodoo_ui_icons%2Fstyle.css?ref=a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8",
+        "patch": "@@ -1,6 +1,8 @@\n @font-face {\n   font-family: 'odoo_ui_icons';\n-  src: url('fonts/odoo_ui_icons.woff2') format('woff2'), url('fonts/odoo_ui_icons.woff') format('woff');\n+  src: /* see web.odoo_ui_icons asset */\n+    url('/web/static/lib/odoo_ui_icons/fonts/odoo_ui_icons.woff2') format('woff2'),\n+    url('/web/static/lib/odoo_ui_icons/fonts/odoo_ui_icons.woff') format('woff');\n   font-weight: normal;\n   font-style: normal;\n   font-display: block;"
+      },
+      {
+        "sha": "8820b70bbb2987d5dfa2e91f86d77cf4ea0a7628",
+        "filename": "addons/web/static/src/libs/fontawesome/css/font-awesome.css",
+        "status": "modified",
+        "additions": 3,
+        "deletions": 1,
+        "changes": 4,
+        "blob_url": "https://github.com/odoo/odoo/blob/a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8/addons%2Fweb%2Fstatic%2Fsrc%2Flibs%2Ffontawesome%2Fcss%2Ffont-awesome.css",
+        "raw_url": "https://github.com/odoo/odoo/raw/a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8/addons%2Fweb%2Fstatic%2Fsrc%2Flibs%2Ffontawesome%2Fcss%2Ffont-awesome.css",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fweb%2Fstatic%2Fsrc%2Flibs%2Ffontawesome%2Fcss%2Ffont-awesome.css?ref=a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8",
+        "patch": "@@ -6,7 +6,9 @@\n  * -------------------------- */\n @font-face {\n   font-family: 'FontAwesome';\n-  src: url('../fonts/fontawesome-webfont.woff2?v=4.7.0') format('woff2'), url('../fonts/fontawesome-webfont.woff?v=4.7.0') format('woff');\n+  src: /* see web.fontawesome asset */\n+    url('/web/static/src/libs/fontawesome/fonts/fontawesome-webfont.woff2') format('woff2'),\n+    url('/web/static/src/libs/fontawesome/fonts/fontawesome-webfont.woff') format('woff');\n   font-weight: normal;\n   font-style: normal;\n   font-display: block;"
+      },
+      {
+        "sha": "18837503e572cd97c4a6b2654224947f0b93c97f",
+        "filename": "addons/web/views/webclient_templates.xml",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8/addons%2Fweb%2Fviews%2Fwebclient_templates.xml",
+        "raw_url": "https://github.com/odoo/odoo/raw/a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8/addons%2Fweb%2Fviews%2Fwebclient_templates.xml",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fweb%2Fviews%2Fwebclient_templates.xml?ref=a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8",
+        "patch": "@@ -40,7 +40,7 @@\n         <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"/>\n       </xpath>\n       <xpath expr=\"//head/link[last()]\" position=\"after\">\n-        <link rel=\"preload\" href=\"/web/static/src/libs/fontawesome/fonts/fontawesome-webfont.woff2?v=4.7.0\" as=\"font\" crossorigin=\"\"/>\n+        <t t-call-assets=\"web.fontawesome\" t-binary=\"True\"/>\n         <t t-call-assets=\"web.assets_frontend\" t-js=\"false\"/>\n       </xpath>\n       <xpath expr=\"//head/script[@id='web.layout.odooscript']\" position=\"after\">"
+      },
+      {
+        "sha": "944cf6f67b724a124da5a60efc028e78a52e0e22",
+        "filename": "addons/website/tests/test_assets.py",
+        "status": "modified",
+        "additions": 34,
+        "deletions": 0,
+        "changes": 34,
+        "blob_url": "https://github.com/odoo/odoo/blob/a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8/addons%2Fwebsite%2Ftests%2Ftest_assets.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8/addons%2Fwebsite%2Ftests%2Ftest_assets.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Ftests%2Ftest_assets.py?ref=a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8",
+        "patch": "@@ -136,6 +136,40 @@ def test_invalid_unlink(self):\n         no_website_bundle.css()\n         self.assertTrue(website_attach.exists(), 'attachment for website should still exist after generating attachment for no website')\n \n+    def test_binary_asset_neutral(self):\n+        # Verify that CSS contains link to binary asset\n+        css = self.url_open('/web/assets/_______/web.assets_frontend.min.css').text\n+        self.assertNotIn('''/web/static/src/libs/fontawesome/fonts/fontawesome-webfont.woff''', css, \"Fonts should have been replaced\")\n+        fontface = re.findall(r'''@font-face{font-family: 'FontAwesome'; src: url\\(\"/web/assets/\\w{7}/web.fontawesome.min.woff2\"\\) format\\('woff2'\\), url\\(\"/web/assets/\\w{7}/web.fontawesome.min.woff\"\\) format\\('woff'\\);''', css)\n+        self.assertTrue(fontface, \"Font should have been replaced\")\n+        # Verify that links actually return expected binary\n+        font = self.url_open('/web/assets/_______/web.fontawesome.min.woff2')\n+        self.assertEqual('font/woff2', font.headers.get('Content-Type'), \"Should be woff2\")\n+        self.assertEqual(b'wOF2', font.content[:4])\n+        font = self.url_open('/web/assets/_______/web.fontawesome.min.woff')\n+        self.assertEqual('font/woff', font.headers.get('Content-Type'), \"Should be woff\")\n+        self.assertEqual(b'wOFF', font.content[:4])\n+\n+    def test_binary_asset_website(self):\n+        # Make website 1's CSS distinct from base one\n+        self.env['website.assets'].with_context(website_id=1).make_scss_customization(\n+            '/website/static/src/scss/options/colors/user_color_palette.scss',\n+            {\"o-cc1-bg\": \"'400'\"},\n+        )\n+\n+        # Verify that CSS contains link to binary asset\n+        css = self.url_open('/web/assets/1/_______/web.assets_frontend.min.css').text\n+        self.assertNotIn('''/web/static/src/libs/fontawesome/fonts/fontawesome-webfont.woff''', css, \"Fonts should have been replaced\")\n+        fontface = re.findall(r'''@font-face{font-family: 'FontAwesome'; src: url\\(\"/web/assets/1/\\w{7}/web.fontawesome.min.woff2\"\\) format\\('woff2'\\), url\\(\"/web/assets/1/\\w{7}/web.fontawesome.min.woff\"\\) format\\('woff'\\);''', css)\n+        self.assertTrue(fontface, \"Font should have been replaced\")\n+        # Verify that links actually return expected binary\n+        font = self.url_open('/web/assets/1/_______/web.fontawesome.min.woff2')\n+        self.assertEqual('font/woff2', font.headers.get('Content-Type'), \"Should be woff2\")\n+        self.assertEqual(b'wOF2', font.content[:4])\n+        font = self.url_open('/web/assets/1/_______/web.fontawesome.min.woff')\n+        self.assertEqual('font/woff', font.headers.get('Content-Type'), \"Should be woff\")\n+        self.assertEqual(b'wOFF', font.content[:4])\n+\n \n @odoo.tests.tagged('-at_install', 'post_install')\n class TestWebAssets(odoo.tests.HttpCase):"
+      },
+      {
+        "sha": "af1b372205e5e08f81b69ce95e99d31f67bdb221",
+        "filename": "odoo/addons/base/models/assetsbundle.py",
+        "status": "modified",
+        "additions": 103,
+        "deletions": 13,
+        "changes": 116,
+        "blob_url": "https://github.com/odoo/odoo/blob/a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8/odoo%2Faddons%2Fbase%2Fmodels%2Fassetsbundle.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8/odoo%2Faddons%2Fbase%2Fmodels%2Fassetsbundle.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/odoo%2Faddons%2Fbase%2Fmodels%2Fassetsbundle.py?ref=a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8",
+        "patch": "@@ -6,7 +6,7 @@\n import re\n import textwrap\n import uuid\n-from collections import OrderedDict\n+from collections import OrderedDict, defaultdict\n from contextlib import closing\n from subprocess import Popen, PIPE\n \n@@ -17,7 +17,7 @@\n from odoo.api import SUPERUSER_ID\n from odoo.http import request\n from odoo.tools import OrderedSet, misc, profiler\n-from odoo.tools.constants import SCRIPT_EXTENSIONS, STYLE_EXTENSIONS\n+from odoo.tools.constants import SCRIPT_EXTENSIONS, STYLE_EXTENSIONS, BINARY_EXTENSIONS\n from odoo.tools.json import scriptsafe as json\n from odoo.tools.misc import file_open, file_path\n \n@@ -45,32 +45,36 @@ class AssetsBundle(object):\n \n     TRACKED_BUNDLES = ['web.assets_web']\n \n-    def __init__(self, name, files, external_assets=(), env=None, css=True, js=True, debug_assets=False, rtl=False, assets_params=None, autoprefix=False):\n+    def __init__(self, name, files, external_assets=(), env=None, css=True, js=True, binary=False, debug_assets=False, rtl=False, assets_params=None, autoprefix=False):\n         \"\"\"\n         :param name: bundle name\n         :param files: files to be added to the bundle\n         :param css: if css is True, the stylesheets files are added to the bundle\n         :param js: if js is True, the javascript files are added to the bundle\n+        :param binary: if binary is True, the bundle IS the first file of the bundle\n         \"\"\"\n         self.name = name\n         self.env = request.env if env is None else env\n         self.javascripts = []\n         self.templates = []\n         self.stylesheets = []\n+        self.binaries = []\n         self.css_errors = []\n         self.files = files\n         self.rtl = rtl\n         self.assets_params = assets_params or {}\n         self.autoprefix = autoprefix\n         self.has_css = css\n         self.has_js = js\n+        self.has_binary = binary\n         self._checksum_cache = {}\n         self.is_debug_assets = debug_assets\n         self.external_assets = [\n             url\n             for url in external_assets\n             if (css and url.rpartition('.')[2] in STYLE_EXTENSIONS) or (js and url.rpartition('.')[2] in SCRIPT_EXTENSIONS)\n         ]\n+        css_urls = None\n \n         # asset-wide html \"media\" attribute\n         for f in files:\n@@ -81,11 +85,24 @@ def __init__(self, name, files, external_assets=(), env=None, css=True, js=True,\n                 'inline': f['content'],\n                 'last_modified': None if self.is_debug_assets else f.get('last_modified'),\n             }\n-            if css:\n+            if css and not binary and extension in STYLE_EXTENSIONS:\n+                if css_urls is None and self.binaries:\n+                    # Required binaries must be BEFORE *css inside bundle\n+                    css_urls = {}\n+                    definition_bundles = defaultdict(list)\n+                    for bin in self.binaries:\n+                        definition_bundles[bin.definition_bundle].append(bin)\n+                    for definition_bundle, bins in definition_bundles.items():\n+                        links = self.env['ir.qweb'].with_context(**self.assets_params)._get_asset_links(definition_bundle, binary=True)\n+                        for link, bin in zip(links, bins):\n+                            css_urls.setdefault(bin.name, link)\n+\n                 css_params = {\n                     'rtl': self.rtl,\n                     'autoprefix': self.autoprefix,\n+                    'css_urls': css_urls or {},\n                 }\n+\n                 if extension == 'sass':\n                     self.stylesheets.append(SassStylesheetAsset(self, **params, **css_params))\n                 elif extension == 'scss':\n@@ -99,13 +116,24 @@ def __init__(self, name, files, external_assets=(), env=None, css=True, js=True,\n                     self.javascripts.append(JavascriptAsset(self, **params))\n                 elif extension == 'xml':\n                     self.templates.append(XMLAsset(self, **params))\n+            if (css or binary) and extension in BINARY_EXTENSIONS:\n+                self.binaries.append(BinaryAsset(self, definition_bundle=f['definition_bundle'], **params))\n+                # Mapping needs to be recomputed upon encountering new binaries\n+                css_urls = None\n+        if self.has_binary and not self.binaries:\n+            _logger.warning(\"Binary asset bundles requires a binary file: %r\", BINARY_EXTENSIONS)\n \n     def get_links(self):\n         \"\"\"\n         :returns a list of tuple. a tuple can be (url, None) or (None, inlineContent)\n         \"\"\"\n         response = []\n \n+        if self.has_binary:\n+            for bin in self.binaries:\n+                response.append(self.get_link(bin.extension))\n+            return response\n+\n         if self.has_css and self.stylesheets:\n             response.append(self.get_link('css'))\n \n@@ -129,9 +157,14 @@ def get_checksum(self, asset_type):\n         \"\"\"\n         if asset_type not in self._checksum_cache:\n             if asset_type == 'css':\n-                assets = self.stylesheets\n+                assets = self.stylesheets + self.binaries\n             elif asset_type == 'js':\n                 assets = self.javascripts + self.templates\n+            elif self.has_binary:\n+                for binary in self.binaries:\n+                    if binary.extension == asset_type:\n+                        assets = [binary]\n+                        break\n             else:\n                 raise ValueError(f'Asset type {asset_type} not known')\n \n@@ -208,7 +241,8 @@ def get_attachments(self, extension, ignore_version=False):\n                                else: the url contains a version equal to that of the self.get_version(type)\n                                 => web/assets/self.get_version(type)/name.extension.\n         \"\"\"\n-        unique = ANY_UNIQUE if ignore_version else self.get_version('css' if self.is_css(extension) else 'js')\n+        extension_type = extension.split('.')[-1]\n+        unique = ANY_UNIQUE if ignore_version else self.get_version('css' if self.is_css(extension) else extension_type if extension_type in BINARY_EXTENSIONS else 'js')\n         url_pattern = self.get_asset_url(\n             unique=unique,\n             extension=extension,\n@@ -264,7 +298,7 @@ def save_attachment(self, extension, content):\n \n         :return the ir.attachment records for a given bundle.\n         \"\"\"\n-        assert extension in ('js', 'min.js', 'js.map', 'css', 'min.css', 'css.map', 'xml', 'min.xml')\n+        assert self.has_binary or extension in ('js', 'min.js', 'js.map', 'css', 'min.css', 'css.map', 'xml', 'min.xml')\n         ira = self.env['ir.attachment']\n \n         # Set user direction in name to store two bundles\n@@ -273,12 +307,17 @@ def save_attachment(self, extension, content):\n         # (this applies to css bundles only)\n         fname = '%s.%s' % (self.name, extension)\n         mimetype = (\n-            'text/css' if extension in ['css', 'min.css'] else\n-            'text/xml' if extension in ['xml', 'min.xml'] else\n-            'application/json' if extension in ['js.map', 'css.map'] else\n+            'font/woff' if extension in ('woff', 'min.woff') else\n+            'font/woff2' if extension in ('woff2', 'min.woff2') else\n+            'text/css' if extension in ('css', 'min.css') else\n+            'text/xml' if extension in ('xml', 'min.xml') else\n+            'application/json' if extension in ('js.map', 'css.map') else\n             'application/javascript'\n         )\n-        unique = self.get_version('css' if self.is_css(extension) else 'js')\n+        unique = self.get_version(\n+            extension.rsplit('.')[-1] if self.has_binary else\n+            'css' if self.is_css(extension) else 'js'\n+        )\n         url = self.get_asset_url(\n             unique=unique,\n             extension=extension,\n@@ -290,7 +329,7 @@ def save_attachment(self, extension, content):\n             'res_id': False,\n             'type': 'binary',\n             'public': True,\n-            'raw': content.encode('utf8'),\n+            'raw': content if self.has_binary else content.encode('utf8'),\n             'url': url,\n         }\n         attachment = ira.with_user(SUPERUSER_ID).create(values)\n@@ -707,6 +746,19 @@ def get_rtlcss_error(self, stderr, source=None):\n         error = f\"{error}This error occurred while compiling the bundle {self.name!r} containing:\"\n         return error\n \n+    def bin(self, extension):\n+        for binary in self.binaries:\n+            base_ext = binary.extension\n+            if base_ext != extension:\n+                continue\n+            is_minified = not self.is_debug_assets\n+            extension = f'min.{base_ext}' if is_minified else base_ext\n+            attachments = self.get_attachments(extension)\n+            if attachments:\n+                return attachments\n+            return self.save_attachment(extension, binary._fetch_content())\n+        return self.env['ir.attachment']\n+\n \n class WebAsset(object):\n     _content = None\n@@ -912,14 +964,16 @@ def with_header(self, content=None):\n \n \n class StylesheetAsset(WebAsset):\n+    rx_full_url = re.compile(r\"\"\"\\burl\\(['\"]?(.*?)['\"]?\\)\"\"\")\n     rx_import = re.compile(r\"\"\"@import\\s+('|\")(?!'|\"|/|https?://)\"\"\", re.U)\n     rx_url = re.compile(r\"\"\"(?<!\")url\\s*\\(\\s*('|\"|)(?!'|\"|/|https?://|data:|#{str)\"\"\", re.U)\n     rx_sourceMap = re.compile(r'(/\\*# sourceMappingURL=.*)', re.U)\n     rx_charset = re.compile(r'(@charset \"[^\"]+\";)', re.U)\n \n-    def __init__(self, *args, rtl=False, autoprefix=False, **kw):\n+    def __init__(self, *args, rtl=False, autoprefix=False, css_urls=None, **kw):\n         self.rtl = rtl\n         self.autoprefix = autoprefix\n+        self.css_urls = css_urls\n         super().__init__(*args, **kw)\n \n     @property\n@@ -935,6 +989,15 @@ def unique_descriptor(self):\n     def _fetch_content(self):\n         try:\n             content = super()._fetch_content()\n+            if self.css_urls:\n+                def map_url(matched):\n+                    plain_url = matched[1].split('?')[0]\n+                    asset_url = self.css_urls.get(plain_url)\n+                    if asset_url:\n+                        asset_url = asset_url.replace('\"', '%22')\n+                        return 'url(\"%s\")' % asset_url\n+                    return matched.group()\n+                content = re.sub(self.rx_full_url, map_url, content)\n             web_dir = os.path.dirname(self.url)\n \n             if self.rx_import:\n@@ -1085,3 +1148,30 @@ def get_command(self):\n         except IOError:\n             lessc = 'lessc'\n         return [lessc, '-', '--no-js', '--no-color']\n+\n+\n+class BinaryAsset(WebAsset):\n+    def __init__(self, bundle, definition_bundle, **kwargs):\n+        super().__init__(bundle, **kwargs)\n+        self.extension = '' if '.' not in self._filename else self._filename.split('.')[-1]\n+        self.definition_bundle = definition_bundle\n+\n+    def _fetch_content(self):\n+        try:\n+            self.stat()\n+            if self._filename:\n+                with file_open(self._filename, 'rb', filter_ext=BINARY_EXTENSIONS) as fp:\n+                    return fp.read()\n+            else:\n+                return self._ir_attach.raw\n+        except OSError as exc:\n+            raise AssetNotFound('File %s does not exist.' % self.name) from exc\n+        except Exception as exc:  # noqa: BLE001\n+            raise AssetError('Could not get content for %s.' % self.name) from exc\n+\n+    @property\n+    def bundle_version(self):\n+        return self.bundle.get_version('binary')\n+\n+    def with_header(self, content=None):\n+        return content"
+      },
+      {
+        "sha": "231a53a8c02715d8229cb63d74d4435c74e0e2dd",
+        "filename": "odoo/addons/base/models/ir_asset.py",
+        "status": "modified",
+        "additions": 9,
+        "deletions": 6,
+        "changes": 15,
+        "blob_url": "https://github.com/odoo/odoo/blob/a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8/odoo%2Faddons%2Fbase%2Fmodels%2Fir_asset.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8/odoo%2Faddons%2Fbase%2Fmodels%2Fir_asset.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/odoo%2Faddons%2Fbase%2Fmodels%2Fir_asset.py?ref=a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8",
+        "patch": "@@ -7,7 +7,7 @@\n from odoo import api, fields, models, tools\n from odoo.modules import Manifest\n from odoo.tools import misc\n-from odoo.tools.constants import ASSET_EXTENSIONS, EXTERNAL_ASSET\n+from odoo.tools.constants import ASSET_EXTENSIONS, EXTERNAL_ASSET, BINARY_EXTENSIONS\n \n _logger = getLogger(__name__)\n \n@@ -103,9 +103,12 @@ def _get_asset_bundle_url(self, filename, unique, assets_params, ignore_params=F\n \n     def _parse_bundle_name(self, bundle_name, debug_assets):\n         bundle_name, asset_type = bundle_name.rsplit('.', 1)\n+        if asset_type in BINARY_EXTENSIONS:\n+            asset_type = 'binary'\n+            bundle_name = bundle_name.rsplit('.', 1)[0]\n         rtl = False\n         autoprefix = False\n-        if not debug_assets:\n+        if not debug_assets and asset_type != 'binary':\n             bundle_name, min_ = bundle_name.rsplit('.', 1)\n             if min_ != 'min':\n                 raise ValueError(\"'min' expected in extension in non debug mode\")\n@@ -116,9 +119,9 @@ def _parse_bundle_name(self, bundle_name, debug_assets):\n             if bundle_name.endswith('.rtl'):\n                 bundle_name = bundle_name[:-4]\n                 rtl = True\n-        elif asset_type != 'js':\n-            raise ValueError('Only js and css assets bundle are supported for now')\n-        if len(bundle_name.split('.')) != 2:\n+        elif asset_type not in ('js', 'binary'):\n+            raise ValueError('Only js, css and binary assets bundle are supported for now')\n+        if len(bundle_name.split('.')) != 2 and asset_type != 'binary':\n             raise ValueError(f'{bundle_name} is not a valid bundle name, should have two parts')\n         return bundle_name, rtl, asset_type, autoprefix\n \n@@ -385,7 +388,7 @@ def _process_command(self, command):\n \n \n class AssetPaths:\n-    \"\"\" A list of asset paths (path, addon, bundle) with efficient operations. \"\"\"\n+    \"\"\" A list of asset paths (path, addon, bundle, last_modified) with efficient operations. \"\"\"\n     def __init__(self):\n         self.list = []\n         self.memo = set()"
+      },
+      {
+        "sha": "4f76a6e6b089f24979d3f2c4274f84250e7cf42c",
+        "filename": "odoo/addons/base/models/ir_qweb.py",
+        "status": "modified",
+        "additions": 28,
+        "deletions": 15,
+        "changes": 43,
+        "blob_url": "https://github.com/odoo/odoo/blob/a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8/odoo%2Faddons%2Fbase%2Fmodels%2Fir_qweb.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8/odoo%2Faddons%2Fbase%2Fmodels%2Fir_qweb.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/odoo%2Faddons%2Fbase%2Fmodels%2Fir_qweb.py?ref=a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8",
+        "patch": "@@ -401,7 +401,7 @@\n from odoo.exceptions import UserError, MissingError\n \n from odoo.addons.base.models.assetsbundle import AssetsBundle\n-from odoo.tools.constants import SCRIPT_EXTENSIONS, STYLE_EXTENSIONS, TEMPLATE_EXTENSIONS\n+from odoo.tools.constants import SCRIPT_EXTENSIONS, STYLE_EXTENSIONS, TEMPLATE_EXTENSIONS, FONT_EXTENSIONS\n \n _logger = logging.getLogger(__name__)\n \n@@ -2626,6 +2626,7 @@ def _compile_directive_call_assets(self, el, compile_context, level):\n         xmlid = el.attrib.pop('t-call-assets')\n         css = self._compile_bool(el.attrib.pop('t-css', True))\n         js = self._compile_bool(el.attrib.pop('t-js', True))\n+        binary = self._compile_bool(el.attrib.pop('t-binary', False))\n         # async_load support was removed\n         defer_load = self._compile_bool(el.attrib.pop('defer_load', False))\n         lazy_load = self._compile_bool(el.attrib.pop('lazy_load', False))\n@@ -2636,6 +2637,7 @@ def _compile_directive_call_assets(self, el, compile_context, level):\n                 {xmlid!r},\n                 css={css},\n                 js={js},\n+                binary={binary},\n                 debug=values.get(\"debug\"),\n                 defer_load={defer_load},\n                 lazy_load={lazy_load},\n@@ -2754,16 +2756,16 @@ def _get_widget(self, value, expression, tagName, field_options, values):\n \n         return (attributes, content, inherit_branding)\n \n-    def _get_asset_nodes(self, bundle, css=True, js=True, debug=False, defer_load=False, lazy_load=False, media=None, autoprefix=False):\n+    def _get_asset_nodes(self, bundle, css=True, js=True, binary=False, debug=False, defer_load=False, lazy_load=False, media=None, autoprefix=False):\n         \"\"\"Generates asset nodes.\n         If debug=assets, the assets will be regenerated when a file which composes them has been modified.\n         Else, the assets will be generated only once and then stored in cache.\n         \"\"\"\n         media = css and media or None\n-        links = self._get_asset_links(bundle, css=css, js=js, debug=debug, autoprefix=autoprefix)\n-        return self._links_to_nodes(links, defer_load=defer_load, lazy_load=lazy_load, media=media)\n+        links = self._get_asset_links(bundle, css=css, js=js, binary=binary, debug=debug, autoprefix=autoprefix)\n+        return self._links_to_nodes([links[0]] if binary else links, defer_load=defer_load, lazy_load=lazy_load, media=media)\n \n-    def _get_asset_links(self, bundle, css=True, js=True, debug=None, autoprefix=False):\n+    def _get_asset_links(self, bundle, css=True, js=True, binary=False, debug=None, autoprefix=False):\n         \"\"\"Generates asset nodes.\n         If debug=assets, the assets will be regenerated when a file which composes them has been modified.\n         Else, the assets will be generated only once and then stored in cache.\n@@ -2773,43 +2775,44 @@ def _get_asset_links(self, bundle, css=True, js=True, debug=None, autoprefix=Fal\n         debug_assets = debug and 'assets' in debug\n \n         if debug_assets:\n-            return self._generate_asset_links(bundle, css=css, js=js, debug_assets=True, assets_params=assets_params, rtl=rtl, autoprefix=autoprefix)\n+            return self._generate_asset_links(bundle, css=css, js=js, binary=binary, debug_assets=True, assets_params=assets_params, rtl=rtl, autoprefix=autoprefix)\n         else:\n-            return self._generate_asset_links_cache(bundle, css=css, js=js, assets_params=assets_params, rtl=rtl, autoprefix=autoprefix)\n+            return self._generate_asset_links_cache(bundle, css=css, js=js, binary=binary, assets_params=assets_params, rtl=rtl, autoprefix=autoprefix)\n \n     # other methods used for the asset bundles\n     @tools.conditional(\n         # in non-xml-debug mode we want assets to be cached forever, and the admin can force a cache clear\n         # by restarting the server after updating the source code (or using the \"Clear server cache\" in debug tools)\n         'xml' not in tools.config['dev_mode'],\n-        tools.ormcache('bundle', 'css', 'js', 'tuple(sorted(assets_params.items()))', 'rtl', 'autoprefix', cache='assets'),\n+        tools.ormcache('bundle', 'css', 'js', 'binary', 'tuple(sorted(assets_params.items()))', 'rtl', 'autoprefix', cache='assets'),\n     )\n-    def _generate_asset_links_cache(self, bundle, css=True, js=True, assets_params=None, rtl=False, autoprefix=False):\n-        return self._generate_asset_links(bundle, css, js, False, assets_params, rtl, autoprefix=autoprefix)\n+    def _generate_asset_links_cache(self, bundle, css=True, js=True, binary=False, assets_params=None, rtl=False, autoprefix=False):\n+        return self._generate_asset_links(bundle, css, js, binary, False, assets_params, rtl, autoprefix=autoprefix)\n \n     def _get_asset_content(self, bundle, assets_params=None):\n         if assets_params is None:\n             assets_params = self.env['ir.asset']._get_asset_params()  # website_id\n         asset_paths = self.env['ir.asset']._get_asset_paths(bundle=bundle, assets_params=assets_params)\n         files = []\n         external_asset = []\n-        for path, full_path, _bundle, last_modified in asset_paths:\n+        for path, full_path, definition_bundle, last_modified in asset_paths:\n             if full_path is not EXTERNAL_ASSET:\n                 files.append({\n                     'url': path,\n                     'filename': full_path,\n                     'content': '',\n                     'last_modified': last_modified,\n+                    'definition_bundle': definition_bundle,\n                 })\n             else:\n                 external_asset.append(path)\n         return (files, external_asset)\n \n-    def _get_asset_bundle(self, bundle_name, css=True, js=True, debug_assets=False, rtl=False, assets_params=None, autoprefix=False):\n+    def _get_asset_bundle(self, bundle_name, css=True, js=True, binary=False, debug_assets=False, rtl=False, assets_params=None, autoprefix=False):\n         if assets_params is None:\n             assets_params = self.env['ir.asset']._get_asset_params()\n         files, external_assets = self._get_asset_content(bundle_name, assets_params)\n-        return AssetsBundle(bundle_name, files, external_assets, env=self.env, css=css, js=js, debug_assets=debug_assets, rtl=rtl, assets_params=assets_params, autoprefix=autoprefix)\n+        return AssetsBundle(bundle_name, files, external_assets, env=self.env, css=css, js=js, binary=binary, debug_assets=debug_assets, rtl=rtl, assets_params=assets_params, autoprefix=autoprefix)\n \n     def _links_to_nodes(self, paths, defer_load=False, lazy_load=False, media=None):\n         return [self._link_to_node(path, defer_load=defer_load, lazy_load=lazy_load, media=media) for path in paths]\n@@ -2819,6 +2822,7 @@ def _link_to_node(self, path, defer_load=False, lazy_load=False, media=None):\n         is_js = ext in SCRIPT_EXTENSIONS\n         is_xml = ext in TEMPLATE_EXTENSIONS\n         is_css = ext in STYLE_EXTENSIONS\n+        is_font = ext in FONT_EXTENSIONS\n \n         if is_js:\n             is_asset_bundle = path and path.startswith('/web/assets/')\n@@ -2860,10 +2864,19 @@ def _link_to_node(self, path, defer_load=False, lazy_load=False, media=None):\n                 }\n             return ('script', attributes)\n \n+        if is_font:\n+            attributes = {\n+                'rel': 'preload',\n+                'href': path,\n+                'as': 'font',\n+                'crossorigin': '',\n+            }\n+            return ('link', attributes)\n+\n         return None\n \n-    def _generate_asset_links(self, bundle, css=True, js=True, debug_assets=False, assets_params=None, rtl=False, autoprefix=False):\n-        asset_bundle = self._get_asset_bundle(bundle, css=css, js=js, debug_assets=debug_assets, rtl=rtl, assets_params=assets_params, autoprefix=autoprefix)\n+    def _generate_asset_links(self, bundle, css=True, js=True, binary=False, debug_assets=False, assets_params=None, rtl=False, autoprefix=False):\n+        asset_bundle = self._get_asset_bundle(bundle, css=css, js=js, binary=binary, debug_assets=debug_assets, rtl=rtl, assets_params=assets_params, autoprefix=autoprefix)\n         return asset_bundle.get_links()\n \n     def _get_asset_link_urls(self, bundle, debug=False):"
+      },
+      {
+        "sha": "b360230974e2e07a1640344e34b80bb34116af71",
+        "filename": "odoo/tools/constants.py",
+        "status": "modified",
+        "additions": 3,
+        "deletions": 1,
+        "changes": 4,
+        "blob_url": "https://github.com/odoo/odoo/blob/a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8/odoo%2Ftools%2Fconstants.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8/odoo%2Ftools%2Fconstants.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/odoo%2Ftools%2Fconstants.py?ref=a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8",
+        "patch": "@@ -3,7 +3,9 @@\n SCRIPT_EXTENSIONS = ('js',)\n STYLE_EXTENSIONS = ('css', 'scss', 'sass', 'less')\n TEMPLATE_EXTENSIONS = ('xml',)\n-ASSET_EXTENSIONS = SCRIPT_EXTENSIONS + STYLE_EXTENSIONS + TEMPLATE_EXTENSIONS\n+FONT_EXTENSIONS = ('woff', 'woff2')\n+BINARY_EXTENSIONS = FONT_EXTENSIONS\n+ASSET_EXTENSIONS = SCRIPT_EXTENSIONS + STYLE_EXTENSIONS + TEMPLATE_EXTENSIONS + BINARY_EXTENSIONS\n \n SUPPORTED_DEBUGGER = {'pdb', 'ipdb', 'wdb', 'pudb'}\n EXTERNAL_ASSET = object()"
+      }
+    ],
+    "paths": [
+      "addons/website"
+    ]
+  },
+  {
+    "sha": "b7d9ae53ff0b6df8ceb1f8be79ad3304c843e258",
+    "node_id": "C_kwDOAS1I7NoAKGI3ZDlhZTUzZmYwYjZkZjhjZWIxZjhiZTc5YWQzMzA0Yzg0M2UyNTg",
+    "commit": {
+      "author": {
+        "name": "assk-odoo",
+        "email": "assk@odoo.com",
+        "date": "2025-09-15T12:44:21Z"
+      },
+      "committer": {
+        "name": "assk-odoo",
+        "email": "assk@odoo.com",
+        "date": "2025-10-09T10:00:04Z"
+      },
+      "message": "[FIX] website: fix when creating new page in mobile view\n\nSteps to reproduce:\n1.Open website.\n2.Switch to mobile view.\n3.Click new button and select new page option.\n4.A traceback occurs.\n\nBefore this commit:\nCreating a new page in mobile view raised a traceback as\ncontentDocument was undefined due to an incorrect selector.\n\nAfter this commit:\nThe issue is resolved by using the correct querySelector value,\nensuring that contentDocument can be accessed properly.\n\ncloses odoo/odoo#230642\n\nX-original-commit: 106039c6af98809db18ae9ef6b0e1a705c2a8eb6\nSigned-off-by: Francois Georis (fge) <fge@odoo.com>\nSigned-off-by: Sujal Kamleshbhai Asodariya (assk) <assk@odoo.com>",
+      "tree": {
+        "sha": "02a5cc1a7f8a3fac2c2f589342690b4d12d5d660",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/02a5cc1a7f8a3fac2c2f589342690b4d12d5d660"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/b7d9ae53ff0b6df8ceb1f8be79ad3304c843e258",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/b7d9ae53ff0b6df8ceb1f8be79ad3304c843e258",
+    "html_url": "https://github.com/odoo/odoo/commit/b7d9ae53ff0b6df8ceb1f8be79ad3304c843e258",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/b7d9ae53ff0b6df8ceb1f8be79ad3304c843e258/comments",
+    "author": {
+      "login": "assk-odoo",
+      "id": 195764924,
+      "node_id": "U_kgDOC6sivA",
+      "avatar_url": "https://avatars.githubusercontent.com/u/195764924?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/assk-odoo",
+      "html_url": "https://github.com/assk-odoo",
+      "followers_url": "https://api.github.com/users/assk-odoo/followers",
+      "following_url": "https://api.github.com/users/assk-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/assk-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/assk-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/assk-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/assk-odoo/orgs",
+      "repos_url": "https://api.github.com/users/assk-odoo/repos",
+      "events_url": "https://api.github.com/users/assk-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/assk-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "assk-odoo",
+      "id": 195764924,
+      "node_id": "U_kgDOC6sivA",
+      "avatar_url": "https://avatars.githubusercontent.com/u/195764924?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/assk-odoo",
+      "html_url": "https://github.com/assk-odoo",
+      "followers_url": "https://api.github.com/users/assk-odoo/followers",
+      "following_url": "https://api.github.com/users/assk-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/assk-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/assk-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/assk-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/assk-odoo/orgs",
+      "repos_url": "https://api.github.com/users/assk-odoo/repos",
+      "events_url": "https://api.github.com/users/assk-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/assk-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "2efdd820ad682a4848eea9b1ae797925516328e5",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/2efdd820ad682a4848eea9b1ae797925516328e5",
+        "html_url": "https://github.com/odoo/odoo/commit/2efdd820ad682a4848eea9b1ae797925516328e5"
+      }
+    ],
+    "stats": {
+      "total": 2,
+      "additions": 1,
+      "deletions": 1
+    },
+    "files": [
+      {
+        "sha": "7b5ee31c43f7cd8cbcdbf959a9ead142b632f7c8",
+        "filename": "addons/website/static/src/components/dialog/add_page_dialog.js",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/b7d9ae53ff0b6df8ceb1f8be79ad3304c843e258/addons%2Fwebsite%2Fstatic%2Fsrc%2Fcomponents%2Fdialog%2Fadd_page_dialog.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/b7d9ae53ff0b6df8ceb1f8be79ad3304c843e258/addons%2Fwebsite%2Fstatic%2Fsrc%2Fcomponents%2Fdialog%2Fadd_page_dialog.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fcomponents%2Fdialog%2Fadd_page_dialog.js?ref=b7d9ae53ff0b6df8ceb1f8be79ad3304c843e258",
+        "patch": "@@ -514,7 +514,7 @@ export class AddPageDialog extends Component {\n         if (!this.cssLinkEls) {\n             this.cssLinkEls = new Promise((resolve) => {\n                 const container = document.querySelector(\".o_website_preview .o_iframe_container\");\n-                const iframe = container?.lastElementChild;\n+                const iframe = container?.querySelector('iframe:not([src=\"/website/iframefallback\"])');\n                 if (iframe?.contentDocument.body.getAttribute(\"is-ready\") === \"true\") {\n                     // If there is a fully loaded website preview, use it.\n                     resolve(iframe.contentDocument.head.querySelectorAll(\"link[type='text/css']\"));"
+      }
+    ],
+    "paths": [
+      "addons/website"
+    ]
+  },
+  {
+    "sha": "0cb45457ccd59c4caf28fddccb43ccdbd3e73257",
+    "node_id": "C_kwDOAS1I7NoAKDBjYjQ1NDU3Y2NkNTljNGNhZjI4ZmRkY2NiNDNjY2RiZDNlNzMyNTc",
+    "commit": {
+      "author": {
+        "name": "khaj-odoo",
+        "email": "khaj@odoo.com",
+        "date": "2025-08-21T07:19:56Z"
+      },
+      "committer": {
+        "name": "khaj-odoo",
+        "email": "khaj@odoo.com",
+        "date": "2025-10-09T09:59:44Z"
+      },
+      "message": "[IMP] website,*: update configurator features and website menus\n\n* = [website_sale,test_website]\nDescription:\n- This commit updates website configurator features, menus and related\n  tests/tours to reflect the current functional scope.\n\nAfter this commit:\n- Renamed Pricing to Pricing Plan with updated description\n- Moved Privacy Policy to a default website page instead of configurator feature\n- Removed Success Stories, Forum and Stores Locator features\n- Dropped default Contact us\n- Updated related tours and tests to reflect menu and feature changes\n- Updated indentation for the `website_sale_menus`\ntask-4855511\n\ncloses odoo/odoo#223724\n\nRelated: odoo/upgrade#8320\nSigned-off-by: Valeriya Chuprina (vchu) <vchu@odoo.com>",
+      "tree": {
+        "sha": "a53cd1d93fb2f176f175a6f12bb357516a019ba2",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/a53cd1d93fb2f176f175a6f12bb357516a019ba2"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/0cb45457ccd59c4caf28fddccb43ccdbd3e73257",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/0cb45457ccd59c4caf28fddccb43ccdbd3e73257",
+    "html_url": "https://github.com/odoo/odoo/commit/0cb45457ccd59c4caf28fddccb43ccdbd3e73257",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/0cb45457ccd59c4caf28fddccb43ccdbd3e73257/comments",
+    "author": {
+      "login": "khaj-odoo",
+      "id": 195760197,
+      "node_id": "U_kgDOC6sQRQ",
+      "avatar_url": "https://avatars.githubusercontent.com/u/195760197?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/khaj-odoo",
+      "html_url": "https://github.com/khaj-odoo",
+      "followers_url": "https://api.github.com/users/khaj-odoo/followers",
+      "following_url": "https://api.github.com/users/khaj-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/khaj-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/khaj-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/khaj-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/khaj-odoo/orgs",
+      "repos_url": "https://api.github.com/users/khaj-odoo/repos",
+      "events_url": "https://api.github.com/users/khaj-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/khaj-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "khaj-odoo",
+      "id": 195760197,
+      "node_id": "U_kgDOC6sQRQ",
+      "avatar_url": "https://avatars.githubusercontent.com/u/195760197?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/khaj-odoo",
+      "html_url": "https://github.com/khaj-odoo",
+      "followers_url": "https://api.github.com/users/khaj-odoo/followers",
+      "following_url": "https://api.github.com/users/khaj-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/khaj-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/khaj-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/khaj-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/khaj-odoo/orgs",
+      "repos_url": "https://api.github.com/users/khaj-odoo/repos",
+      "events_url": "https://api.github.com/users/khaj-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/khaj-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "ac61e79b16dd55be54e94a03b7f1f73ced8799d0",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/ac61e79b16dd55be54e94a03b7f1f73ced8799d0",
+        "html_url": "https://github.com/odoo/odoo/commit/ac61e79b16dd55be54e94a03b7f1f73ced8799d0"
+      }
+    ],
+    "stats": {
+      "total": 139,
+      "additions": 49,
+      "deletions": 90
+    },
+    "files": [
+      {
+        "sha": "1c5a1f5a5ce6ce0a56462810a6f0cf130e3d9241",
+        "filename": "addons/test_website/tests/test_page.py",
+        "status": "modified",
+        "additions": 6,
+        "deletions": 4,
+        "changes": 10,
+        "blob_url": "https://github.com/odoo/odoo/blob/0cb45457ccd59c4caf28fddccb43ccdbd3e73257/addons%2Ftest_website%2Ftests%2Ftest_page.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/0cb45457ccd59c4caf28fddccb43ccdbd3e73257/addons%2Ftest_website%2Ftests%2Ftest_page.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Ftest_website%2Ftests%2Ftest_page.py?ref=0cb45457ccd59c4caf28fddccb43ccdbd3e73257",
+        "patch": "@@ -18,10 +18,12 @@ def test_01_homepage_url(self):\n         contactus_url = '/contactus'\n         contactus_url_full = website.domain + contactus_url\n         contactus_content = b'content=\"Contact Us | Test Website\"'\n-        self.env['website.menu'].search([\n-            ('website_id', '=', website.id),\n-            ('url', '=', contactus_url),\n-        ]).sequence = 1\n+        self.env['website.menu'].create({\n+            'name': \"Contact us\",\n+            'url': contactus_url,\n+            'website_id': website.id,\n+            'parent_id': website.menu_id.id,\n+        }).sequence = 1\n \n         # 404 shouldn't be served but fallback on first menu\n         # -------------------------------------------"
+      },
+      {
+        "sha": "912aed2ae6f049b7b97a576daac0c89d79012f36",
+        "filename": "addons/test_website_modules/static/tests/tours/configurator_flow.js",
+        "status": "modified",
+        "additions": 6,
+        "deletions": 10,
+        "changes": 16,
+        "blob_url": "https://github.com/odoo/odoo/blob/0cb45457ccd59c4caf28fddccb43ccdbd3e73257/addons%2Ftest_website_modules%2Fstatic%2Ftests%2Ftours%2Fconfigurator_flow.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/0cb45457ccd59c4caf28fddccb43ccdbd3e73257/addons%2Ftest_website_modules%2Fstatic%2Ftests%2Ftours%2Fconfigurator_flow.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Ftest_website_modules%2Fstatic%2Ftests%2Ftours%2Fconfigurator_flow.js?ref=0cb45457ccd59c4caf28fddccb43ccdbd3e73257",
+        "patch": "@@ -55,12 +55,12 @@ registry.category(\"web_tour.tours\").add(\"configurator_flow\", {\n         },\n         // Features screen\n         {\n-            content: \"select Pricing\",\n-            trigger: '.card:contains(\"Pricing\")',\n+            content: \"select Pricing Plan\",\n+            trigger: '.card:contains(\"Pricing Plan\")',\n             run: \"click\",\n         },\n         {\n-            trigger: '.card.border-success:contains(\"Pricing\")',\n+            trigger: '.card.border-success:contains(\"Pricing Plan\")',\n         },\n         {\n             content: \"Events should be selected (module already installed)\",\n@@ -71,11 +71,7 @@ registry.category(\"web_tour.tours\").add(\"configurator_flow\", {\n             trigger: '.card.card_installed:contains(\"eLearning\")',\n         },\n         {\n-            trigger: '.card.card_installed:contains(\"Success Stories\")',\n-        },\n-        {\n-            content:\n-                \"Success Stories (Blog) and News (Blog) should be selected (module already installed)\",\n+            content:\"News (Blog) should be selected (module already installed)\",\n             trigger: '.card.card_installed:contains(\"News\")',\n         },\n         {\n@@ -113,13 +109,13 @@ registry.category(\"web_tour.tours\").add(\"configurator_flow\", {\n             content: `Check footer menu ${menu} is there`,\n             trigger: `:iframe footer a:contains(${menu})`,\n         })),\n-        ...[\"Home\", \"Events\", \"Courses\", \"Pricing\", \"News\", \"Success Stories\", \"Contact us\"].map(\n+        ...[\"Home\", \"Events\", \"Courses\", \"Pricing Plan\", \"News\"].map(\n             (menu) => ({\n                 content: `Check menu ${menu} is there`,\n                 trigger: `:iframe .top_menu a:contains(${menu}):not(:visible)`,\n             })\n         ),\n-        ...[\"/\", \"/event\", \"/slides\", \"/pricing\", \"/blog/\", \"/blog/\", \"/contactus\"].map((url) => ({\n+        ...[\"/\", \"/event\", \"/slides\", \"/pricing\", \"/blog/\"].map((url) => ({\n             content: `Check url ${url} is there`,\n             trigger: `:iframe .top_menu a[href^='${url}']:not(:visible)`,\n         })),"
+      },
+      {
+        "sha": "46a91f16864502007b33ab7080fbc98a6d120d04",
+        "filename": "addons/website/data/website_data.xml",
+        "status": "modified",
+        "additions": 9,
+        "deletions": 43,
+        "changes": 52,
+        "blob_url": "https://github.com/odoo/odoo/blob/0cb45457ccd59c4caf28fddccb43ccdbd3e73257/addons%2Fwebsite%2Fdata%2Fwebsite_data.xml",
+        "raw_url": "https://github.com/odoo/odoo/raw/0cb45457ccd59c4caf28fddccb43ccdbd3e73257/addons%2Fwebsite%2Fdata%2Fwebsite_data.xml",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fdata%2Fwebsite_data.xml?ref=0cb45457ccd59c4caf28fddccb43ccdbd3e73257",
+        "patch": "@@ -392,24 +392,15 @@\n         <field name=\"feature_url\">/our-services</field>\n     </record>\n     <record id=\"feature_page_pricing\" model=\"website.configurator.feature\">\n-        <field name=\"name\">Pricing</field>\n-        <field name=\"description\">Designed to drive conversion</field>\n+        <field name=\"name\">Pricing Plan</field>\n+        <field name=\"description\">Useful if you sell subscriptions</field>\n         <field name=\"iap_page_code\">pricing</field>\n         <field name=\"sequence\">4</field>\n         <field name=\"page_view_id\" ref=\"pricing\"/>\n         <field name=\"icon\">fa-random</field>\n         <field name=\"menu_sequence\">35</field>\n         <field name=\"feature_url\">/pricing</field>\n     </record>\n-    <record id=\"feature_page_privacy_policy\" model=\"website.configurator.feature\">\n-        <field name=\"name\">Privacy Policy</field>\n-        <field name=\"description\">Explain how you protect privacy</field>\n-        <field name=\"iap_page_code\">privacy_policy</field>\n-        <field name=\"sequence\">5</field>\n-        <field name=\"page_view_id\" ref=\"privacy_policy\"/>\n-        <field name=\"icon\">fa-gavel</field>\n-        <field name=\"feature_url\">/privacy</field>\n-    </record>\n \n     <!-- Configurator apps features -->\n     <record id=\"feature_module_news\" model=\"website.configurator.feature\">\n@@ -423,16 +414,6 @@\n         <field name=\"menu_sequence\">40</field>\n         <field name=\"feature_url\">/blog</field>\n     </record>\n-    <record id=\"feature_module_success_stories\" model=\"website.configurator.feature\">\n-        <field name=\"name\">Success Stories</field>\n-        <field name=\"description\">Share your best case studies</field>\n-        <field name=\"sequence\">7</field>\n-        <field name=\"module_id\" ref=\"base.module_website_blog\"/>\n-        <field name=\"icon\">fa-star</field>\n-        <field name=\"menu_company\">True</field>\n-        <field name=\"menu_sequence\">45</field>\n-        <field name=\"feature_url\">/blog</field>\n-    </record>\n     <record id=\"feature_module_career\" model=\"website.configurator.feature\">\n         <field name=\"name\">Career</field>\n         <field name=\"description\">Publish job offers</field>\n@@ -460,14 +441,6 @@\n         <field name=\"menu_sequence\">20</field>\n         <field name=\"feature_url\">/event</field>\n     </record>\n-    <record id=\"feature_module_forum\" model=\"website.configurator.feature\">\n-        <field name=\"name\">Forum</field>\n-        <field name=\"description\">Give visitors the information they need</field>\n-        <field name=\"sequence\">11</field>\n-        <field name=\"module_id\" ref=\"base.module_website_forum\"/>\n-        <field name=\"icon\">fa-users</field>\n-        <field name=\"feature_url\">/forum</field>\n-    </record>\n     <record id=\"feature_module_live_chat\" model=\"website.configurator.feature\">\n         <field name=\"name\">Live Chat</field>\n         <field name=\"description\">Chat with visitors to improve traction</field>\n@@ -485,13 +458,6 @@\n         <field name=\"menu_sequence\">25</field>\n         <field name=\"feature_url\">/slides</field>\n     </record>\n-    <record id=\"feature_module_stores_locator\" model=\"website.configurator.feature\">\n-        <field name=\"name\">Stores Locator</field>\n-        <field name=\"description\">A map and a listing of your stores</field>\n-        <field name=\"sequence\">15</field>\n-        <field name=\"module_id\" ref=\"base.module_website_google_map\"/>\n-        <field name=\"icon\">fa-map-marker</field>\n-    </record>\n \n     <data noupdate=\"1\">\n         <!-- Default pagese -->\n@@ -509,6 +475,13 @@\n             <field name=\"track\">True</field>\n             <field name=\"website_meta_description\">This is the contact us page of the website</field>\n         </record>\n+        <record id=\"privacy_policy_page\" model=\"website.page\">\n+            <field name=\"url\">/privacy</field>\n+            <field name=\"view_id\" ref=\"privacy_policy\"/>\n+            <field name=\"is_published\">True</field>\n+            <field name=\"track\">True</field>\n+            <field name=\"website_meta_description\">This is the privacy policy page of the website</field>\n+        </record>\n \n         <!-- Default Menu to store module menus for new website -->\n         <record id=\"main_menu\" model=\"website.menu\">\n@@ -522,13 +495,6 @@\n             <field name=\"parent_id\" ref=\"website.main_menu\"/>\n             <field name=\"sequence\" type=\"int\">10</field>\n         </record>\n-        <record id=\"menu_contactus\" model=\"website.menu\">\n-            <field name=\"name\">Contact us</field>\n-            <field name=\"url\">/contactus</field>\n-            <field name=\"page_id\" ref=\"website.contactus_page\"/>\n-            <field name=\"parent_id\" ref=\"website.main_menu\"/>\n-            <field name=\"sequence\" type=\"int\">60</field>\n-        </record>\n \n         <!-- Default Website -->\n         <record id=\"default_website\" model=\"website\">"
+      },
+      {
+        "sha": "60531e6bfb41f585908b60b1d53fb5f836cf223b",
+        "filename": "addons/website/static/src/client_actions/configurator/configurator.js",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/0cb45457ccd59c4caf28fddccb43ccdbd3e73257/addons%2Fwebsite%2Fstatic%2Fsrc%2Fclient_actions%2Fconfigurator%2Fconfigurator.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/0cb45457ccd59c4caf28fddccb43ccdbd3e73257/addons%2Fwebsite%2Fstatic%2Fsrc%2Fclient_actions%2Fconfigurator%2Fconfigurator.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fclient_actions%2Fconfigurator%2Fconfigurator.js?ref=0cb45457ccd59c4caf28fddccb43ccdbd3e73257",
+        "patch": "@@ -38,7 +38,7 @@ export const ROUTES = {\n \n export const WEBSITE_TYPES = {\n     1: {id: 1, label: _t(\"a website\"), name: 'business'},\n-    2: {id: 2, label: _t(\"an online store\"), name: 'online_store'},\n+    2: {id: 2, label: _t(\"an eCommerce\"), name: 'eCommerce'},\n     3: {id: 3, label: _t(\"a blog\"), name: 'blog'},\n     4: {id: 4, label: _t(\"an event website\"), name: 'event'},\n     5: {id: 5, label: _t(\"an elearning platform\"), name: 'elearning'},"
+      },
+      {
+        "sha": "d9c337d11764bfb5d4a20477554c8446cedc003b",
+        "filename": "addons/website/static/tests/tours/configurator_translation.js",
+        "status": "modified",
+        "additions": 2,
+        "deletions": 2,
+        "changes": 4,
+        "blob_url": "https://github.com/odoo/odoo/blob/0cb45457ccd59c4caf28fddccb43ccdbd3e73257/addons%2Fwebsite%2Fstatic%2Ftests%2Ftours%2Fconfigurator_translation.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/0cb45457ccd59c4caf28fddccb43ccdbd3e73257/addons%2Fwebsite%2Fstatic%2Ftests%2Ftours%2Fconfigurator_translation.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Ftests%2Ftours%2Fconfigurator_translation.js?ref=0cb45457ccd59c4caf28fddccb43ccdbd3e73257",
+        "patch": "@@ -79,7 +79,7 @@ function runConfiguratorFlow(industrySearchText, featureOrPageName) {\n registry.category(\"web_tour.tours\").add('configurator_translation', {\n     url: '/website/configurator',\n     steps: () => [\n-    ...runConfiguratorFlow(\"in fr\", \"Parseltongue_privacy\"),\n+    ...runConfiguratorFlow(\"in fr\", \"Parseltongue_pricing\"),\n     {\n         content: \"Check if the current interface language is active and monkey patch terms\",\n         trigger: \"body\",\n@@ -108,7 +108,7 @@ registry.category(\"web_tour.tours\").add('configurator_translation', {\n registry.category(\"web_tour.tours\").add(\"configurator_page_creation\", {\n     url: \"/website/configurator\",\n     steps: () => [\n-        ...runConfiguratorFlow(\"abbey\", \"Pricing\"),\n+        ...runConfiguratorFlow(\"abbey\", \"Pricing Plan\"),\n         // Verify configurator page templates exist in landing pages category.\n         {\n             content: \"Open create content menu\","
+      },
+      {
+        "sha": "0febfba35b17420959e15804ed01b8b29a4b1c18",
+        "filename": "addons/website/static/tests/tours/edit_menus.js",
+        "status": "modified",
+        "additions": 10,
+        "deletions": 10,
+        "changes": 20,
+        "blob_url": "https://github.com/odoo/odoo/blob/0cb45457ccd59c4caf28fddccb43ccdbd3e73257/addons%2Fwebsite%2Fstatic%2Ftests%2Ftours%2Fedit_menus.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/0cb45457ccd59c4caf28fddccb43ccdbd3e73257/addons%2Fwebsite%2Fstatic%2Ftests%2Ftours%2Fedit_menus.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Ftests%2Ftours%2Fedit_menus.js?ref=0cb45457ccd59c4caf28fddccb43ccdbd3e73257",
+        "patch": "@@ -292,8 +292,8 @@ registerWebsitePreviewTour('edit_menus', {\n         run: \"click\",\n     },\n     {\n-        content: `Drag \"Contact Us\" menu below \"Home\" menu`,\n-        trigger: '.oe_menu_editor li:contains(\"Contact us\") .oi-draggable',\n+        content: `Drag \"Modnar !!\" menu below \"Home\" menu`,\n+        trigger: '.oe_menu_editor li:contains(\"Modnar !!\") .oi-draggable',\n         run(helpers) {\n             return helpers.drag_and_drop('.oe_menu_editor li:contains(\"Home\")', {\n                 position: {\n@@ -305,13 +305,13 @@ registerWebsitePreviewTour('edit_menus', {\n         },\n     },\n     {\n-        content: \"Drag 'Contact Us' item as a child of the 'Home' item\",\n-        trigger: '.oe_menu_editor li:contains(\"Contact us\") .oi-draggable',\n-        run: 'drag_and_drop .oe_menu_editor li:contains(\"Contact us\") .form-control',\n+        content: \"Drag 'Modnar !!' item as a child of the 'Home' item\",\n+        trigger: '.oe_menu_editor li:contains(\"Modnar !!\") .oi-draggable',\n+        run: 'drag_and_drop .oe_menu_editor li:contains(\"Modnar !!\") .form-control',\n     },\n     {\n         content: \"Wait for drop\",\n-        trigger: '.oe_menu_editor li:contains(\"Home\") ul li:contains(\"Contact us\")',\n+        trigger: '.oe_menu_editor li:contains(\"Home\") ul li:contains(\"Modnar !!\")',\n     },\n     // Drag the Mega menu to the first position.\n     {\n@@ -344,7 +344,7 @@ registerWebsitePreviewTour('edit_menus', {\n     // openable.\n     {\n         content: \"When menu item is opened, child item must appear in the shown menu\",\n-        trigger: ':iframe .top_menu .nav-item:contains(\"Home\") ul.show li a.dropdown-item:contains(\"Contact us\")[href=\"/contactus\"]',\n+        trigger: ':iframe .top_menu .nav-item:contains(\"Home\") ul.show li a.dropdown-item:contains(\"Modnar !!\")',\n         run() {\n             // Scroll down.\n             this.anchor.closest(\"body\").querySelector(\".o_footer_copyright_name\")\n@@ -366,7 +366,7 @@ registerWebsitePreviewTour('edit_menus', {\n     {\n         content: \"Check that the Home menu is opened\",\n         trigger: ':iframe .top_menu .nav-item:contains(\"Home\") ul.show li' +\n-            ' a.dropdown-item:contains(\"Contact us\")[href=\"/contactus\"]',\n+            ' a.dropdown-item:contains(\"Modnar !!\")',\n     },\n     {\n         content: \"Close the Home menu\",\n@@ -422,7 +422,7 @@ registerWebsitePreviewTour('edit_menus', {\n     {\n         // If this step fails, it means that a patch inside bootstrap was lost.\n         content: \"Press the 'down arrow' key.\",\n-        trigger: ':iframe .top_menu .nav-item:contains(\"Home\") li:contains(\"Contact us\")',\n+        trigger: ':iframe .top_menu .nav-item:contains(\"Home\") li:contains(\"Modnar !!\")',\n         run: \"press ArrowDown\",\n     },\n     ...clickOnSave(),\n@@ -492,7 +492,7 @@ registerWebsitePreviewTour('edit_menus', {\n     },\n     {\n         content: \"Drag 'Modnar !!' below 'new_menu'\",\n-        trigger: '.oe_menu_editor li:contains(\"Modnar !!\") .oi-draggable',\n+        trigger: '.oe_menu_editor li:contains(\"Home\") > ul > li:contains(\"Modnar !!\") .oi-draggable',\n         async run(helpers) {\n             await helpers.drag_and_drop('.oe_menu_editor li:contains(\"new_menu\") .oi-draggable', {\n                 position: \"bottom\","
+      },
+      {
+        "sha": "c9426f6d03a92490d1cc684b56a70cb41b30e913",
+        "filename": "addons/website/static/tests/tours/navigation.js",
+        "status": "modified",
+        "additions": 0,
+        "deletions": 9,
+        "changes": 9,
+        "blob_url": "https://github.com/odoo/odoo/blob/0cb45457ccd59c4caf28fddccb43ccdbd3e73257/addons%2Fwebsite%2Fstatic%2Ftests%2Ftours%2Fnavigation.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/0cb45457ccd59c4caf28fddccb43ccdbd3e73257/addons%2Fwebsite%2Fstatic%2Ftests%2Ftours%2Fnavigation.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Ftests%2Ftours%2Fnavigation.js?ref=0cb45457ccd59c4caf28fddccb43ccdbd3e73257",
+        "patch": "@@ -7,21 +7,12 @@ registerWebsitePreviewTour(\n         url: \"/\",\n     },\n     () => [\n-        {\n-            content: \"Navigate to the 'Contact Us' page\",\n-            trigger: \":iframe .top_menu a[href='/contactus']:not(:visible)\",\n-            run: \"click\",\n-        },\n         {\n             content: \"Click on Edit right after that\",\n             trigger: \".o_menu_systray_item.o_edit_website_container > button\",\n             run: \"click\",\n         },\n         stepUtils.waitIframeIsReady(),\n-        {\n-            content: \"Contact us page appears first before the builder sidebar\",\n-            trigger: \":iframe section h1:contains('Contact Us'), :not(.o-website-builder_sidebar)\",\n-        },\n         {\n             content: \"Can insert a snippet\",\n             trigger: \".o-website-builder_sidebar\","
+      },
+      {
+        "sha": "a34bdc17156fc9cc3b59e70278d8207a09e66a38",
+        "filename": "addons/website/tests/test_configurator.py",
+        "status": "modified",
+        "additions": 2,
+        "deletions": 2,
+        "changes": 4,
+        "blob_url": "https://github.com/odoo/odoo/blob/0cb45457ccd59c4caf28fddccb43ccdbd3e73257/addons%2Fwebsite%2Ftests%2Ftest_configurator.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/0cb45457ccd59c4caf28fddccb43ccdbd3e73257/addons%2Fwebsite%2Ftests%2Ftest_configurator.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Ftests%2Ftest_configurator.py?ref=0cb45457ccd59c4caf28fddccb43ccdbd3e73257",
+        "patch": "@@ -116,8 +116,8 @@ def test_01_configurator_translation(self):\n             'overwrite': True,\n             'lang_ids': [(6, 0, [parseltongue.id])],\n         }).lang_install()\n-        feature = self.env['website.configurator.feature'].search([('name', '=', 'Privacy Policy')])\n-        feature.with_context(lang=parseltongue.code).write({'name': 'Parseltongue_privacy'})\n+        feature = self.env['website.configurator.feature'].search([('name', '=', 'Pricing Plan')])\n+        feature.with_context(lang=parseltongue.code).write({'name': 'Parseltongue_pricing'})\n         self.env.ref('base.user_admin').write({'lang': parseltongue.code})\n         website_fr = self.env['website'].create({\n             'name': \"New website\","
+      },
+      {
+        "sha": "d938289725e3f8f863f04c3483fdd1bc236533de",
+        "filename": "addons/website/tests/test_menu.py",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/0cb45457ccd59c4caf28fddccb43ccdbd3e73257/addons%2Fwebsite%2Ftests%2Ftest_menu.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/0cb45457ccd59c4caf28fddccb43ccdbd3e73257/addons%2Fwebsite%2Ftests%2Ftest_menu.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Ftests%2Ftest_menu.py?ref=0cb45457ccd59c4caf28fddccb43ccdbd3e73257",
+        "patch": "@@ -71,7 +71,7 @@ def test_03_default_menu_for_new_website(self):\n         # Ensure new website got a top menu\n         total_menus = Menu.search_count([])\n         Website.create({'name': 'new website'})\n-        self.assertEqual(total_menus + 4, Menu.search_count([]), \"New website's bootstraping should have duplicate default menu tree (Top/Home/Contactus/Sub Default Menu)\")\n+        self.assertEqual(total_menus + 3, Menu.search_count([]), \"New website's bootstraping should have duplicate default menu tree (Top/Home/Sub Default Menu)\")\n \n     def test_04_specific_menu_translation(self):\n         IrModuleModule = self.env['ir.module.module']"
+      },
+      {
+        "sha": "9aa42412590d81ed08fcf4c692b425fec4792a26",
+        "filename": "addons/website/tests/test_page.py",
+        "status": "modified",
+        "additions": 6,
+        "deletions": 4,
+        "changes": 10,
+        "blob_url": "https://github.com/odoo/odoo/blob/0cb45457ccd59c4caf28fddccb43ccdbd3e73257/addons%2Fwebsite%2Ftests%2Ftest_page.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/0cb45457ccd59c4caf28fddccb43ccdbd3e73257/addons%2Fwebsite%2Ftests%2Ftest_page.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Ftests%2Ftest_page.py?ref=0cb45457ccd59c4caf28fddccb43ccdbd3e73257",
+        "patch": "@@ -370,10 +370,12 @@ def test_06_homepage_url(self):\n         contactus_url = '/contactus'\n         contactus_url_full = website.domain + contactus_url\n         contactus_content = b'content=\"Contact Us | Test Website\"'\n-        contactus_menu = self.env['website.menu'].search([\n-            ('website_id', '=', website.id),\n-            ('url', '=', contactus_url),\n-        ], limit=1)\n+        contactus_menu = self.env['website.menu'].create({\n+            'name': \"Contact us\",\n+            'url': contactus_url,\n+            'website_id': website.id,\n+            'parent_id': website.menu_id.id,\n+        })\n         home_url = '/'\n         home_url_full = website.domain + home_url\n         home_content = b'content=\"Home | Test Website\"'"
+      },
+      {
+        "sha": "c687676672f3f37e6e8a4ce196850aec40c763d3",
+        "filename": "addons/website_sale/views/website_sale_menus.xml",
+        "status": "modified",
+        "additions": 6,
+        "deletions": 4,
+        "changes": 10,
+        "blob_url": "https://github.com/odoo/odoo/blob/0cb45457ccd59c4caf28fddccb43ccdbd3e73257/addons%2Fwebsite_sale%2Fviews%2Fwebsite_sale_menus.xml",
+        "raw_url": "https://github.com/odoo/odoo/raw/0cb45457ccd59c4caf28fddccb43ccdbd3e73257/addons%2Fwebsite_sale%2Fviews%2Fwebsite_sale_menus.xml",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite_sale%2Fviews%2Fwebsite_sale_menus.xml?ref=0cb45457ccd59c4caf28fddccb43ccdbd3e73257",
+        "patch": "@@ -56,12 +56,14 @@\n                 action=\"product.product_combo_action\"\n                 sequence=\"6\"\n             />\n-            <menuitem id=\"product_catalog_product_tags\"\n-                name=\"Product Tags\"\n-                action=\"product.product_tag_action\"/>\n+            <menuitem\n+                id=\"product_catalog_product_tags\"\n+                name=\"Tags\"\n+                action=\"product.product_tag_action\"\n+            />\n             <menuitem\n                 id=\"product_catalog_product_ribbons\"\n-                name=\"Product Ribbons\"\n+                name=\"Ribbons\"\n                 action=\"website_sale.product_ribbon_action\"\n             />\n         </menuitem>"
+      }
+    ],
+    "paths": [
+      "addons/website"
+    ]
+  },
+  {
+    "sha": "d3dc69b0431ae2f037ddb9e0e881ddf03b657638",
+    "node_id": "C_kwDOAS1I7NoAKGQzZGM2OWIwNDMxYWUyZjAzN2RkYjllMGU4ODFkZGYwM2I2NTc2Mzg",
+    "commit": {
+      "author": {
+        "name": "Benjamin Vray",
+        "email": "bvr@odoo.com",
+        "date": "2025-10-02T11:21:55Z"
+      },
+      "committer": {
+        "name": "Benjamin Vray",
+        "email": "bvr@odoo.com",
+        "date": "2025-10-09T08:09:05Z"
+      },
+      "message": "[FIX] website: stabilize showcase background video in Chrome\n\nSteps to reproduce:\n\n- Drop the \"s_ecomm_categories_showcase\" snippet.\n- Change its background to a video.\n- Hover between the different blocks.\n- Bug: the video flicker on hover.\n\nBefore this commit Chrome kept resizing the iframe, making the video\nflicker on hover.\n\nAfter this commit we freeze the iframe sizing in pixels so Chrome\nkeeps the video stable.\n\ntask-5104176\n\ncloses odoo/odoo#230647\n\nX-original-commit: cf16e5c3e406084ff1d2a0feff49008491ebee3e\nSigned-off-by: Serge Bayet (seba) <seba@odoo.com>\nSigned-off-by: Benjamin Vray (bvr) <bvr@odoo.com>",
+      "tree": {
+        "sha": "d829bf1c7c6aa59e8fa7015122958f2baa77a4ba",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/d829bf1c7c6aa59e8fa7015122958f2baa77a4ba"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/d3dc69b0431ae2f037ddb9e0e881ddf03b657638",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/d3dc69b0431ae2f037ddb9e0e881ddf03b657638",
+    "html_url": "https://github.com/odoo/odoo/commit/d3dc69b0431ae2f037ddb9e0e881ddf03b657638",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/d3dc69b0431ae2f037ddb9e0e881ddf03b657638/comments",
+    "author": {
+      "login": "bvr-odoo",
+      "id": 52911687,
+      "node_id": "MDQ6VXNlcjUyOTExNjg3",
+      "avatar_url": "https://avatars.githubusercontent.com/u/52911687?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/bvr-odoo",
+      "html_url": "https://github.com/bvr-odoo",
+      "followers_url": "https://api.github.com/users/bvr-odoo/followers",
+      "following_url": "https://api.github.com/users/bvr-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/bvr-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/bvr-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/bvr-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/bvr-odoo/orgs",
+      "repos_url": "https://api.github.com/users/bvr-odoo/repos",
+      "events_url": "https://api.github.com/users/bvr-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/bvr-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "bvr-odoo",
+      "id": 52911687,
+      "node_id": "MDQ6VXNlcjUyOTExNjg3",
+      "avatar_url": "https://avatars.githubusercontent.com/u/52911687?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/bvr-odoo",
+      "html_url": "https://github.com/bvr-odoo",
+      "followers_url": "https://api.github.com/users/bvr-odoo/followers",
+      "following_url": "https://api.github.com/users/bvr-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/bvr-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/bvr-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/bvr-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/bvr-odoo/orgs",
+      "repos_url": "https://api.github.com/users/bvr-odoo/repos",
+      "events_url": "https://api.github.com/users/bvr-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/bvr-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "b3a6c5904b9c8ce572670b7c817f4bf018146b0f",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/b3a6c5904b9c8ce572670b7c817f4bf018146b0f",
+        "html_url": "https://github.com/odoo/odoo/commit/b3a6c5904b9c8ce572670b7c817f4bf018146b0f"
+      }
+    ],
+    "stats": {
+      "total": 16,
+      "additions": 15,
+      "deletions": 1
+    },
+    "files": [
+      {
+        "sha": "2bc4ea59dd19e3557d921766dd2baf50bc9eb9a3",
+        "filename": "addons/website/static/src/interactions/video/background_video.js",
+        "status": "modified",
+        "additions": 9,
+        "deletions": 1,
+        "changes": 10,
+        "blob_url": "https://github.com/odoo/odoo/blob/d3dc69b0431ae2f037ddb9e0e881ddf03b657638/addons%2Fwebsite%2Fstatic%2Fsrc%2Finteractions%2Fvideo%2Fbackground_video.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/d3dc69b0431ae2f037ddb9e0e881ddf03b657638/addons%2Fwebsite%2Fstatic%2Fsrc%2Finteractions%2Fvideo%2Fbackground_video.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Finteractions%2Fvideo%2Fbackground_video.js?ref=d3dc69b0431ae2f037ddb9e0e881ddf03b657638",
+        "patch": "@@ -67,7 +67,15 @@ export class BackgroundVideo extends Interaction {\n         const wrapperHeight = this.el.clientHeight;\n         const relativeRatio = (wrapperWidth / wrapperHeight) / (16 / 9);\n \n-        if (relativeRatio >= 1.0) {\n+        if (this.el.closest(\".s_ecomm_categories_showcase_block\")) {\n+            // Chrome-only: percentage sizing makes the video in \"Categories\n+            // Showcase\" snippet jitter on hover, so force pixel values while\n+            // keeping the ratio.\n+            const iframeHeight = Math.round(relativeRatio >= 1 ? wrapperWidth * (9 / 16) : wrapperHeight);\n+            const iframeWidth = Math.round(relativeRatio >= 1 ? wrapperWidth : wrapperHeight * (16 / 9));\n+            this.iframeEl.style.height = `${iframeHeight}px`;\n+            this.iframeEl.style.width = `${iframeWidth}px`;\n+        } else if (relativeRatio >= 1.0) {\n             this.iframeEl.style.width = \"100%\";\n             this.iframeEl.style.height = (relativeRatio * 100) + \"%\";\n             this.iframeEl.style.insetInlineStart = \"0\";"
+      },
+      {
+        "sha": "ab4187dcf9d18b7a995e2b153752fe883d5622a3",
+        "filename": "addons/website/static/src/snippets/s_ecomm_categories_showcase/000.scss",
+        "status": "modified",
+        "additions": 6,
+        "deletions": 0,
+        "changes": 6,
+        "blob_url": "https://github.com/odoo/odoo/blob/d3dc69b0431ae2f037ddb9e0e881ddf03b657638/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_ecomm_categories_showcase%2F000.scss",
+        "raw_url": "https://github.com/odoo/odoo/raw/d3dc69b0431ae2f037ddb9e0e881ddf03b657638/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_ecomm_categories_showcase%2F000.scss",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_ecomm_categories_showcase%2F000.scss?ref=d3dc69b0431ae2f037ddb9e0e881ddf03b657638",
+        "patch": "@@ -25,6 +25,12 @@\n             margin: 0;\n             z-index: 2;\n         }\n+\n+        .o_bg_video_container iframe {\n+            top: 50%;\n+            left: 50%;\n+            transform: translate(-50%, -50%);\n+        }\n     }\n \n     .s_ecomm_categories_showcase_content {"
+      }
+    ],
+    "paths": [
+      "addons/website"
+    ]
+  },
+  {
+    "sha": "faf42a1555fd6d268a0b47a2692ceeabde058aef",
+    "node_id": "C_kwDOAS1I7NoAKGZhZjQyYTE1NTVmZDZkMjY4YTBiNDdhMjY5MmNlZWFiZGUwNThhZWY",
+    "commit": {
+      "author": {
+        "name": "Tiffany Chang (tic)",
+        "email": "tic@odoo.com",
+        "date": "2025-10-07T13:45:43Z"
+      },
+      "committer": {
+        "name": "Tiffany Chang (tic)",
+        "email": "tic@odoo.com",
+        "date": "2025-10-15T08:55:45Z"
+      },
+      "message": "[I18N] html_builder: add missing msgstr \"\"\n\npot file was manually edited, resulting in invalid pot file.\n\ncloses odoo/odoo#230409\n\nX-original-commit: a8818f596774a902eb8568fbe7634c3a4bcf7268\nSigned-off-by: Tiffany Chang (tic) <tic@odoo.com>",
+      "tree": {
+        "sha": "27670197c5d0eacf61d5963683415a6801371b29",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/27670197c5d0eacf61d5963683415a6801371b29"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/faf42a1555fd6d268a0b47a2692ceeabde058aef",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/faf42a1555fd6d268a0b47a2692ceeabde058aef",
+    "html_url": "https://github.com/odoo/odoo/commit/faf42a1555fd6d268a0b47a2692ceeabde058aef",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/faf42a1555fd6d268a0b47a2692ceeabde058aef/comments",
+    "author": {
+      "login": "ticodoo",
+      "id": 57942143,
+      "node_id": "MDQ6VXNlcjU3OTQyMTQz",
+      "avatar_url": "https://avatars.githubusercontent.com/u/57942143?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/ticodoo",
+      "html_url": "https://github.com/ticodoo",
+      "followers_url": "https://api.github.com/users/ticodoo/followers",
+      "following_url": "https://api.github.com/users/ticodoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/ticodoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/ticodoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/ticodoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/ticodoo/orgs",
+      "repos_url": "https://api.github.com/users/ticodoo/repos",
+      "events_url": "https://api.github.com/users/ticodoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/ticodoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "ticodoo",
+      "id": 57942143,
+      "node_id": "MDQ6VXNlcjU3OTQyMTQz",
+      "avatar_url": "https://avatars.githubusercontent.com/u/57942143?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/ticodoo",
+      "html_url": "https://github.com/ticodoo",
+      "followers_url": "https://api.github.com/users/ticodoo/followers",
+      "following_url": "https://api.github.com/users/ticodoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/ticodoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/ticodoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/ticodoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/ticodoo/orgs",
+      "repos_url": "https://api.github.com/users/ticodoo/repos",
+      "events_url": "https://api.github.com/users/ticodoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/ticodoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "e29921a6df52ba567132d7ffe63de86eb1efa1ff",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/e29921a6df52ba567132d7ffe63de86eb1efa1ff",
+        "html_url": "https://github.com/odoo/odoo/commit/e29921a6df52ba567132d7ffe63de86eb1efa1ff"
+      }
+    ],
+    "stats": {
+      "total": 1,
+      "additions": 1,
+      "deletions": 0
+    },
+    "files": [
+      {
+        "sha": "3be07df397e921b7f82f0c67ac03d0d492e1d141",
+        "filename": "addons/html_builder/i18n/html_builder.pot",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 0,
+        "changes": 1,
+        "blob_url": "https://github.com/odoo/odoo/blob/faf42a1555fd6d268a0b47a2692ceeabde058aef/addons%2Fhtml_builder%2Fi18n%2Fhtml_builder.pot",
+        "raw_url": "https://github.com/odoo/odoo/raw/faf42a1555fd6d268a0b47a2692ceeabde058aef/addons%2Fhtml_builder%2Fi18n%2Fhtml_builder.pot",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_builder%2Fi18n%2Fhtml_builder.pot?ref=faf42a1555fd6d268a0b47a2692ceeabde058aef",
+        "patch": "@@ -3024,6 +3024,7 @@ msgstr \"\"\n #. odoo-javascript\n #: code:addons/html_builder/static/src/plugins/background_option/background_shapes_definition.js:0\n msgid \"Wavy 14\"\n+msgstr \"\"\n \n #. module: html_builder\n #. odoo-javascript"
+      }
+    ],
+    "paths": [
+      "addons/html_builder"
+    ]
+  },
+  {
+    "sha": "899c08bd2ba2f8571cf025245219621d36ed999c",
+    "node_id": "C_kwDOAS1I7NoAKDg5OWMwOGJkMmJhMmY4NTcxY2YwMjUyNDUyMTk2MjFkMzZlZDk5OWM",
+    "commit": {
+      "author": {
+        "name": "Serhii Rubanskyi",
+        "email": "seru@odoo.com",
+        "date": "2025-10-14T12:28:04Z"
+      },
+      "committer": {
+        "name": "Serhii Rubanskyi",
+        "email": "seru@odoo.com",
+        "date": "2025-10-15T06:36:33Z"
+      },
+      "message": "[IMP] html_editor, web, website: export color picker tabs\n\nSince the [1] color picker tabs are plugable now, and so, in order to\nbe able to patch them we'd need to export them. This commit exports\nthem all at once.\n\n[1]: https://github.com/odoo/odoo/commit/edc9d5bb9582db704ed02051ee4adb3801ddfaa9\n\ncloses odoo/odoo#231551\n\nX-original-commit: 2e175aecf2db567ed879190531cf4f80cc81facd\nSigned-off-by: Robin Lejeune (role) <role@odoo.com>\nSigned-off-by: Serhii Rubanskyi (seru) <seru@odoo.com>",
+      "tree": {
+        "sha": "943e41abe36a75fbe714f4ff1ea3231be71e5772",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/943e41abe36a75fbe714f4ff1ea3231be71e5772"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/899c08bd2ba2f8571cf025245219621d36ed999c",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/899c08bd2ba2f8571cf025245219621d36ed999c",
+    "html_url": "https://github.com/odoo/odoo/commit/899c08bd2ba2f8571cf025245219621d36ed999c",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/899c08bd2ba2f8571cf025245219621d36ed999c/comments",
+    "author": {
+      "login": "Syozik",
+      "id": 82968368,
+      "node_id": "MDQ6VXNlcjgyOTY4MzY4",
+      "avatar_url": "https://avatars.githubusercontent.com/u/82968368?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/Syozik",
+      "html_url": "https://github.com/Syozik",
+      "followers_url": "https://api.github.com/users/Syozik/followers",
+      "following_url": "https://api.github.com/users/Syozik/following{/other_user}",
+      "gists_url": "https://api.github.com/users/Syozik/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/Syozik/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/Syozik/subscriptions",
+      "organizations_url": "https://api.github.com/users/Syozik/orgs",
+      "repos_url": "https://api.github.com/users/Syozik/repos",
+      "events_url": "https://api.github.com/users/Syozik/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/Syozik/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "Syozik",
+      "id": 82968368,
+      "node_id": "MDQ6VXNlcjgyOTY4MzY4",
+      "avatar_url": "https://avatars.githubusercontent.com/u/82968368?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/Syozik",
+      "html_url": "https://github.com/Syozik",
+      "followers_url": "https://api.github.com/users/Syozik/followers",
+      "following_url": "https://api.github.com/users/Syozik/following{/other_user}",
+      "gists_url": "https://api.github.com/users/Syozik/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/Syozik/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/Syozik/subscriptions",
+      "organizations_url": "https://api.github.com/users/Syozik/orgs",
+      "repos_url": "https://api.github.com/users/Syozik/repos",
+      "events_url": "https://api.github.com/users/Syozik/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/Syozik/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "387bd4f830469555864a36e284339d18c049aeff",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/387bd4f830469555864a36e284339d18c049aeff",
+        "html_url": "https://github.com/odoo/odoo/commit/387bd4f830469555864a36e284339d18c049aeff"
+      }
+    ],
+    "stats": {
+      "total": 8,
+      "additions": 4,
+      "deletions": 4
+    },
+    "files": [
+      {
+        "sha": "80ed3a7e57d9714944574997780145d14664dc8c",
+        "filename": "addons/html_builder/static/src/core/building_blocks/color_picker_theme_tab.js",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/899c08bd2ba2f8571cf025245219621d36ed999c/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fcore%2Fbuilding_blocks%2Fcolor_picker_theme_tab.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/899c08bd2ba2f8571cf025245219621d36ed999c/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fcore%2Fbuilding_blocks%2Fcolor_picker_theme_tab.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fcore%2Fbuilding_blocks%2Fcolor_picker_theme_tab.js?ref=899c08bd2ba2f8571cf025245219621d36ed999c",
+        "patch": "@@ -2,7 +2,7 @@ import { Component } from \"@odoo/owl\";\n import { _t } from \"@web/core/l10n/translation\";\n import { registry } from \"@web/core/registry\";\n \n-class ColorPickerThemeTab extends Component {\n+export class ColorPickerThemeTab extends Component {\n     static template = \"html_builder.ColorPickerThemeTab\";\n     static props = {\n         onColorClick: Function,"
+      },
+      {
+        "sha": "9e6fea4c6124a48f7f438d223c518e20e1951aa4",
+        "filename": "addons/html_editor/static/src/main/font/color_picker_gradient_tab.js",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/899c08bd2ba2f8571cf025245219621d36ed999c/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fmain%2Ffont%2Fcolor_picker_gradient_tab.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/899c08bd2ba2f8571cf025245219621d36ed999c/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fmain%2Ffont%2Fcolor_picker_gradient_tab.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fmain%2Ffont%2Fcolor_picker_gradient_tab.js?ref=899c08bd2ba2f8571cf025245219621d36ed999c",
+        "patch": "@@ -15,7 +15,7 @@ const DEFAULT_GRADIENT_COLORS = [\n     \"linear-gradient(135deg, rgb(255, 222, 202) 0%, rgb(202, 115, 69) 100%)\",\n ];\n \n-class ColorPickerGradientTab extends Component {\n+export class ColorPickerGradientTab extends Component {\n     static template = \"html_editor.ColorPickerGradientTab\";\n     static components = { GradientPicker };\n     static props = {"
+      },
+      {
+        "sha": "e7feb5884e934c8779f5d85875d157998285b2e5",
+        "filename": "addons/web/static/src/core/color_picker/tabs/color_picker_custom_tab.js",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/899c08bd2ba2f8571cf025245219621d36ed999c/addons%2Fweb%2Fstatic%2Fsrc%2Fcore%2Fcolor_picker%2Ftabs%2Fcolor_picker_custom_tab.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/899c08bd2ba2f8571cf025245219621d36ed999c/addons%2Fweb%2Fstatic%2Fsrc%2Fcore%2Fcolor_picker%2Ftabs%2Fcolor_picker_custom_tab.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fweb%2Fstatic%2Fsrc%2Fcore%2Fcolor_picker%2Ftabs%2Fcolor_picker_custom_tab.js?ref=899c08bd2ba2f8571cf025245219621d36ed999c",
+        "patch": "@@ -4,7 +4,7 @@ import { registry } from \"@web/core/registry\";\n import { isColorGradient } from \"@web/core/utils/colors\";\n import { CustomColorPicker } from \"../custom_color_picker/custom_color_picker\";\n \n-class ColorPickerCustomTab extends Component {\n+export class ColorPickerCustomTab extends Component {\n     static template = \"web.ColorPickerCustomTab\";\n     static components = { CustomColorPicker };\n     static props = {"
+      },
+      {
+        "sha": "5025a7e4cb037e68c5732de9c9b70e491fe38ace",
+        "filename": "addons/web/static/src/core/color_picker/tabs/color_picker_solid_tab.js",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/899c08bd2ba2f8571cf025245219621d36ed999c/addons%2Fweb%2Fstatic%2Fsrc%2Fcore%2Fcolor_picker%2Ftabs%2Fcolor_picker_solid_tab.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/899c08bd2ba2f8571cf025245219621d36ed999c/addons%2Fweb%2Fstatic%2Fsrc%2Fcore%2Fcolor_picker%2Ftabs%2Fcolor_picker_solid_tab.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fweb%2Fstatic%2Fsrc%2Fcore%2Fcolor_picker%2Ftabs%2Fcolor_picker_solid_tab.js?ref=899c08bd2ba2f8571cf025245219621d36ed999c",
+        "patch": "@@ -2,7 +2,7 @@ import { Component } from \"@odoo/owl\";\n import { _t } from \"@web/core/l10n/translation\";\n import { registry } from \"@web/core/registry\";\n \n-class ColorPickerSolidTab extends Component {\n+export class ColorPickerSolidTab extends Component {\n     static template = \"web.ColorPickerSolidTab\";\n     static props = {\n         colorPickerNavigation: Function,"
+      }
+    ],
+    "paths": [
+      "addons/html_builder"
+    ]
+  },
+  {
+    "sha": "19409315e54c28d1b411e0e6ea3226ee09d20084",
+    "node_id": "C_kwDOAS1I7NoAKDE5NDA5MzE1ZTU0YzI4ZDFiNDExZTBlNmVhMzIyNmVlMDlkMjAwODQ",
+    "commit": {
+      "author": {
+        "name": "Julien (jula)",
+        "email": "jula@odoo.com",
+        "date": "2025-10-01T08:23:28Z"
+      },
+      "committer": {
+        "name": "Julien Launois (jula)",
+        "email": "jula@odoo.com",
+        "date": "2025-10-14T10:10:16Z"
+      },
+      "message": "[FIX] html_builder, *: fix non-deterministic crash on editor reload\n\n*: website_sale\n\n__Current behavior before commit:__\nSome builder actions (e.g `ProductPageImageLayoutAction`) reload the\neditor after being applied. If another button in the builder is pressed\nrapidly, `refreshCurrentItem` might be called after the editor is\ndestroyed leading to the following error in [`isApplied`]:\n\n`TypeError: Cannot read properties of undefined (reading 'getAction')`.\n\nThe \"Product page options\" test fails in rare occasion due to this\nissue.\n\n__Description of the fix:__\n- Add a safety guard to make sure the editor is not destroyed before\ncalling `refreshCurrentItem`.\n- Add some checks at the end of the test in order for the crash to\nappear consistently (if the fix is not applied).\n- Make the test more robust (some code is backported from\n[this commit]).\n\n[this commit]: https://github.com/odoo/odoo/commit/670b1daa2254d76\n[`isApplied`]: https://github.com/odoo/odoo/blob/f258b263136f606f7896/addons/html_builder/static/src/core/utils.js#L939\n\nRunbot error: https://runbot.odoo.com/odoo/runbot.build.error/232649\n\ncloses odoo/odoo#230179\n\nX-original-commit: c3bbd7509b381fce59fc9e1aad43d5147e5b9af4\nSigned-off-by: Francois Georis (fge) <fge@odoo.com>\nSigned-off-by: Julien Launois (jula) <jula@odoo.com>",
+      "tree": {
+        "sha": "9d1931f118d4a3abab4f0b1f88d82dd58d518f06",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/9d1931f118d4a3abab4f0b1f88d82dd58d518f06"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/19409315e54c28d1b411e0e6ea3226ee09d20084",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/19409315e54c28d1b411e0e6ea3226ee09d20084",
+    "html_url": "https://github.com/odoo/odoo/commit/19409315e54c28d1b411e0e6ea3226ee09d20084",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/19409315e54c28d1b411e0e6ea3226ee09d20084/comments",
+    "author": {
+      "login": "Dj0ulo",
+      "id": 46035353,
+      "node_id": "MDQ6VXNlcjQ2MDM1MzUz",
+      "avatar_url": "https://avatars.githubusercontent.com/u/46035353?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/Dj0ulo",
+      "html_url": "https://github.com/Dj0ulo",
+      "followers_url": "https://api.github.com/users/Dj0ulo/followers",
+      "following_url": "https://api.github.com/users/Dj0ulo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/Dj0ulo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/Dj0ulo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/Dj0ulo/subscriptions",
+      "organizations_url": "https://api.github.com/users/Dj0ulo/orgs",
+      "repos_url": "https://api.github.com/users/Dj0ulo/repos",
+      "events_url": "https://api.github.com/users/Dj0ulo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/Dj0ulo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "Dj0ulo",
+      "id": 46035353,
+      "node_id": "MDQ6VXNlcjQ2MDM1MzUz",
+      "avatar_url": "https://avatars.githubusercontent.com/u/46035353?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/Dj0ulo",
+      "html_url": "https://github.com/Dj0ulo",
+      "followers_url": "https://api.github.com/users/Dj0ulo/followers",
+      "following_url": "https://api.github.com/users/Dj0ulo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/Dj0ulo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/Dj0ulo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/Dj0ulo/subscriptions",
+      "organizations_url": "https://api.github.com/users/Dj0ulo/orgs",
+      "repos_url": "https://api.github.com/users/Dj0ulo/repos",
+      "events_url": "https://api.github.com/users/Dj0ulo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/Dj0ulo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "421def4492601f15c81efe539755ca96ac2f06f1",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/421def4492601f15c81efe539755ca96ac2f06f1",
+        "html_url": "https://github.com/odoo/odoo/commit/421def4492601f15c81efe539755ca96ac2f06f1"
+      }
+    ],
+    "stats": {
+      "total": 16,
+      "additions": 12,
+      "deletions": 4
+    },
+    "files": [
+      {
+        "sha": "c42f94b1378928dca48cca0591d11f32517e2dbd",
+        "filename": "addons/html_builder/static/src/core/utils.js",
+        "status": "modified",
+        "additions": 3,
+        "deletions": 0,
+        "changes": 3,
+        "blob_url": "https://github.com/odoo/odoo/blob/19409315e54c28d1b411e0e6ea3226ee09d20084/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fcore%2Futils.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/19409315e54c28d1b411e0e6ea3226ee09d20084/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fcore%2Futils.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fcore%2Futils.js?ref=19409315e54c28d1b411e0e6ea3226ee09d20084",
+        "patch": "@@ -239,6 +239,9 @@ export function useSelectableComponent(id, { onItemChange } = {}) {\n     });\n \n     function refreshCurrentItem() {\n+        if (env.editor.isDestroyed) {\n+            return;\n+        }\n         let currentItem;\n         let itemPriority = 0;\n         for (const selectableItem of selectableItems) {"
+      },
+      {
+        "sha": "8a30786408c8e78cdaa989fb62a0d107b853f4f3",
+        "filename": "addons/website_sale/static/tests/builder/product_page_option.test.js",
+        "status": "modified",
+        "additions": 9,
+        "deletions": 4,
+        "changes": 13,
+        "blob_url": "https://github.com/odoo/odoo/blob/19409315e54c28d1b411e0e6ea3226ee09d20084/addons%2Fwebsite_sale%2Fstatic%2Ftests%2Fbuilder%2Fproduct_page_option.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/19409315e54c28d1b411e0e6ea3226ee09d20084/addons%2Fwebsite_sale%2Fstatic%2Ftests%2Fbuilder%2Fproduct_page_option.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite_sale%2Fstatic%2Ftests%2Fbuilder%2Fproduct_page_option.test.js?ref=19409315e54c28d1b411e0e6ea3226ee09d20084",
+        "patch": "@@ -97,22 +97,21 @@ test(\"Product page options\", async () => {\n     await contains(\":iframe .o_wsale_product_page\").click();\n     await contains(\"[data-action-id=productReplaceMainImage]\").click();\n     await contains(\".o_select_media_dialog .o_existing_attachment_cell button\").click();\n+    await expect.waitForSteps([\"theme_customize_data_get\", \"get_image_info\"]);\n     await waitForNone(\".o_select_media_dialog\");\n \n     expect(\":iframe #product_detail_main img[src^='data:image/webp;base64,']\").toHaveCount(1);\n     expect(\":iframe img\").toHaveCount(2);\n-    expect.verifySteps([\"theme_customize_data_get\", \"get_image_info\"]);\n-\n     await contains(\"button#o_wsale_image_width\").click();\n     // Avoid selecting the first option to prevent the image layout option from disappearing\n     await contains(\"[data-action-id=productPageImageWidth][data-action-value='50_pc']\").click();\n+    await expect.waitForSteps([\"config\"]);\n     await waitSidebarUpdated();\n-    expect.verifySteps([\"config\"]);\n \n     await contains(\"button#o_wsale_image_layout\").click();\n     await contains(\"[data-action-id=productPageImageLayout]\").click();\n     await waitSidebarUpdated();\n-    expect.verifySteps([\n+    await expect.waitForSteps([\n         // Activate the carousel view and change the shop config\n         \"config\",\n         // Shop config changes don't trigger the `savePlugin`; image edits are saved because of the\n@@ -125,4 +124,10 @@ test(\"Product page options\", async () => {\n         // Reload the view\n         \"theme_customize_data_get\"\n     ]);\n+\n+    // Make sure that clicking quickly on a builder button after an clicking on\n+    // an action that reloads the editor does not produce a crash.\n+    await contains(\"[data-action-id=websiteConfig].o_we_buy_now_btn\").click();\n+    await contains(\"button#o_wsale_image_layout\").click();\n+    await expect.waitForSteps([\"theme_customize_data\", \"theme_customize_data_get\"]);\n });"
+      }
+    ],
+    "paths": [
+      "addons/html_builder",
+      "addons/website"
+    ]
+  },
+  {
+    "sha": "a34aee6aadb8c9a26d1f1d93bc8d94d964bbe8dc",
+    "node_id": "C_kwDOAS1I7NoAKGEzNGFlZTZhYWRiOGM5YTI2ZDFmMWQ5M2JjOGQ5NGQ5NjRiYmU4ZGM",
+    "commit": {
+      "author": {
+        "name": "assk-odoo",
+        "email": "assk@odoo.com",
+        "date": "2025-07-24T07:08:18Z"
+      },
+      "committer": {
+        "name": "assk-odoo",
+        "email": "assk@odoo.com",
+        "date": "2025-10-10T16:10:04Z"
+      },
+      "message": "[FIX] website: prevent crash editing job location\n\nSteps to reproduce:\n1. Go to Website \u2192 Jobs.\n2. Open any job application.\n3. Change the Job Location to the option \"Remote\".\n4. A traceback occurs.\n\nContext:\n\"Remote\" option was originally introduced in dropdown (see PR[1]).\nLater, it was removed during refactoring in (see PR[2]).\n\nBefore this commit:\nWhen selecting a job location, initially no Many2One field is selected,\nthat's why no many2oneid is find. which results in a null value being\nreturned. This caused a traceback error\n\nAfter this commit:\nThe \"Remote\" option is explicitly included in the dropdown, restoring\nthe previous behavior.\n\n[1] https://github.com/odoo/odoo/pull/67913\n[2] https://github.com/odoo/odoo/pull/187419\n\ncloses odoo/odoo#230986\n\nX-original-commit: fa81ccfbc6d6bd5837af2b8584de55196f35156a\nSigned-off-by: Francois Georis (fge) <fge@odoo.com>\nSigned-off-by: Sujal Kamleshbhai Asodariya (assk) <assk@odoo.com>",
+      "tree": {
+        "sha": "f621ae6dc44b52b7d900cbf503f6d0cf86f90e88",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/f621ae6dc44b52b7d900cbf503f6d0cf86f90e88"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/a34aee6aadb8c9a26d1f1d93bc8d94d964bbe8dc",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/a34aee6aadb8c9a26d1f1d93bc8d94d964bbe8dc",
+    "html_url": "https://github.com/odoo/odoo/commit/a34aee6aadb8c9a26d1f1d93bc8d94d964bbe8dc",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/a34aee6aadb8c9a26d1f1d93bc8d94d964bbe8dc/comments",
+    "author": {
+      "login": "assk-odoo",
+      "id": 195764924,
+      "node_id": "U_kgDOC6sivA",
+      "avatar_url": "https://avatars.githubusercontent.com/u/195764924?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/assk-odoo",
+      "html_url": "https://github.com/assk-odoo",
+      "followers_url": "https://api.github.com/users/assk-odoo/followers",
+      "following_url": "https://api.github.com/users/assk-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/assk-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/assk-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/assk-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/assk-odoo/orgs",
+      "repos_url": "https://api.github.com/users/assk-odoo/repos",
+      "events_url": "https://api.github.com/users/assk-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/assk-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "assk-odoo",
+      "id": 195764924,
+      "node_id": "U_kgDOC6sivA",
+      "avatar_url": "https://avatars.githubusercontent.com/u/195764924?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/assk-odoo",
+      "html_url": "https://github.com/assk-odoo",
+      "followers_url": "https://api.github.com/users/assk-odoo/followers",
+      "following_url": "https://api.github.com/users/assk-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/assk-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/assk-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/assk-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/assk-odoo/orgs",
+      "repos_url": "https://api.github.com/users/assk-odoo/repos",
+      "events_url": "https://api.github.com/users/assk-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/assk-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "b39b6a0b33b8585c920ce1347ac0d2ff928ac6e2",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/b39b6a0b33b8585c920ce1347ac0d2ff928ac6e2",
+        "html_url": "https://github.com/odoo/odoo/commit/b39b6a0b33b8585c920ce1347ac0d2ff928ac6e2"
+      }
+    ],
+    "stats": {
+      "total": 91,
+      "additions": 84,
+      "deletions": 7
+    },
+    "files": [
+      {
+        "sha": "39e4f239fb3e46062c065f80348133261cb27e10",
+        "filename": "addons/html_builder/static/src/core/building_blocks/builder_many2one.js",
+        "status": "modified",
+        "additions": 12,
+        "deletions": 5,
+        "changes": 17,
+        "blob_url": "https://github.com/odoo/odoo/blob/a34aee6aadb8c9a26d1f1d93bc8d94d964bbe8dc/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fcore%2Fbuilding_blocks%2Fbuilder_many2one.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/a34aee6aadb8c9a26d1f1d93bc8d94d964bbe8dc/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fcore%2Fbuilding_blocks%2Fbuilder_many2one.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fcore%2Fbuilding_blocks%2Fbuilder_many2one.js?ref=a34aee6aadb8c9a26d1f1d93bc8d94d964bbe8dc",
+        "patch": "@@ -23,6 +23,7 @@ export class BuilderMany2One extends Component {\n         allowUnselect: { type: Boolean, optional: true },\n         defaultMessage: { type: String, optional: true },\n         createAction: { type: String, optional: true },\n+        nullText: { type: String, optional: true },\n     };\n     static defaultProps = {\n         ...BuilderComponent.defaultProps,\n@@ -50,16 +51,22 @@ export class BuilderMany2One extends Component {\n             const selectedString = getValue(el);\n             const selected = selectedString && JSON.parse(selectedString);\n             if (selected && !(\"display_name\" in selected && \"name\" in selected)) {\n-                Object.assign(\n-                    selected,\n-                    (\n+                let value;\n+                if (!selected.id) {\n+                    value = {\n+                        display_name: this.props.nullText,\n+                        name: this.props.nullText,\n+                    };\n+                } else {\n+                    value = (\n                         await this.cachedModel.ormRead(\n                             this.props.model,\n                             [selected.id],\n                             [\"display_name\", \"name\"]\n                         )\n-                    )[0]\n-                );\n+                    )[0];\n+                }\n+                Object.assign(selected, value);\n             }\n \n             return { selected };"
+      },
+      {
+        "sha": "be2345334ee19a8b3127d3701796d7ba984f3446",
+        "filename": "addons/html_builder/static/src/core/building_blocks/builder_many2one.xml",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 0,
+        "changes": 1,
+        "blob_url": "https://github.com/odoo/odoo/blob/a34aee6aadb8c9a26d1f1d93bc8d94d964bbe8dc/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fcore%2Fbuilding_blocks%2Fbuilder_many2one.xml",
+        "raw_url": "https://github.com/odoo/odoo/raw/a34aee6aadb8c9a26d1f1d93bc8d94d964bbe8dc/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fcore%2Fbuilding_blocks%2Fbuilder_many2one.xml",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fcore%2Fbuilding_blocks%2Fbuilder_many2one.xml?ref=a34aee6aadb8c9a26d1f1d93bc8d94d964bbe8dc",
+        "patch": "@@ -7,6 +7,7 @@\n             model=\"props.model\"\n             fields=\"props.fields\"\n             limit=\"props.limit\"\n+            nullText=\"props.nullText\"\n             domain=\"props.domain\"\n             selected=\"domState.selected ? [domState.selected] : []\"\n             select=\"select.bind(this)\""
+      },
+      {
+        "sha": "a006db2647d06b0fa4e93fbd8e75537efdb0656b",
+        "filename": "addons/html_builder/static/src/core/building_blocks/select_many2x.js",
+        "status": "modified",
+        "additions": 10,
+        "deletions": 1,
+        "changes": 11,
+        "blob_url": "https://github.com/odoo/odoo/blob/a34aee6aadb8c9a26d1f1d93bc8d94d964bbe8dc/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fcore%2Fbuilding_blocks%2Fselect_many2x.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/a34aee6aadb8c9a26d1f1d93bc8d94d964bbe8dc/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fcore%2Fbuilding_blocks%2Fselect_many2x.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fcore%2Fbuilding_blocks%2Fselect_many2x.js?ref=a34aee6aadb8c9a26d1f1d93bc8d94d964bbe8dc",
+        "patch": "@@ -40,6 +40,7 @@ export class SelectMany2X extends Component {\n         closeOnEnterKey: { type: Boolean, optional: true },\n         message: { type: String, optional: true },\n         create: { type: Function, optional: true },\n+        nullText: { type: String, optional: true },\n     };\n     static defaultProps = {\n         fields: [],\n@@ -100,11 +101,19 @@ export class SelectMany2X extends Component {\n             limit: this.state.limit + 1,\n         });\n         this.state.hasMore = tuples.length > this.state.limit;\n-        this.state.searchResults = await this.cachedModel.ormRead(\n+        const results = await this.cachedModel.ormRead(\n             this.props.model,\n             tuples.slice(0, this.state.limit).map(([id, _name]) => id),\n             [...new Set(this.props.fields).add(\"display_name\").add(\"name\")]\n         );\n+        if (this.props.nullText && (!results.length || results[0].id)) {\n+            results.unshift({\n+                id: 0,\n+                name: this.props.nullText,\n+                display_name: this.props.nullText,\n+            });\n+        }\n+        this.state.searchResults = results;\n     }\n     filteredSearchResult() {\n         const selectedIds = new Set(this.props.selected.map((e) => e.id));"
+      },
+      {
+        "sha": "c6f03d3d15f47343fe1ad0a8e782ee41ef2c991c",
+        "filename": "addons/html_builder/static/src/plugins/many2one_option.js",
+        "status": "modified",
+        "additions": 2,
+        "deletions": 0,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/a34aee6aadb8c9a26d1f1d93bc8d94d964bbe8dc/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fplugins%2Fmany2one_option.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/a34aee6aadb8c9a26d1f1d93bc8d94d964bbe8dc/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fplugins%2Fmany2one_option.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fplugins%2Fmany2one_option.js?ref=a34aee6aadb8c9a26d1f1d93bc8d94d964bbe8dc",
+        "patch": "@@ -10,6 +10,8 @@ export class Many2OneOption extends BaseOptionComponent {\n         this.orm = useService(\"orm\");\n         onWillStart(async () => {\n             const el = this.env.getEditingElement();\n+            const contactOpts = JSON.parse(el.dataset.oeContactOptions || \"{}\");\n+            this.nullText = contactOpts.null_text;\n             this.model = el.dataset.oeMany2oneModel;\n             this.domain = JSON.parse(el.dataset.oeMany2oneDomain|| \"[]\");\n             const searchResult = await this.orm.searchRead("
+      },
+      {
+        "sha": "f23127cccf8a6d5f2ed8d39137040fe739e792a7",
+        "filename": "addons/html_builder/static/src/plugins/many2one_option.xml",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/a34aee6aadb8c9a26d1f1d93bc8d94d964bbe8dc/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fplugins%2Fmany2one_option.xml",
+        "raw_url": "https://github.com/odoo/odoo/raw/a34aee6aadb8c9a26d1f1d93bc8d94d964bbe8dc/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fplugins%2Fmany2one_option.xml",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fplugins%2Fmany2one_option.xml?ref=a34aee6aadb8c9a26d1f1d93bc8d94d964bbe8dc",
+        "patch": "@@ -3,7 +3,7 @@\n \n <t t-name=\"html_builder.Many2OneOption\">\n     <BuilderRow label=\"label\">\n-        <BuilderMany2One action=\"'many2One'\" model=\"model\" fields=\"['name']\" domain=\"domain\" allowUnselect=\"false\"/>\n+        <BuilderMany2One action=\"'many2One'\" model=\"model\" fields=\"['name']\" domain=\"domain\" nullText=\"nullText\" allowUnselect=\"false\"/>\n     </BuilderRow>\n </t>\n "
+      },
+      {
+        "sha": "91b2704b9ac818e07417760c9316c309b5fc1e47",
+        "filename": "addons/html_builder/static/tests/custom_tab/builder_components/builder_many2one.test.js",
+        "status": "modified",
+        "additions": 37,
+        "deletions": 0,
+        "changes": 37,
+        "blob_url": "https://github.com/odoo/odoo/blob/a34aee6aadb8c9a26d1f1d93bc8d94d964bbe8dc/addons%2Fhtml_builder%2Fstatic%2Ftests%2Fcustom_tab%2Fbuilder_components%2Fbuilder_many2one.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/a34aee6aadb8c9a26d1f1d93bc8d94d964bbe8dc/addons%2Fhtml_builder%2Fstatic%2Ftests%2Fcustom_tab%2Fbuilder_components%2Fbuilder_many2one.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_builder%2Fstatic%2Ftests%2Fcustom_tab%2Fbuilder_components%2Fbuilder_many2one.test.js?ref=a34aee6aadb8c9a26d1f1d93bc8d94d964bbe8dc",
+        "patch": "@@ -128,3 +128,40 @@ test(\"dependency definition should not be outdated\", async () => {\n     await contains(\"span.o-dropdown-item:contains(Third)\").click();\n     expect(\"span:contains(Dependant)\").toHaveCount(0);\n });\n+\n+test(\"BuilderMany2One: add null_text option in website builder dropdown\", async () => {\n+    onRpc(\"test\", \"name_search\", () => [\n+        [1, \"First\"],\n+        [2, \"Second\"],\n+        [3, \"Third\"],\n+    ]);\n+    addBuilderAction({\n+        testAction: class extends BuilderAction {\n+            static id = \"testAction\";\n+            apply({ editingElement, value }) {\n+                editingElement.textContent = JSON.parse(value).name;\n+                editingElement.dataset.test = value;\n+            }\n+            getValue({ editingElement }) {\n+                return editingElement.dataset.test;\n+            }\n+        },\n+    });\n+    addBuilderOption(\n+        class extends BaseOptionComponent {\n+            static selector = \".test-options-target\";\n+            static template = xml`<BuilderMany2One action=\"'testAction'\" model=\"'test'\" limit=\"10\" nullText=\"'Remote'\"/>`;\n+        }\n+    );\n+    const { getEditableContent } = await setupHTMLBuilder(`\n+        <div class=\"test-options-target\">b</div>\n+    `);\n+    const editableContent = getEditableContent();\n+    await contains(\":iframe .test-options-target\").click();\n+    await contains(\".btn.o-dropdown\").click();\n+    await contains(\"span.o-dropdown-item:contains('Remote')\").click();\n+    expect(editableContent.textContent.trim()).toBe(\"Remote\");\n+    await contains(\".btn.o-dropdown\").click();\n+    await contains(\"span.o-dropdown-item:contains('First')\").click();\n+    expect(editableContent.textContent.trim()).toBe(\"First\");\n+});"
+      },
+      {
+        "sha": "10d2191f9f666b6deb7281bde6dbc46a0066ff9e",
+        "filename": "addons/html_builder/static/tests/many2one_field.test.js",
+        "status": "modified",
+        "additions": 21,
+        "deletions": 0,
+        "changes": 21,
+        "blob_url": "https://github.com/odoo/odoo/blob/a34aee6aadb8c9a26d1f1d93bc8d94d964bbe8dc/addons%2Fhtml_builder%2Fstatic%2Ftests%2Fmany2one_field.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/a34aee6aadb8c9a26d1f1d93bc8d94d964bbe8dc/addons%2Fhtml_builder%2Fstatic%2Ftests%2Fmany2one_field.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_builder%2Fstatic%2Ftests%2Fmany2one_field.test.js?ref=a34aee6aadb8c9a26d1f1d93bc8d94d964bbe8dc",
+        "patch": "@@ -52,3 +52,24 @@ test(\"Preview changes of many2one option\", async () => {\n     expect(\":iframe span.span-2 > span\").toHaveText(\"The Address of 3\");\n     expect(\":iframe span.span-4\").toHaveText(\"Other\");\n });\n+\n+test(\"Many2OneOption: add null_text option in dropdown\", async () => {\n+    onRpc(\n+        \"ir.qweb.field.contact\",\n+        \"get_record_to_html\",\n+        ({ args: [[id]], kwargs }) => `<span>The ${kwargs.options.option} of ${id}</span>`\n+    );\n+    await setupHTMLBuilder(`\n+        <div class=\"many2oneoption_dropdown\"\n+            data-oe-many2one-id=\"1\"\n+            data-oe-many2one-model=\"res.partner\"\n+            data-oe-contact-options='{\"null_text\":\"Remote\"}'>\n+            <span>location</span>\n+        </div>\n+    `);\n+    await contains(\":iframe .many2oneoption_dropdown\").click();\n+    expect(\"button.btn.dropdown\").toHaveCount(1);\n+    await contains(\"button.btn.dropdown\").click();\n+    await contains(\"span.o-dropdown-item.dropdown-item:contains('Remote')\").click();\n+    expect(\":iframe div.many2oneoption_dropdown\").toHaveText(\"Remote\");\n+});"
+      }
+    ],
+    "paths": [
+      "addons/html_builder"
+    ]
+  }
+]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ nav:
   - Tutorials:
     - Create your own Builder Component: tutorials/create-your-own-builder-component.md
   - Reports:
+    - Website & HTML Builder Commits (9–15 Oct 2025): reports/2025-10-15-odoo-website-html-builder-commits.md
     - Website & HTML Builder Commits (1–8 Oct 2025): reports/2025-10-08-odoo-website-html-builder-commits.md
     - Website & HTML Builder Commits (25 Sep–1 Oct 2025): reports/2025-10-01-odoo-website-html-builder-commits.md
     - Website & HTML Builder Commits (17–24 Sep 2025): reports/2025-09-24-odoo-website-html-builder-commits.md


### PR DESCRIPTION
## Summary
- add the 9–15 Oct 2025 Website & HTML Builder weekly commit digest with highlights and tables
- snapshot the GitHub API commit data for the covered paths and dates
- register the new digest in the mkdocs navigation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68efa25bb9e08331915f27c59b7d5f1a