### PR TITLE
Add Oct 22–29 2025 website/html builder weekly digest

### DIFF
--- a/docs/reports/2025-10-29-odoo-website-html-builder-commits.md
+++ b/docs/reports/2025-10-29-odoo-website-html-builder-commits.md
@@ -1,0 +1,54 @@
+# Odoo Website & HTML Builder — Weekly Commit Digest (22–29 Oct 2025)
+This digest covers all commits merged into the `odoo/odoo` repository’s `master` branch between **22 and 29 October 2025** (UTC).
+
+The window is based on the committer timestamp — the moment GitHub records the change as landing in `master` — and is limited to
+updates that touched `addons/website`, `addons/html_builder`, or `addons/website_sale/static/src/website_builder`. The list was
+assembled on 29 Oct 2025 using the GitHub REST API with scoped path filters for all three areas, then re-queried to confirm the
+final set matches every commit that landed in `master` during the window. No Website Builder assets shipped from
+`website_sale/static/src/website_builder` this week, although one test update touched that module’s suite.
+
+## Commit of the Week
+- **[350da9c](https://github.com/odoo/odoo/commit/350da9c8561276a45d65b3e74418a8cfc28eda16)** — Introduces the new
+  `s_newsletter_aside` snippet with dedicated preview assets and shared mass-mailing options, giving sites an out-of-the-box
+  newsletter layout that pairs copy with a visual call to action.
+
+## Highlights
+- **Fresh conversion snippets.** The redesigned contact page and new `s_newsletter_aside` snippet ship updated imagery, map
+  defaults, and CTA icons so freshly generated sites feel polished from the first publish.
+- **Builder stability & controls.** Header content, image shape options, background patterns, and aspect-ratio toggles all
+  received fixes, while the editor’s automated tests now simulate server errors correctly to avoid false positives.
+- **Configurator & form polish.** Loading indicators, dropdown interactions, form field safeguards, and cache keys were all tuned
+  to keep the website configurator and out-of-the-box forms responsive across devices.
+
+## Commit details
+| Merged (UTC) | Commit | Author | Scope | Summary |
+| --- | --- | --- | --- | --- |
+| 2025-10-29 | [c528c9c](https://github.com/odoo/odoo/commit/c528c9c198825c01e67d89f2dad79aceb010e22f) | assh-odoo | website | Guard the Send Email snippet so submissions no longer crash when required values are missing. |
+| 2025-10-29 | [7406a05](https://github.com/odoo/odoo/commit/7406a05116d9adeb8f0aada996cda06f978194f2) | divy-odoo | website | Show a fullscreen loader when fetching additional website themes so users see progress feedback. |
+| 2025-10-28 | [df5e739](https://github.com/odoo/odoo/commit/df5e7396f93418a96be703b2a58ed20c09740671) | Walid (wasa) | html_builder | Preserve header slot content when switching layout types inside the HTML editor. |
+| 2025-10-28 | [68bfe6f](https://github.com/odoo/odoo/commit/68bfe6fec67b0d87c59454b254a98bee57dc5d4c) | Julien (jula) | website | Keep background pattern repeats consistent between the editor, website, and mass mailing themes. |
+| 2025-10-27 | [57f7a35](https://github.com/odoo/odoo/commit/57f7a3537bff44c56928a1db4df413465e92dff7) | Rahil Ghanchi | website | Add an aspect-ratio toggle so embedded media can be forced to stay proportional. |
+| 2025-10-27 | [54698f4](https://github.com/odoo/odoo/commit/54698f4d2854ca1777ec62a6464004b5b88a4dc5) | Julien Mougenot | website | Update website and builder tests to handle simulated server errors without relying on pure RPC stubs. |
+| 2025-10-27 | [350da9c](https://github.com/odoo/odoo/commit/350da9c8561276a45d65b3e74418a8cfc28eda16) | Antoine (anso) | website | Ship the `s_newsletter_aside` snippet, preview art, and shared options for quick newsletter CTAs. |
+| 2025-10-24 | [3e9b2fc](https://github.com/odoo/odoo/commit/3e9b2fcabeba28e685a748d5f542362284faa317) | Nicolas Lempereur | website | Build dynamic asset bundles using the visitor’s language to avoid cross-locale mixes. |
+| 2025-10-24 | [a34db9d](https://github.com/odoo/odoo/commit/a34db9d13c4cacfde158619471c70ad91adb7b75) | Aaron Bohy | html_builder | Eliminate drag-and-drop race conditions so Kanban boards and the builder stay in sync. |
+| 2025-10-24 | [78d406c](https://github.com/odoo/odoo/commit/78d406ce5456dc20c10e884d8abd76458bb78e22) | krip-odoo | website | Block deletion of website form fields that are still referenced to keep forms valid. |
+| 2025-10-24 | [ba8d1f6](https://github.com/odoo/odoo/commit/ba8d1f60b82ffeada0b222481706a5c65623020d) | Antoine (anso) | website | Rebuild the default Contact Us page around modern snippets and refreshed company info handling. |
+| 2025-10-24 | [9bb2a86](https://github.com/odoo/odoo/commit/9bb2a86af6b913884dcafc4e49b202947b911a0d) | Sanjay Sharma | website | Switch social link defaults to the YouTube play icon for clearer branding. |
+| 2025-10-23 | [7f1ddba](https://github.com/odoo/odoo/commit/7f1ddba17a19cab22f6106ecc6a3624f67101c21) | sben-odoo | html_builder | Stop the image shape selector from raising tracebacks inside the builder. |
+| 2025-10-23 | [f4436d4](https://github.com/odoo/odoo/commit/f4436d4f8400995dcf382107d93cd95d9f625335) | Augustin (duau) | html_builder | Align the shape animation speed option between HTML editor controllers and builder plugins. |
+| 2025-10-22 | [411bf8d](https://github.com/odoo/odoo/commit/411bf8dce9c0fd391bddc950ee030086d5c6e9b4) | Serhii Rubanskyi | website | Fix the `_get_page_info` cache key so multi-website navigation picks up the right metadata. |
+| 2025-10-22 | [3e7038c](https://github.com/odoo/odoo/commit/3e7038ce72389638309f0a2d9552fd45b7426e1d) | Serhii Rubanskyi | website | Drop leftover sidebar padding whenever the website header is hidden. |
+| 2025-10-22 | [54a621f](https://github.com/odoo/odoo/commit/54a621f5f7728ca1b1ea14ef6d1912984eac0418) | Augustin (duau) | html_builder, website | Relocate custom snippet helpers from `html_editor` into the website module to simplify overrides. |
+| 2025-10-22 | [d957f69](https://github.com/odoo/odoo/commit/d957f6965384ab66557c9622a9f7cd6a4f06dfe9) | Augustin (duau) | html_builder, website | Move view-saving routines into the website app so builder persistence lives in one place. |
+| 2025-10-22 | [65f677b](https://github.com/odoo/odoo/commit/65f677be1d4450a36929b9f9dbd8c17e9a34e3e3) | chdh-odoo | website | Refresh the default About Us footer copy with GPT-generated text. |
+| 2025-10-22 | [82e927a](https://github.com/odoo/odoo/commit/82e927a5ea994d148d859fd1ce4e458f72e2cb1a) | Nicolas Lempereur | website | Make the website configurator dropdown respond properly on iOS Safari. |
+| 2025-10-22 | [3071ce4](https://github.com/odoo/odoo/commit/3071ce47799648ab90f3e4e0d4723dc13870356c) | Chrysanthe (chgo) | website | Ensure `.o_tag` styling no longer shrinks Bootstrap badge text. |
+| 2025-10-22 | [708b336](https://github.com/odoo/odoo/commit/708b336fba8abed927843ea8843eacc6e4551555) | Gorash | website | Rebalance `/shop` performance test expectations after the latest storefront changes. |
+
+> **How to read the data:** The accompanying JSON export at [`docs/reports/data/2025-10-29-website-html-builder.json`](./data/2025-10-29-website-html-builder.json) is sorted by the GitHub committer timestamp and includes every file-level diff touching the tracked paths within the window.
+
+## Verification
+
+- **Window coverage.** All 22 commits in the export have committer timestamps between 22 Oct 2025 00:00 UTC and 29 Oct 2025 23:59 UTC.
+- **Master parity check.** Re-running the GitHub REST API queries (`sha=master`) for each tracked path returns the same 22 commit SHAs, confirming no extra or missing entries for the covered week.

--- a/docs/reports/data/2025-10-29-website-html-builder.json
+++ b/docs/reports/data/2025-10-29-website-html-builder.json
@@ -1,0 +1,3111 @@
+[
+  {
+    "sha": "411bf8dce9c0fd391bddc950ee030086d5c6e9b4",
+    "node_id": "C_kwDOAS1I7NoAKDQxMWJmOGRjZTljMGZkMzkxYmRkYzk1MGVlMDMwMDg2ZDVjNmU5YjQ",
+    "commit": {
+      "author": {
+        "name": "Serhii Rubanskyi",
+        "email": "seru@odoo.com",
+        "date": "2025-10-08T09:21:37Z"
+      },
+      "committer": {
+        "name": "Serhii Rubanskyi",
+        "email": "seru@odoo.com",
+        "date": "2025-10-22T00:04:50Z"
+      },
+      "message": "[FIX] website: use the correct cache key for _get_page_info\n\nAfter this [commit], we had an issue when we had multiple websites and\ntried to switch from one of them to another, the cached page of the\nprevious one would still be present.\n\ntask-5152918\n\n[commit]: https://github.com/odoo/odoo/commit/6c8a90ecba45fb99addf1b86fe237fd626fba650\n\ncloses odoo/odoo#232576\n\nX-original-commit: 091a618c40904e3a5e992048455daee0e3d7457d\nSigned-off-by: Benoit Socias (bso) <bso@odoo.com>\nSigned-off-by: Serhii Rubanskyi (seru) <seru@odoo.com>",
+      "tree": {
+        "sha": "3cad64a04d7bac565e7ac953f31d255fe4d564da",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/3cad64a04d7bac565e7ac953f31d255fe4d564da"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/411bf8dce9c0fd391bddc950ee030086d5c6e9b4",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/411bf8dce9c0fd391bddc950ee030086d5c6e9b4",
+    "html_url": "https://github.com/odoo/odoo/commit/411bf8dce9c0fd391bddc950ee030086d5c6e9b4",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/411bf8dce9c0fd391bddc950ee030086d5c6e9b4/comments",
+    "author": {
+      "login": "Syozik",
+      "id": 82968368,
+      "node_id": "MDQ6VXNlcjgyOTY4MzY4",
+      "avatar_url": "https://avatars.githubusercontent.com/u/82968368?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/Syozik",
+      "html_url": "https://github.com/Syozik",
+      "followers_url": "https://api.github.com/users/Syozik/followers",
+      "following_url": "https://api.github.com/users/Syozik/following{/other_user}",
+      "gists_url": "https://api.github.com/users/Syozik/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/Syozik/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/Syozik/subscriptions",
+      "organizations_url": "https://api.github.com/users/Syozik/orgs",
+      "repos_url": "https://api.github.com/users/Syozik/repos",
+      "events_url": "https://api.github.com/users/Syozik/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/Syozik/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "Syozik",
+      "id": 82968368,
+      "node_id": "MDQ6VXNlcjgyOTY4MzY4",
+      "avatar_url": "https://avatars.githubusercontent.com/u/82968368?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/Syozik",
+      "html_url": "https://github.com/Syozik",
+      "followers_url": "https://api.github.com/users/Syozik/followers",
+      "following_url": "https://api.github.com/users/Syozik/following{/other_user}",
+      "gists_url": "https://api.github.com/users/Syozik/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/Syozik/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/Syozik/subscriptions",
+      "organizations_url": "https://api.github.com/users/Syozik/orgs",
+      "repos_url": "https://api.github.com/users/Syozik/repos",
+      "events_url": "https://api.github.com/users/Syozik/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/Syozik/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "ba9ac06f83a5d624dea013edef5687e018288d44",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/ba9ac06f83a5d624dea013edef5687e018288d44",
+        "html_url": "https://github.com/odoo/odoo/commit/ba9ac06f83a5d624dea013edef5687e018288d44"
+      }
+    ],
+    "stats": {
+      "total": 32,
+      "additions": 31,
+      "deletions": 1
+    },
+    "files": [
+      {
+        "sha": "82e029c5da598a6076e0cb2e0a538321aaf33df3",
+        "filename": "addons/website/models/website_page.py",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/411bf8dce9c0fd391bddc950ee030086d5c6e9b4/addons%2Fwebsite%2Fmodels%2Fwebsite_page.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/411bf8dce9c0fd391bddc950ee030086d5c6e9b4/addons%2Fwebsite%2Fmodels%2Fwebsite_page.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fmodels%2Fwebsite_page.py?ref=411bf8dce9c0fd391bddc950ee030086d5c6e9b4",
+        "patch": "@@ -457,7 +457,7 @@ def _get_response_raw(self, request) -> http.Response | None:\n \n     @tools.conditional(\n         'xml' not in tools.config['dev_mode'],\n-        tools.ormcache('request.httprequest.path', cache='templates.cached_values'),\n+        tools.ormcache('(request.httprequest.path, self.env.context.get(\"website_id\"))', cache='templates.cached_values'),\n     )\n     @api.model\n     def _get_page_info(self, request) -> dict | None:"
+      },
+      {
+        "sha": "85eaabdc5fae63ba6cce4bfc46492a20fe6e2571",
+        "filename": "addons/website/tests/__init__.py",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 0,
+        "changes": 1,
+        "blob_url": "https://github.com/odoo/odoo/blob/411bf8dce9c0fd391bddc950ee030086d5c6e9b4/addons%2Fwebsite%2Ftests%2F__init__.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/411bf8dce9c0fd391bddc950ee030086d5c6e9b4/addons%2Fwebsite%2Ftests%2F__init__.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Ftests%2F__init__.py?ref=411bf8dce9c0fd391bddc950ee030086d5c6e9b4",
+        "patch": "@@ -20,6 +20,7 @@\n from . import test_ir_asset\n from . import test_lang_url\n from . import test_menu\n+from . import test_multi_website\n from . import test_page\n from . import test_page_manager\n from . import test_performance"
+      },
+      {
+        "sha": "ac043fe925e8ae7aeb157a7d59f226f480be54e5",
+        "filename": "addons/website/tests/test_multi_website.py",
+        "status": "added",
+        "additions": 29,
+        "deletions": 0,
+        "changes": 29,
+        "blob_url": "https://github.com/odoo/odoo/blob/411bf8dce9c0fd391bddc950ee030086d5c6e9b4/addons%2Fwebsite%2Ftests%2Ftest_multi_website.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/411bf8dce9c0fd391bddc950ee030086d5c6e9b4/addons%2Fwebsite%2Ftests%2Ftest_multi_website.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Ftests%2Ftest_multi_website.py?ref=411bf8dce9c0fd391bddc950ee030086d5c6e9b4",
+        "patch": "@@ -0,0 +1,29 @@\n+import lxml.html\n+\n+from odoo.tests import HttpCase, tagged\n+\n+\n+@tagged('-at_install', 'post_install')\n+class TestMultiWebsite(HttpCase):\n+    def test_multi_website_switch(self):\n+        Website = self.env['website']\n+\n+        website_1 = Website.create({'name': 'Website 1'})\n+        website_2 = Website.create({'name': 'Website 2'})\n+\n+        self.authenticate(\"admin\", \"admin\")\n+        base_url = website_1.get_base_url()\n+\n+        res1 = self.url_open(base_url + '/website/force/%s' % website_2.id)\n+        res2 = self.url_open(base_url + '/website/force/%s' % website_1.id)\n+        website_2_tree = lxml.html.fromstring(res1.content)\n+        website_1_tree = lxml.html.fromstring(res2.content)\n+\n+        data_obj_1 = website_1_tree.xpath('//html/@data-main-object')[0]\n+        data_obj_2 = website_2_tree.xpath('//html/@data-main-object')[0]\n+\n+        website_id_1 = website_1_tree.xpath('//html/@data-website-id')[0]\n+        website_id_2 = website_2_tree.xpath('//html/@data-website-id')[0]\n+\n+        self.assertNotEqual(data_obj_1, data_obj_2)\n+        self.assertNotEqual(website_id_1, website_id_2)"
+      }
+    ]
+  },
+  {
+    "sha": "3e7038ce72389638309f0a2d9552fd45b7426e1d",
+    "node_id": "C_kwDOAS1I7NoAKDNlNzAzOGNlNzIzODk2MzgzMDlmMGEyZDk1NTJmZDQ1Yjc0MjZlMWQ",
+    "commit": {
+      "author": {
+        "name": "Serhii Rubanskyi",
+        "email": "seru@odoo.com",
+        "date": "2025-10-03T09:09:27Z"
+      },
+      "committer": {
+        "name": "Serhii Rubanskyi",
+        "email": "seru@odoo.com",
+        "date": "2025-10-22T07:51:49Z"
+      },
+      "message": "[FIX] website: remove sidebar padding when header is hidden\n\nSteps to reproduce the issue:\n- In edit mode, change the header template to use the \"Sidebar\" header\n(=> since it is a sidebar, the page content is shifted to the right)\n- Go to the theme tab and toggle the \"Show Header\" option so the header\nis removed\n\n=> Bug: the page content is still shifted as if the sidebar was still\npresent.\n\nThis happens because the page still has padding-left for the header,\nalthough there's no header.\n\ntask-5131064\n\ncloses odoo/odoo#232600\n\nX-original-commit: 96309230728540f641a8eee1b7143f0164954984\nSigned-off-by: Serge Bayet (seba) <seba@odoo.com>\nSigned-off-by: Serhii Rubanskyi (seru) <seru@odoo.com>",
+      "tree": {
+        "sha": "4a3b1fba0fe59fc3dcdfd9dde63eb7a718700af5",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/4a3b1fba0fe59fc3dcdfd9dde63eb7a718700af5"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/3e7038ce72389638309f0a2d9552fd45b7426e1d",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/3e7038ce72389638309f0a2d9552fd45b7426e1d",
+    "html_url": "https://github.com/odoo/odoo/commit/3e7038ce72389638309f0a2d9552fd45b7426e1d",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/3e7038ce72389638309f0a2d9552fd45b7426e1d/comments",
+    "author": {
+      "login": "Syozik",
+      "id": 82968368,
+      "node_id": "MDQ6VXNlcjgyOTY4MzY4",
+      "avatar_url": "https://avatars.githubusercontent.com/u/82968368?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/Syozik",
+      "html_url": "https://github.com/Syozik",
+      "followers_url": "https://api.github.com/users/Syozik/followers",
+      "following_url": "https://api.github.com/users/Syozik/following{/other_user}",
+      "gists_url": "https://api.github.com/users/Syozik/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/Syozik/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/Syozik/subscriptions",
+      "organizations_url": "https://api.github.com/users/Syozik/orgs",
+      "repos_url": "https://api.github.com/users/Syozik/repos",
+      "events_url": "https://api.github.com/users/Syozik/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/Syozik/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "Syozik",
+      "id": 82968368,
+      "node_id": "MDQ6VXNlcjgyOTY4MzY4",
+      "avatar_url": "https://avatars.githubusercontent.com/u/82968368?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/Syozik",
+      "html_url": "https://github.com/Syozik",
+      "followers_url": "https://api.github.com/users/Syozik/followers",
+      "following_url": "https://api.github.com/users/Syozik/following{/other_user}",
+      "gists_url": "https://api.github.com/users/Syozik/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/Syozik/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/Syozik/subscriptions",
+      "organizations_url": "https://api.github.com/users/Syozik/orgs",
+      "repos_url": "https://api.github.com/users/Syozik/repos",
+      "events_url": "https://api.github.com/users/Syozik/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/Syozik/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "00b3d07cffb86ca12010eb866e45efe31c365690",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/00b3d07cffb86ca12010eb866e45efe31c365690",
+        "html_url": "https://github.com/odoo/odoo/commit/00b3d07cffb86ca12010eb866e45efe31c365690"
+      }
+    ],
+    "stats": {
+      "total": 63,
+      "additions": 62,
+      "deletions": 1
+    },
+    "files": [
+      {
+        "sha": "cf9865e038a1c518a3c1232143c86be95a043030",
+        "filename": "addons/website/static/src/scss/website.scss",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/3e7038ce72389638309f0a2d9552fd45b7426e1d/addons%2Fwebsite%2Fstatic%2Fsrc%2Fscss%2Fwebsite.scss",
+        "raw_url": "https://github.com/odoo/odoo/raw/3e7038ce72389638309f0a2d9552fd45b7426e1d/addons%2Fwebsite%2Fstatic%2Fsrc%2Fscss%2Fwebsite.scss",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fscss%2Fwebsite.scss?ref=3e7038ce72389638309f0a2d9552fd45b7426e1d",
+        "patch": "@@ -1698,7 +1698,7 @@ header {\n \n @if o-website-value('header-template') == 'sidebar' {\n     @include media-breakpoint-up(lg) {\n-        #wrapwrap {\n+        #wrapwrap:has(> header) {\n             // Two different website options might add padding:\n             // - The sidebar header template\n             // - The website layout template when different than 'full'"
+      },
+      {
+        "sha": "0768f03f5eff20ba49c464bcdc713835a328898f",
+        "filename": "addons/website/static/tests/tours/hide_sidebar_header.js",
+        "status": "added",
+        "additions": 58,
+        "deletions": 0,
+        "changes": 58,
+        "blob_url": "https://github.com/odoo/odoo/blob/3e7038ce72389638309f0a2d9552fd45b7426e1d/addons%2Fwebsite%2Fstatic%2Ftests%2Ftours%2Fhide_sidebar_header.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/3e7038ce72389638309f0a2d9552fd45b7426e1d/addons%2Fwebsite%2Fstatic%2Ftests%2Ftours%2Fhide_sidebar_header.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Ftests%2Ftours%2Fhide_sidebar_header.js?ref=3e7038ce72389638309f0a2d9552fd45b7426e1d",
+        "patch": "@@ -0,0 +1,58 @@\n+import { stepUtils } from \"@web_tour/tour_utils\";\n+import { clickOnSave, registerWebsitePreviewTour } from \"@website/js/tours/tour_utils\";\n+\n+registerWebsitePreviewTour(\n+    \"hide_sidebar_header\",\n+    {\n+        url: \"/\",\n+        edition: true,\n+    },\n+    () => [\n+        {\n+            content: \"Click on the header\",\n+            trigger: \":iframe #o_main_nav\",\n+            run: \"click\",\n+        },\n+        {\n+            content: \"Click on header template\",\n+            trigger: \".hb-row[data-label='Template'] button.o-hb-select-toggle\",\n+            run: \"click\",\n+        },\n+        {\n+            content: \"Change header template to 'Sidebar'\",\n+            trigger: \".dropdown-menu .o-hb-select-dropdown-item[title='Sidebar']\",\n+            run: \"click\",\n+        },\n+        {\n+            content: \"Check that the header changed to 'Sidebar'\",\n+            trigger: \":iframe #wrapwrap>header.o_header_sidebar\",\n+        },\n+        stepUtils.waitIframeIsReady(),\n+        {\n+            content: \"Go to the theme tab\",\n+            trigger: \".o-website-builder_sidebar .o-snippets-tabs button[data-name='theme']\",\n+            run: \"click\",\n+        },\n+        {\n+            content: \"Toggle 'Show Header' off\",\n+            trigger: \".hb-row[data-label='Show Header'] input[type='checkbox']\",\n+            run: \"click\",\n+        },\n+        {\n+            content: \"Check that the header has been hidden\",\n+            trigger: \":iframe #wrapwrap:not(:has(:scope > header))\",\n+        },\n+        stepUtils.waitIframeIsReady(),\n+        {\n+            content: \"Check that there's no header padding on the #wrapwrap\",\n+            trigger: \":iframe #wrapwrap\",\n+            run() {\n+                const style = getComputedStyle(this.anchor);\n+                if (style.paddingLeft !== \"0px\") {\n+                    throw new Error(\"There shouldn't be padding for the header\");\n+                }\n+            },\n+        },\n+        ...clickOnSave(),\n+    ]\n+);"
+      },
+      {
+        "sha": "d9e0e15b4f74b6d000af43f1f082be848ca4e2ee",
+        "filename": "addons/website/tests/test_ui.py",
+        "status": "modified",
+        "additions": 3,
+        "deletions": 0,
+        "changes": 3,
+        "blob_url": "https://github.com/odoo/odoo/blob/3e7038ce72389638309f0a2d9552fd45b7426e1d/addons%2Fwebsite%2Ftests%2Ftest_ui.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/3e7038ce72389638309f0a2d9552fd45b7426e1d/addons%2Fwebsite%2Ftests%2Ftest_ui.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Ftests%2Ftest_ui.py?ref=3e7038ce72389638309f0a2d9552fd45b7426e1d",
+        "patch": "@@ -700,3 +700,6 @@ def test_editing_awaits_navigation(self):\n \n     def test_create_missing_page(self):\n         self.start_tour(\"/\", \"create_missing_page\", login=\"admin\")\n+\n+    def test_hiding_sidebar_header(self):\n+        self.start_tour(\"/\", \"hide_sidebar_header\", login=\"admin\")"
+      }
+    ]
+  },
+  {
+    "sha": "54a621f5f7728ca1b1ea14ef6d1912984eac0418",
+    "node_id": "C_kwDOAS1I7NoAKDU0YTYyMWY1Zjc3MjhjYTFiMWVhMTRlZjZkMTkxMjk4NGVhYzA0MTg",
+    "commit": {
+      "author": {
+        "name": "Augustin (duau)",
+        "email": "duau@odoo.com",
+        "date": "2025-10-03T16:07:10Z"
+      },
+      "committer": {
+        "name": "Augustin (duau)",
+        "email": "duau@odoo.com",
+        "date": "2025-10-22T13:00:32Z"
+      },
+      "message": "[REF] html_editor, *: move custom snippet methods to website\n\n*: html_builder, website\n\nFollowing website refactoring [1], and web_editor deletion, models were\nmoved to html_editor [2].\nThis commit is moving `ir_ui_view` and `SnippetModel` methods related to\n`save_snippet` to website, as they are specific to the module.\n\nThe original method definitions on `SnippetModel` were kept, but their\nlogic was removed, providing an empty structure for other modules to\nextend in the future.\n\n[1]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2\n[2]: https://github.com/odoo/odoo/commit/867d9a2f923a55c0bd6a281e2dea1f524fa04445\n\ntask-5065980\n\nPart-of: odoo/odoo#230322\nRelated: odoo/enterprise#97218\nSigned-off-by: David Monjoie (dmo) <dmo@odoo.com>",
+      "tree": {
+        "sha": "1c279479943e3598a11da9ac5f93b7c0d304ef7f",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/1c279479943e3598a11da9ac5f93b7c0d304ef7f"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/54a621f5f7728ca1b1ea14ef6d1912984eac0418",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/54a621f5f7728ca1b1ea14ef6d1912984eac0418",
+    "html_url": "https://github.com/odoo/odoo/commit/54a621f5f7728ca1b1ea14ef6d1912984eac0418",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/54a621f5f7728ca1b1ea14ef6d1912984eac0418/comments",
+    "author": {
+      "login": "duau-odoo",
+      "id": 199088574,
+      "node_id": "U_kgDOC93Zvg",
+      "avatar_url": "https://avatars.githubusercontent.com/u/199088574?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/duau-odoo",
+      "html_url": "https://github.com/duau-odoo",
+      "followers_url": "https://api.github.com/users/duau-odoo/followers",
+      "following_url": "https://api.github.com/users/duau-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/duau-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/duau-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/duau-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/duau-odoo/orgs",
+      "repos_url": "https://api.github.com/users/duau-odoo/repos",
+      "events_url": "https://api.github.com/users/duau-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/duau-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "duau-odoo",
+      "id": 199088574,
+      "node_id": "U_kgDOC93Zvg",
+      "avatar_url": "https://avatars.githubusercontent.com/u/199088574?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/duau-odoo",
+      "html_url": "https://github.com/duau-odoo",
+      "followers_url": "https://api.github.com/users/duau-odoo/followers",
+      "following_url": "https://api.github.com/users/duau-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/duau-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/duau-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/duau-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/duau-odoo/orgs",
+      "repos_url": "https://api.github.com/users/duau-odoo/repos",
+      "events_url": "https://api.github.com/users/duau-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/duau-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "337273b782b09912611c120d6fbc80a5b84fbefb",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/337273b782b09912611c120d6fbc80a5b84fbefb",
+        "html_url": "https://github.com/odoo/odoo/commit/337273b782b09912611c120d6fbc80a5b84fbefb"
+      }
+    ],
+    "stats": {
+      "total": 672,
+      "additions": 352,
+      "deletions": 320
+    },
+    "files": [
+      {
+        "sha": "5a484e34f52c1a4f1df542e257405a7612b084aa",
+        "filename": "addons/html_builder/static/src/snippets/snippet_service.js",
+        "status": "modified",
+        "additions": 3,
+        "deletions": 109,
+        "changes": 112,
+        "blob_url": "https://github.com/odoo/odoo/blob/54a621f5f7728ca1b1ea14ef6d1912984eac0418/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fsnippets%2Fsnippet_service.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/54a621f5f7728ca1b1ea14ef6d1912984eac0418/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fsnippets%2Fsnippet_service.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fsnippets%2Fsnippet_service.js?ref=54a621f5f7728ca1b1ea14ef6d1912984eac0418",
+        "patch": "@@ -255,54 +255,11 @@ export class SnippetModel extends Reactive {\n     }\n \n     async deleteCustomSnippet(snippet) {\n-        return new Promise((resolve) => {\n-            const message = _t(\"Are you sure you want to delete the block %s?\", snippet.title);\n-            this.dialog.add(\n-                ConfirmationDialog,\n-                {\n-                    body: message,\n-                    confirm: async () => {\n-                        const isInnerContent =\n-                            this.snippetsByCategory.snippet_custom_content.includes(snippet);\n-                        const snippetCustom = isInnerContent\n-                            ? this.snippetsByCategory.snippet_custom_content\n-                            : this.snippetsByCategory.snippet_custom;\n-                        const index = snippetCustom.findIndex((s) => s.id === snippet.id);\n-                        if (index > -1) {\n-                            snippetCustom.splice(index, 1);\n-                        }\n-                        await this.orm.call(\"ir.ui.view\", \"delete_snippet\", [], {\n-                            view_id: snippet.viewId,\n-                            template_key: this.snippetsName,\n-                        });\n-                    },\n-                    cancel: () => {},\n-                    confirmLabel: _t(\"Yes\"),\n-                    cancelLabel: _t(\"No\"),\n-                },\n-                {\n-                    onClose: resolve,\n-                }\n-            );\n-        });\n+        throw new Error(\"Method not implemented\");\n     }\n \n     async renameCustomSnippet(snippet, newName) {\n-        if (newName === snippet.title) {\n-            return;\n-        }\n-        snippet.title = newName;\n-        for (const snippetEl of this.snippetsDocument.body.querySelectorAll(\n-            `snippets#snippet_custom > [data-oe-snippet-key = ${snippet.key}]`\n-        )) {\n-            snippetEl.setAttribute(\"name\", newName);\n-            snippetEl.children[0].dataset[\"name\"] = newName;\n-        }\n-        await this.orm.call(\"ir.ui.view\", \"rename_snippet\", [], {\n-            name: newName,\n-            view_id: snippet.viewId,\n-            template_key: this.snippetsName,\n-        });\n+        throw new Error(\"Method not implemented\");\n     }\n \n     setSnippetName(snippetsDocument) {\n@@ -365,70 +322,7 @@ export class SnippetModel extends Reactive {\n         cleanForSaveHandlers,\n         wrapWithSaveSnippetHandlers = (_, callback) => callback()\n     ) {\n-        return new Promise((resolve) => {\n-            this.dialog.add(\n-                ConfirmationDialog,\n-                {\n-                    title: _t(\"Create a custom snippet\"),\n-                    body: _t(\"Do you want to save this snippet as a custom one?\"),\n-                    confirmLabel: _t(\"Save\"),\n-                    cancel: () => resolve(false),\n-                    confirm: async () => {\n-                        const isButton = snippetEl.matches(\"a.btn\");\n-                        const snippetKey = isButton ? \"s_button\" : snippetEl.dataset.snippet;\n-                        const thumbnailURL = this.getSnippetThumbnailURL(snippetKey);\n-\n-                        const snippetCopyEl = await wrapWithSaveSnippetHandlers(snippetEl, () =>\n-                            snippetEl.cloneNode(true)\n-                        );\n-\n-                        // \"CleanForSave\" the snippet copy (only its children in\n-                        // the case of a popup, or it will be saved as invisible\n-                        // and will not be visible in the \"add snippet\" dialog).\n-                        const rootEl = snippetEl.matches(\".s_popup\")\n-                            ? snippetCopyEl.firstElementChild\n-                            : snippetCopyEl;\n-                        cleanForSaveHandlers.forEach((handler) => handler({ root: rootEl }));\n-\n-                        const defaultSnippetName = isButton\n-                            ? _t(\"Custom Button\")\n-                            : _t(\"Custom %s\", snippetEl.dataset.name);\n-                        snippetCopyEl.classList.add(\"s_custom_snippet\");\n-                        delete snippetCopyEl.dataset.name;\n-                        if (isButton) {\n-                            snippetCopyEl.classList.remove(\"mb-2\");\n-                            snippetCopyEl.classList.add(\n-                                \"o_snippet_drop_in_only\",\n-                                \"s_custom_button\"\n-                            );\n-                        }\n-\n-                        const editableParentEl = snippetEl.closest(\n-                            \"[data-oe-model][data-oe-field][data-oe-id]\"\n-                        );\n-                        const context = {\n-                            ...this.context,\n-                            model: editableParentEl.dataset.oeModel,\n-                            field: editableParentEl.dataset.oeField,\n-                            resId: editableParentEl.dataset.oeId,\n-                        };\n-                        const savedName = await this.orm.call(\"ir.ui.view\", \"save_snippet\", [], {\n-                            name: defaultSnippetName,\n-                            arch: snippetCopyEl.outerHTML,\n-                            template_key: this.snippetsName,\n-                            snippet_key: snippetKey,\n-                            thumbnail_url: thumbnailURL,\n-                            context,\n-                        });\n-\n-                        // Reload the snippets so the sidebar is up to date.\n-                        await this.reload();\n-                        resolve(savedName);\n-                    },\n-                },\n-                { onClose: () => resolve(false) }\n-            );\n-        });\n+        throw new Error(\"Method not implemented\");\n     }\n \n     /**"
+      },
+      {
+        "sha": "372bb662caf8cac6cf439c0306b6e5a5c6244eb9",
+        "filename": "addons/html_builder/static/tests/block_tab/snippet_groups.test.js",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 79,
+        "changes": 80,
+        "blob_url": "https://github.com/odoo/odoo/blob/54a621f5f7728ca1b1ea14ef6d1912984eac0418/addons%2Fhtml_builder%2Fstatic%2Ftests%2Fblock_tab%2Fsnippet_groups.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/54a621f5f7728ca1b1ea14ef6d1912984eac0418/addons%2Fhtml_builder%2Fstatic%2Ftests%2Fblock_tab%2Fsnippet_groups.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_builder%2Fstatic%2Ftests%2Fblock_tab%2Fsnippet_groups.test.js?ref=54a621f5f7728ca1b1ea14ef6d1912984eac0418",
+        "patch": "@@ -1,5 +1,4 @@\n import {\n-    addBuilderPlugin,\n     addDropZoneSelector,\n     createTestSnippets,\n     getDragHelper,\n@@ -10,10 +9,9 @@ import {\n     waitForSnippetDialog,\n } from \"@html_builder/../tests/helpers\";\n import { Builder } from \"@html_builder/builder\";\n-import { Plugin } from \"@html_editor/plugin\";\n import { beforeEach, expect, test, describe } from \"@odoo/hoot\";\n import { animationFrame, click, queryAll, queryAllTexts, queryFirst } from \"@odoo/hoot-dom\";\n-import { contains, onRpc, patchWithCleanup } from \"@web/../tests/web_test_helpers\";\n+import { contains, patchWithCleanup } from \"@web/../tests/web_test_helpers\";\n \n describe.current.tags(\"desktop\");\n \n@@ -455,79 +453,3 @@ test(\"Cancel snippet drag & drop over sidebar\", async () => {\n \n     expect(contentEl).toHaveInnerHTML(\"\");\n });\n-\n-test(\"Renaming custom snippets don't make an orm call\", async () => {\n-    class TestSetupEditorPlugin extends Plugin {\n-        static id = \"test.setup_editor_plugin\";\n-        resources = {\n-            snippet_preview_dialog_bundles: [\"web.assets_frontend\"],\n-        };\n-    }\n-    addBuilderPlugin(TestSetupEditorPlugin);\n-\n-    // Stub rename_snippet RPC to succeed if it is called\n-    onRpc(\"ir.ui.view\", \"rename_snippet\", ({ args }) => true);\n-\n-    const customSnippets = createTestSnippets({\n-        snippets: [\n-            {\n-                name: \"Dummy Section\",\n-                groupName: \"custom\",\n-                keywords: [\"dummy\"],\n-                content: `\n-        <section data-snippet=\"s_dummy\">\n-            <div class=\"container\">\n-                <div class=\"row\">\n-                    <div class=\"col-lg-7\">\n-                        <p>TEST</p>\n-                    </div>\n-                </div>\n-            </div>\n-        </section>\n-    `,\n-            },\n-        ],\n-        withName: true,\n-    });\n-    const snippets = {\n-        snippet_groups: [\n-            '<div name=\"Custom\" data-oe-snippet-id=\"123\" data-o-snippet-group=\"custom\"><section data-snippet=\"s_snippet_group\"></section></div>',\n-        ],\n-        snippet_structure: customSnippets.map((snippetDesc) => getSnippetStructure(snippetDesc)),\n-        snippet_custom: customSnippets.map((snippetDesc) => getSnippetStructure(snippetDesc)),\n-    };\n-\n-    await setupHTMLBuilder(\n-        `<section data-name=\"Dummy Section\" data-snippet=\"s_dummy\">\n-            <div class=\"container\">\n-                <div class=\"row\">\n-                    <div class=\"col-lg-7\">\n-                        <p>TEST</p>\n-                        <p><a class=\"btn\">BUTTON</a></p>\n-                    </div>\n-                </div>\n-            </div>\n-        </section>`,\n-        { snippets }\n-    );\n-\n-    await contains(\n-        \".o-website-builder_sidebar .o_snippets_container .o_snippet[name='Custom'] button\"\n-    ).click();\n-    await animationFrame();\n-\n-    // Throw if any render_public_asset RPC happens during rename\n-    onRpc(\"ir.ui.view\", \"render_public_asset\", () => {\n-        throw new Error(\"shouldn't make an rpc call on snippet rename\");\n-    });\n-\n-    await contains(\n-        \".o_add_snippet_dialog .o_add_snippet_iframe:iframe .o_custom_snippet_edit button > .fa-pencil\"\n-    ).click();\n-    expect(\".o-overlay-item .modal-dialog:contains('Rename the block')\").toHaveCount(1);\n-    await contains(\".o-overlay-item .modal-dialog input#inputConfirmation\").fill(\"new custom name\");\n-    await contains(\".o-overlay-item .modal-dialog footer>button:contains('Save')\").click();\n-    expect(\n-        \".o_add_snippet_dialog .o_add_snippet_iframe:iframe .o_custom_snippet_edit>span:contains('new custom name')\"\n-    ).toHaveCount(1);\n-});"
+      },
+      {
+        "sha": "e00ed0de55f7ed4c00a58f06899df80e3ea4c149",
+        "filename": "addons/html_editor/models/ir_ui_view.py",
+        "status": "modified",
+        "additions": 0,
+        "deletions": 118,
+        "changes": 118,
+        "blob_url": "https://github.com/odoo/odoo/blob/54a621f5f7728ca1b1ea14ef6d1912984eac0418/addons%2Fhtml_editor%2Fmodels%2Fir_ui_view.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/54a621f5f7728ca1b1ea14ef6d1912984eac0418/addons%2Fhtml_editor%2Fmodels%2Fir_ui_view.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_editor%2Fmodels%2Fir_ui_view.py?ref=54a621f5f7728ca1b1ea14ef6d1912984eac0418",
+        "patch": "@@ -2,12 +2,10 @@\n \n import copy\n import logging\n-import uuid\n from lxml import etree, html\n \n from odoo import api, models, _\n from odoo.exceptions import ValidationError, MissingError\n-from odoo.fields import Domain\n from odoo.addons.base.models.ir_ui_view import MOVABLE_BRANDING\n \n _logger = logging.getLogger(__name__)\n@@ -398,119 +396,3 @@ def get_related_views(self, key, bundles=False):\n         View = self.with_context(new_context)\n         views = View._views_get(key, bundles=bundles)\n         return views.filtered(lambda v: not v.group_ids or len(user_groups.intersection(v.group_ids)))\n-\n-    # --------------------------------------------------------------------------\n-    # Snippet saving\n-    # --------------------------------------------------------------------------\n-\n-    @api.model\n-    def _get_snippet_addition_view_key(self, template_key, key):\n-        return '%s.%s' % (template_key, key)\n-\n-    @api.model\n-    def _snippet_save_view_values_hook(self):\n-        return {}\n-\n-    def _find_available_name(self, name, used_names):\n-        attempt = 1\n-        candidate_name = name\n-        while candidate_name in used_names:\n-            attempt += 1\n-            candidate_name = f\"{name} ({attempt})\"\n-        return candidate_name\n-\n-    @api.model\n-    def save_snippet(self, name, arch, template_key, snippet_key, thumbnail_url):\n-        \"\"\"\n-        Saves a new snippet arch so that it appears with the given name when\n-        using the given snippets template.\n-\n-        :param name: the name of the snippet to save\n-        :param arch: the html structure of the snippet to save\n-        :param template_key: the key of the view regrouping all snippets in\n-            which the snippet to save is meant to appear\n-        :param snippet_key: the key (without module part) to identify\n-            the snippet from which the snippet to save originates\n-        :param thumbnail_url: the url of the thumbnail to use when displaying\n-            the snippet to save\n-        \"\"\"\n-        app_name = template_key.split('.')[0]\n-        snippet_key = '%s_%s' % (snippet_key, uuid.uuid4().hex)\n-        full_snippet_key = '%s.%s' % (app_name, snippet_key)\n-\n-        # find available name\n-        current_website = self.env['website'].browse(self.env.context.get('website_id'))\n-        website_domain = Domain(current_website.website_domain())\n-        used_names = self.search(Domain('name', '=like', '%s%%' % name) & website_domain).mapped('name')\n-        name = self._find_available_name(name, used_names)\n-\n-        # html to xml to add '/' at the end of self closing tags like br, ...\n-        arch_tree = html.fromstring(arch)\n-        attributes = self._get_cleaned_non_editing_attributes(arch_tree.attrib.items())\n-        for attr in arch_tree.attrib:\n-            if attr in attributes:\n-                arch_tree.attrib[attr] = attributes[attr]\n-            else:\n-                del arch_tree.attrib[attr]\n-        xml_arch = etree.tostring(arch_tree, encoding='utf-8')\n-        new_snippet_view_values = {\n-            'name': name,\n-            'key': full_snippet_key,\n-            'type': 'qweb',\n-            'arch': xml_arch,\n-        }\n-        new_snippet_view_values.update(self._snippet_save_view_values_hook())\n-        custom_snippet_view = self.create(new_snippet_view_values)\n-        model = self.env.context.get('model')\n-        field = self.env.context.get('field')\n-        if field == 'arch':\n-            # Special case for `arch` which is a kind of related (through a\n-            # compute) to `arch_db` but which is hosting XML/HTML content while\n-            # being a char field.. Which is then messing around with the\n-            # `get_translation_dictionary` call, returning XML instead of\n-            # strings\n-            field = 'arch_db'\n-        res_id = self.env.context.get('resId')\n-        if model and field and res_id:\n-            self._copy_field_terms_translations(\n-                self.env[model].browse(int(res_id)),\n-                field,\n-                custom_snippet_view,\n-                'arch_db',\n-            )\n-\n-        custom_section = self.search([('key', '=', template_key)])\n-        snippet_addition_view_values = {\n-            'name': name + ' Block',\n-            'key': self._get_snippet_addition_view_key(template_key, snippet_key),\n-            'inherit_id': custom_section.id,\n-            'type': 'qweb',\n-            'arch': \"\"\"\n-                <data inherit_id=\"%s\">\n-                    <xpath expr=\"//snippets[@id='snippet_custom']\" position=\"inside\">\n-                        <t t-snippet=\"%s\" t-thumbnail=\"%s\"/>\n-                    </xpath>\n-                </data>\n-            \"\"\" % (template_key, full_snippet_key, thumbnail_url),\n-        }\n-        snippet_addition_view_values.update(self._snippet_save_view_values_hook())\n-        self.create(snippet_addition_view_values)\n-        return name\n-\n-    @api.model\n-    def rename_snippet(self, name, view_id, template_key):\n-        snippet_view = self.browse(view_id)\n-        key = snippet_view.key.split('.')[1]\n-        custom_key = self._get_snippet_addition_view_key(template_key, key)\n-        snippet_addition_view = self.search([('key', '=', custom_key)])\n-        if snippet_addition_view:\n-            snippet_addition_view.name = name + ' Block'\n-        snippet_view.name = name\n-\n-    @api.model\n-    def delete_snippet(self, view_id, template_key):\n-        snippet_view = self.browse(view_id)\n-        key = snippet_view.key.split('.')[1]\n-        custom_key = self._get_snippet_addition_view_key(template_key, key)\n-        snippet_addition_view = self.search([('key', '=', custom_key)])\n-        (snippet_addition_view | snippet_view).unlink()"
+      },
+      {
+        "sha": "3456500376f3fffd82540939b4f293661f544bf0",
+        "filename": "addons/html_editor/tests/test_views.py",
+        "status": "modified",
+        "additions": 0,
+        "deletions": 13,
+        "changes": 13,
+        "blob_url": "https://github.com/odoo/odoo/blob/54a621f5f7728ca1b1ea14ef6d1912984eac0418/addons%2Fhtml_editor%2Ftests%2Ftest_views.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/54a621f5f7728ca1b1ea14ef6d1912984eac0418/addons%2Fhtml_editor%2Ftests%2Ftest_views.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_editor%2Ftests%2Ftest_views.py?ref=54a621f5f7728ca1b1ea14ef6d1912984eac0418",
+        "patch": "@@ -62,16 +62,3 @@ def test_oe_structure_as_inherited_view(self):\n             '<p>Hello World!</p>',\n             base.inherit_children_ids.get_combined_arch(),\n         )\n-\n-    def test_find_available_name(self):\n-        View = self.env['ir.ui.view']\n-        used_names = ['Unrelated name']\n-        initial_name = \"Test name\"\n-        name = View._find_available_name(initial_name, used_names)\n-        self.assertEqual(initial_name, name)\n-        used_names.append(name)\n-        name = View._find_available_name(initial_name, used_names)\n-        self.assertEqual('Test name (2)', name)\n-        used_names.append(name)\n-        name = View._find_available_name(initial_name, used_names)\n-        self.assertEqual('Test name (3)', name)"
+      },
+      {
+        "sha": "d415dc3b670e0fe01a9df31f5f1a3bbe284afb48",
+        "filename": "addons/website/models/ir_ui_view.py",
+        "status": "modified",
+        "additions": 115,
+        "deletions": 1,
+        "changes": 116,
+        "blob_url": "https://github.com/odoo/odoo/blob/54a621f5f7728ca1b1ea14ef6d1912984eac0418/addons%2Fwebsite%2Fmodels%2Fir_ui_view.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/54a621f5f7728ca1b1ea14ef6d1912984eac0418/addons%2Fwebsite%2Fmodels%2Fir_ui_view.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fmodels%2Fir_ui_view.py?ref=54a621f5f7728ca1b1ea14ef6d1912984eac0418",
+        "patch": "@@ -3,6 +3,8 @@\n import logging\n import uuid\n import werkzeug\n+from lxml import etree, html\n+\n \n from odoo import api, fields, models\n from odoo.exceptions import AccessError, MissingError\n@@ -519,12 +521,124 @@ def _get_allowed_root_attrs(self):\n \n     @api.model\n     def _snippet_save_view_values_hook(self):\n-        res = super()._snippet_save_view_values_hook()\n+        res = {}\n         website_id = self.env.context.get('website_id')\n         if website_id:\n             res['website_id'] = website_id\n         return res\n \n+    @api.model\n+    def _get_snippet_addition_view_key(self, template_key, key):\n+        return '%s.%s' % (template_key, key)\n+\n+    def _find_available_name(self, name, used_names):\n+        attempt = 1\n+        candidate_name = name\n+        while candidate_name in used_names:\n+            attempt += 1\n+            candidate_name = f\"{name} ({attempt})\"\n+        return candidate_name\n+\n+    @api.model\n+    def save_snippet(self, name, arch, template_key, snippet_key, thumbnail_url):\n+        \"\"\"\n+        Saves a new snippet arch so that it appears with the given name when\n+        using the given snippets template.\n+\n+        :param name: the name of the snippet to save\n+        :param arch: the html structure of the snippet to save\n+        :param template_key: the key of the view regrouping all snippets in\n+            which the snippet to save is meant to appear\n+        :param snippet_key: the key (without module part) to identify\n+            the snippet from which the snippet to save originates\n+        :param thumbnail_url: the url of the thumbnail to use when displaying\n+            the snippet to save\n+        \"\"\"\n+        app_name = template_key.split('.')[0]\n+        snippet_key = '%s_%s' % (snippet_key, uuid.uuid4().hex)\n+        full_snippet_key = '%s.%s' % (app_name, snippet_key)\n+\n+        # find available name\n+        current_website = self.env['website'].browse(self.env.context.get('website_id'))\n+        website_domain = Domain(current_website.website_domain())\n+        used_names = self.search(Domain('name', '=like', '%s%%' % name) & website_domain).mapped('name')\n+        name = self._find_available_name(name, used_names)\n+\n+        # html to xml to add '/' at the end of self closing tags like br, ...\n+        arch_tree = html.fromstring(arch)\n+        attributes = self._get_cleaned_non_editing_attributes(arch_tree.attrib.items())\n+        for attr in arch_tree.attrib:\n+            if attr in attributes:\n+                arch_tree.attrib[attr] = attributes[attr]\n+            else:\n+                del arch_tree.attrib[attr]\n+        xml_arch = etree.tostring(arch_tree, encoding='utf-8')\n+        new_snippet_view_values = {\n+            'name': name,\n+            'key': full_snippet_key,\n+            'type': 'qweb',\n+            'arch': xml_arch,\n+        }\n+        new_snippet_view_values.update(self._snippet_save_view_values_hook())\n+        custom_snippet_view = self.create(new_snippet_view_values)\n+        model = self.env.context.get('model')\n+        field = self.env.context.get('field')\n+        if field == 'arch':\n+            # Special case for `arch` which is a kind of related (through a\n+            # compute) to `arch_db` but which is hosting XML/HTML content while\n+            # being a char field.. Which is then messing around with the\n+            # `get_translation_dictionary` call, returning XML instead of\n+            # strings\n+            field = 'arch_db'\n+        res_id = self.env.context.get('resId')\n+        if model and field and res_id:\n+            self._copy_field_terms_translations(\n+                self.env[model].browse(int(res_id)),\n+                field,\n+                custom_snippet_view,\n+                'arch_db',\n+            )\n+\n+        custom_section = self.search([('key', '=', template_key)])\n+        snippet_addition_view_values = {\n+            'name': name + ' Block',\n+            'key': self._get_snippet_addition_view_key(template_key, snippet_key),\n+            'inherit_id': custom_section.id,\n+            'type': 'qweb',\n+            'arch': \"\"\"\n+                <data inherit_id=\"%s\">\n+                    <xpath expr=\"//snippets[@id='snippet_custom']\" position=\"inside\">\n+                        <t t-snippet=\"%s\" t-thumbnail=\"%s\"/>\n+                    </xpath>\n+                </data>\n+            \"\"\" % (template_key, full_snippet_key, thumbnail_url),\n+        }\n+        snippet_addition_view_values.update(self._snippet_save_view_values_hook())\n+        self.create(snippet_addition_view_values)\n+        return name\n+\n+    @api.model\n+    def rename_snippet(self, name, view_id, template_key):\n+        snippet_view = self.browse(view_id)\n+        key = snippet_view.key.split('.')[1]\n+        custom_key = self._get_snippet_addition_view_key(template_key, key)\n+        snippet_addition_view = self.search([('key', '=', custom_key)])\n+        if snippet_addition_view:\n+            snippet_addition_view.name = name + ' Block'\n+        snippet_view.name = name\n+\n+    @api.model\n+    def delete_snippet(self, view_id, template_key):\n+        snippet_view = self.browse(view_id)\n+        key = snippet_view.key.split('.')[1]\n+        custom_key = self._get_snippet_addition_view_key(template_key, key)\n+        snippet_addition_view = self.search([('key', '=', custom_key)])\n+        (snippet_addition_view | snippet_view).unlink()\n+\n+    # --------------------------------------------------------------------------\n+    # Languages\n+    # --------------------------------------------------------------------------\n+\n     def _update_field_translations(self, field_name, translations, digest=None, source_lang=''):\n         return super(IrUiView, self.with_context(no_cow=True))._update_field_translations(field_name, translations, digest=digest, source_lang=source_lang)\n "
+      },
+      {
+        "sha": "3ab7e18ea5d18ebbdd12e13dbe0109d470bc5a89",
+        "filename": "addons/website/static/src/builder/snippet_model.js",
+        "status": "modified",
+        "additions": 132,
+        "deletions": 0,
+        "changes": 132,
+        "blob_url": "https://github.com/odoo/odoo/blob/54a621f5f7728ca1b1ea14ef6d1912984eac0418/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fsnippet_model.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/54a621f5f7728ca1b1ea14ef6d1912984eac0418/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fsnippet_model.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fsnippet_model.js?ref=54a621f5f7728ca1b1ea14ef6d1912984eac0418",
+        "patch": "@@ -3,6 +3,7 @@ import { applyTextHighlight } from \"@website/js/highlight_utils\";\n import { registry } from \"@web/core/registry\";\n import { patch } from \"@web/core/utils/patch\";\n import { _t } from \"@web/core/l10n/translation\";\n+import { ConfirmationDialog } from \"@web/core/confirmation_dialog/confirmation_dialog\";\n \n patch(SnippetModel.prototype, {\n     /**\n@@ -33,6 +34,137 @@ patch(SnippetModel.prototype, {\n         }\n         return label;\n     },\n+\n+    /**\n+     * @override\n+     */\n+    async deleteCustomSnippet(snippet) {\n+        return new Promise((resolve) => {\n+            const message = _t(\"Are you sure you want to delete the block %s?\", snippet.title);\n+            this.dialog.add(\n+                ConfirmationDialog,\n+                {\n+                    body: message,\n+                    confirm: async () => {\n+                        const isInnerContent =\n+                            this.snippetsByCategory.snippet_custom_content.includes(snippet);\n+                        const snippetCustom = isInnerContent\n+                            ? this.snippetsByCategory.snippet_custom_content\n+                            : this.snippetsByCategory.snippet_custom;\n+                        const index = snippetCustom.findIndex((s) => s.id === snippet.id);\n+                        if (index > -1) {\n+                            snippetCustom.splice(index, 1);\n+                        }\n+                        await this.orm.call(\"ir.ui.view\", \"delete_snippet\", [], {\n+                            view_id: snippet.viewId,\n+                            template_key: this.snippetsName,\n+                        });\n+                    },\n+                    cancel: () => {},\n+                    confirmLabel: _t(\"Yes\"),\n+                    cancelLabel: _t(\"No\"),\n+                },\n+                {\n+                    onClose: resolve,\n+                }\n+            );\n+        });\n+    },\n+\n+    /**\n+     * @override\n+     */\n+    async renameCustomSnippet(snippet, newName) {\n+        if (newName === snippet.title) {\n+            return;\n+        }\n+        snippet.title = newName;\n+        for (const snippetEl of this.snippetsDocument.body.querySelectorAll(\n+            `snippets#snippet_custom > [data-oe-snippet-key = ${snippet.key}]`\n+        )) {\n+            snippetEl.setAttribute(\"name\", newName);\n+            snippetEl.children[0].dataset[\"name\"] = newName;\n+        }\n+        await this.orm.call(\"ir.ui.view\", \"rename_snippet\", [], {\n+            name: newName,\n+            view_id: snippet.viewId,\n+            template_key: this.snippetsName,\n+        });\n+    },\n+\n+    /**\n+     * @override\n+     */\n+    saveSnippet(\n+        snippetEl,\n+        cleanForSaveHandlers,\n+        wrapWithSaveSnippetHandlers = (_, callback) => callback()\n+    ) {\n+        return new Promise((resolve) => {\n+            this.dialog.add(\n+                ConfirmationDialog,\n+                {\n+                    title: _t(\"Create a custom snippet\"),\n+                    body: _t(\"Do you want to save this snippet as a custom one?\"),\n+                    confirmLabel: _t(\"Save\"),\n+                    cancel: () => resolve(false),\n+                    confirm: async () => {\n+                        const isButton = snippetEl.matches(\"a.btn\");\n+                        const snippetKey = isButton ? \"s_button\" : snippetEl.dataset.snippet;\n+                        const thumbnailURL = this.getSnippetThumbnailURL(snippetKey);\n+\n+                        const snippetCopyEl = await wrapWithSaveSnippetHandlers(snippetEl, () =>\n+                            snippetEl.cloneNode(true)\n+                        );\n+\n+                        // \"CleanForSave\" the snippet copy (only its children in\n+                        // the case of a popup, or it will be saved as invisible\n+                        // and will not be visible in the \"add snippet\" dialog).\n+                        const rootEl = snippetEl.matches(\".s_popup\")\n+                            ? snippetCopyEl.firstElementChild\n+                            : snippetCopyEl;\n+                        cleanForSaveHandlers.forEach((handler) => handler({ root: rootEl }));\n+\n+                        const defaultSnippetName = isButton\n+                            ? _t(\"Custom Button\")\n+                            : _t(\"Custom %s\", snippetEl.dataset.name);\n+                        snippetCopyEl.classList.add(\"s_custom_snippet\");\n+                        delete snippetCopyEl.dataset.name;\n+                        if (isButton) {\n+                            snippetCopyEl.classList.remove(\"mb-2\");\n+                            snippetCopyEl.classList.add(\n+                                \"o_snippet_drop_in_only\",\n+                                \"s_custom_button\"\n+                            );\n+                        }\n+\n+                        const editableParentEl = snippetEl.closest(\n+                            \"[data-oe-model][data-oe-field][data-oe-id]\"\n+                        );\n+                        const context = {\n+                            ...this.context,\n+                            model: editableParentEl.dataset.oeModel,\n+                            field: editableParentEl.dataset.oeField,\n+                            resId: editableParentEl.dataset.oeId,\n+                        };\n+                        const savedName = await this.orm.call(\"ir.ui.view\", \"save_snippet\", [], {\n+                            name: defaultSnippetName,\n+                            arch: snippetCopyEl.outerHTML,\n+                            template_key: this.snippetsName,\n+                            snippet_key: snippetKey,\n+                            thumbnail_url: thumbnailURL,\n+                            context,\n+                        });\n+\n+                        // Reload the snippets so the sidebar is up to date.\n+                        await this.reload();\n+                        resolve(savedName);\n+                    },\n+                },\n+                { onClose: () => resolve(false) }\n+            );\n+        });\n+    },\n });\n \n registry"
+      },
+      {
+        "sha": "f8129d7216290b3c80047a3b8b787eccb80747bf",
+        "filename": "addons/website/static/tests/builder/snippet_custom.test.js",
+        "status": "added",
+        "additions": 88,
+        "deletions": 0,
+        "changes": 88,
+        "blob_url": "https://github.com/odoo/odoo/blob/54a621f5f7728ca1b1ea14ef6d1912984eac0418/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fsnippet_custom.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/54a621f5f7728ca1b1ea14ef6d1912984eac0418/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fsnippet_custom.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fsnippet_custom.test.js?ref=54a621f5f7728ca1b1ea14ef6d1912984eac0418",
+        "patch": "@@ -0,0 +1,88 @@\n+import { createTestSnippets, getSnippetStructure } from \"@html_builder/../tests/helpers\";\n+import { Plugin } from \"@html_editor/plugin\";\n+import { expect, test } from \"@odoo/hoot\";\n+import { animationFrame } from \"@odoo/hoot-dom\";\n+import { contains, onRpc } from \"@web/../tests/web_test_helpers\";\n+import {\n+    addPlugin,\n+    defineWebsiteModels,\n+    setupWebsiteBuilder,\n+} from \"@website/../tests/builder/website_helpers\";\n+\n+defineWebsiteModels();\n+\n+test(\"Renaming custom snippets don't make an orm call\", async () => {\n+    class TestSetupEditorPlugin extends Plugin {\n+        static id = \"test.setup_editor_plugin\";\n+        resources = {\n+            snippet_preview_dialog_bundles: [\"web.assets_frontend\"],\n+        };\n+    }\n+    addPlugin(TestSetupEditorPlugin);\n+\n+    // Stub rename_snippet RPC to succeed if it is called\n+    onRpc(\"ir.ui.view\", \"rename_snippet\", ({ args }) => true);\n+\n+    const customSnippets = createTestSnippets({\n+        snippets: [\n+            {\n+                name: \"Dummy Section\",\n+                groupName: \"custom\",\n+                keywords: [\"dummy\"],\n+                content: `\n+        <section data-snippet=\"s_dummy\">\n+            <div class=\"container\">\n+                <div class=\"row\">\n+                    <div class=\"col-lg-7\">\n+                        <p>TEST</p>\n+                    </div>\n+                </div>\n+            </div>\n+        </section>\n+    `,\n+            },\n+        ],\n+        withName: true,\n+    });\n+    const snippets = {\n+        snippet_groups: [\n+            '<div name=\"Custom\" data-oe-snippet-id=\"123\" data-o-snippet-group=\"custom\"><section data-snippet=\"s_snippet_group\"></section></div>',\n+        ],\n+        snippet_structure: customSnippets.map((snippetDesc) => getSnippetStructure(snippetDesc)),\n+        snippet_custom: customSnippets.map((snippetDesc) => getSnippetStructure(snippetDesc)),\n+    };\n+\n+    await setupWebsiteBuilder(\n+        `<section data-name=\"Dummy Section\" data-snippet=\"s_dummy\">\n+            <div class=\"container\">\n+                <div class=\"row\">\n+                    <div class=\"col-lg-7\">\n+                        <p>TEST</p>\n+                        <p><a class=\"btn\">BUTTON</a></p>\n+                    </div>\n+                </div>\n+            </div>\n+        </section>`,\n+        { snippets }\n+    );\n+\n+    await contains(\n+        \".o-website-builder_sidebar .o_snippets_container .o_snippet[name='Custom'] button\"\n+    ).click();\n+    await animationFrame();\n+\n+    // Throw if any render_public_asset RPC happens during rename\n+    onRpc(\"ir.ui.view\", \"render_public_asset\", () => {\n+        throw new Error(\"shouldn't make an rpc call on snippet rename\");\n+    });\n+\n+    await contains(\n+        \".o_add_snippet_dialog .o_add_snippet_iframe:iframe .o_custom_snippet_edit button > .fa-pencil\"\n+    ).click();\n+    expect(\".o-overlay-item .modal-dialog:contains('Rename the block')\").toHaveCount(1);\n+    await contains(\".o-overlay-item .modal-dialog input#inputConfirmation\").fill(\"new custom name\");\n+    await contains(\".o-overlay-item .modal-dialog footer>button:contains('Save')\").click();\n+    expect(\n+        \".o_add_snippet_dialog .o_add_snippet_iframe:iframe .o_custom_snippet_edit>span:contains('new custom name')\"\n+    ).toHaveCount(1);\n+});"
+      },
+      {
+        "sha": "6869e088a20f06d8bd03b7332eacd8742da43c69",
+        "filename": "addons/website/tests/test_views.py",
+        "status": "modified",
+        "additions": 13,
+        "deletions": 0,
+        "changes": 13,
+        "blob_url": "https://github.com/odoo/odoo/blob/54a621f5f7728ca1b1ea14ef6d1912984eac0418/addons%2Fwebsite%2Ftests%2Ftest_views.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/54a621f5f7728ca1b1ea14ef6d1912984eac0418/addons%2Fwebsite%2Ftests%2Ftest_views.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Ftests%2Ftest_views.py?ref=54a621f5f7728ca1b1ea14ef6d1912984eac0418",
+        "patch": "@@ -192,6 +192,19 @@ def test_enabling_optional_template_with_editor(self):\n         self.assertEqual(set(actives), {'website.test_view'})\n         self.assertEqual([custo.active, default.active], [True, True])\n \n+    def test_find_available_name(self):\n+        View = self.env['ir.ui.view']\n+        used_names = ['Unrelated name']\n+        initial_name = \"Test name\"\n+        name = View._find_available_name(initial_name, used_names)\n+        self.assertEqual(initial_name, name)\n+        used_names.append(name)\n+        name = View._find_available_name(initial_name, used_names)\n+        self.assertEqual('Test name (2)', name)\n+        used_names.append(name)\n+        name = View._find_available_name(initial_name, used_names)\n+        self.assertEqual('Test name (3)', name)\n+\n \n @tagged('at_install', '-post_install')  # LEGACY at_install\n class TestViewSaving(TestViewSavingCommon):"
+      }
+    ]
+  },
+  {
+    "sha": "d957f6965384ab66557c9622a9f7cd6a4f06dfe9",
+    "node_id": "C_kwDOAS1I7NoAKGQ5NTdmNjk2NTM4NGFiNjY1NTdjOTYyMmE5ZjdjZDZhNGYwNmRmZTk",
+    "commit": {
+      "author": {
+        "name": "Augustin (duau)",
+        "email": "duau@odoo.com",
+        "date": "2025-10-07T16:09:15Z"
+      },
+      "committer": {
+        "name": "Augustin (duau)",
+        "email": "duau@odoo.com",
+        "date": "2025-10-22T13:00:32Z"
+      },
+      "message": "[REF] html_editor, website: move ir_ui_view save methods to website\n\nFollowing website refactoring [1], and web_editor deletion, models were\nmoved to html_editor [2].\nThis commit is moving `ir_ui_view` methods related to `save` to website,\nas they are specific to the module.\n\n[1]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2\n[2]: https://github.com/odoo/odoo/commit/867d9a2f923a55c0bd6a281e2dea1f524fa04445\n\ntask-5065980\n\ncloses odoo/odoo#230322\n\nRelated: odoo/enterprise#97218\nSigned-off-by: David Monjoie (dmo) <dmo@odoo.com>",
+      "tree": {
+        "sha": "bebe1c40b7056c7b69b2bd14f2000f0f72139fbf",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/bebe1c40b7056c7b69b2bd14f2000f0f72139fbf"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/d957f6965384ab66557c9622a9f7cd6a4f06dfe9",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/d957f6965384ab66557c9622a9f7cd6a4f06dfe9",
+    "html_url": "https://github.com/odoo/odoo/commit/d957f6965384ab66557c9622a9f7cd6a4f06dfe9",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/d957f6965384ab66557c9622a9f7cd6a4f06dfe9/comments",
+    "author": {
+      "login": "duau-odoo",
+      "id": 199088574,
+      "node_id": "U_kgDOC93Zvg",
+      "avatar_url": "https://avatars.githubusercontent.com/u/199088574?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/duau-odoo",
+      "html_url": "https://github.com/duau-odoo",
+      "followers_url": "https://api.github.com/users/duau-odoo/followers",
+      "following_url": "https://api.github.com/users/duau-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/duau-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/duau-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/duau-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/duau-odoo/orgs",
+      "repos_url": "https://api.github.com/users/duau-odoo/repos",
+      "events_url": "https://api.github.com/users/duau-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/duau-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "duau-odoo",
+      "id": 199088574,
+      "node_id": "U_kgDOC93Zvg",
+      "avatar_url": "https://avatars.githubusercontent.com/u/199088574?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/duau-odoo",
+      "html_url": "https://github.com/duau-odoo",
+      "followers_url": "https://api.github.com/users/duau-odoo/followers",
+      "following_url": "https://api.github.com/users/duau-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/duau-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/duau-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/duau-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/duau-odoo/orgs",
+      "repos_url": "https://api.github.com/users/duau-odoo/repos",
+      "events_url": "https://api.github.com/users/duau-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/duau-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "54a621f5f7728ca1b1ea14ef6d1912984eac0418",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/54a621f5f7728ca1b1ea14ef6d1912984eac0418",
+        "html_url": "https://github.com/odoo/odoo/commit/54a621f5f7728ca1b1ea14ef6d1912984eac0418"
+      }
+    ],
+    "stats": {
+      "total": 770,
+      "additions": 386,
+      "deletions": 384
+    },
+    "files": [
+      {
+        "sha": "2fd7b78b54273899eb6304fed2dd41dde9eb80d0",
+        "filename": "addons/html_builder/static/src/core/save_plugin.js",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 33,
+        "changes": 34,
+        "blob_url": "https://github.com/odoo/odoo/blob/d957f6965384ab66557c9622a9f7cd6a4f06dfe9/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fcore%2Fsave_plugin.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/d957f6965384ab66557c9622a9f7cd6a4f06dfe9/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fcore%2Fsave_plugin.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fcore%2Fsave_plugin.js?ref=d957f6965384ab66557c9622a9f7cd6a4f06dfe9",
+        "patch": "@@ -1,12 +1,11 @@\n-import { escapeTextNodes } from \"@html_builder/utils/escaping\";\n import { Plugin } from \"@html_editor/plugin\";\n import { withSequence } from \"@html_editor/utils/resource\";\n import { groupBy } from \"@web/core/utils/arrays\";\n import { uniqueId } from \"@web/core/utils/functions\";\n \n export class SavePlugin extends Plugin {\n     static id = \"savePlugin\";\n-    static shared = [\"save\", \"saveView\", \"ignoreDirty\"];\n+    static shared = [\"save\", \"ignoreDirty\"];\n     static dependencies = [\"history\"];\n \n     resources = {\n@@ -33,7 +32,6 @@ export class SavePlugin extends Plugin {\n             // async (el) => {\n             //     called when saving an element (in parallel to saving the view)\n             // }\n-            this.saveView.bind(this),\n         ],\n         save_handlers: [\n             // async () => {\n@@ -108,36 +106,6 @@ export class SavePlugin extends Plugin {\n         this.dependencies.history.reset();\n     }\n \n-    /**\n-     * Saves one (dirty) element of the page.\n-     *\n-     * @param {HTMLElement} el - the element to save.\n-     */\n-    saveView(el, delayTranslations = true) {\n-        const viewID = Number(el.dataset[\"oeId\"]);\n-        if (!viewID) {\n-            return;\n-        }\n-\n-        let context = {};\n-        if (this.services.website) {\n-            const delay = delayTranslations ? { delay_translations: true } : {};\n-            context = {\n-                website_id: this.services.website.currentWebsite.id,\n-                lang: this.services.website.currentWebsite.metadata.lang,\n-                ...delay,\n-            };\n-        }\n-\n-        escapeTextNodes(el);\n-        return this.services.orm.call(\n-            \"ir.ui.view\",\n-            \"save\",\n-            [viewID, el.outerHTML, (!el.dataset[\"oeExpression\"] && el.dataset[\"oeXpath\"]) || null],\n-            { context }\n-        );\n-    }\n-\n     startObserving() {\n         this.canObserve = true;\n     }"
+      },
+      {
+        "sha": "da53aaa6ef11d153448dfc810f9e1abccd8fe2b6",
+        "filename": "addons/html_builder/static/tests/clean_for_save_options.test.js",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 3,
+        "changes": 4,
+        "blob_url": "https://github.com/odoo/odoo/blob/d957f6965384ab66557c9622a9f7cd6a4f06dfe9/addons%2Fhtml_builder%2Fstatic%2Ftests%2Fclean_for_save_options.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/d957f6965384ab66557c9622a9f7cd6a4f06dfe9/addons%2Fhtml_builder%2Fstatic%2Ftests%2Fclean_for_save_options.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_builder%2Fstatic%2Ftests%2Fclean_for_save_options.test.js?ref=d957f6965384ab66557c9622a9f7cd6a4f06dfe9",
+        "patch": "@@ -1,12 +1,11 @@\n import { addBuilderOption, setupHTMLBuilder } from \"@html_builder/../tests/helpers\";\n import { expect, test, describe } from \"@odoo/hoot\";\n import { xml } from \"@odoo/owl\";\n-import { contains, onRpc } from \"@web/../tests/web_test_helpers\";\n+import { contains } from \"@web/../tests/web_test_helpers\";\n \n describe.current.tags(\"desktop\");\n \n test(\"clean for save of option with selector that matches an element on the page\", async () => {\n-    onRpc(\"ir.ui.view\", \"save\", ({ args }) => true);\n     addBuilderOption({\n         selector: \".test-options-target\",\n         template: xml`\n@@ -29,7 +28,6 @@ test(\"clean for save of option with selector that matches an element on the page\n });\n \n test(\"clean for save of option with selector and exclude that matches an element on the page\", async () => {\n-    onRpc(\"ir.ui.view\", \"save\", ({ args }) => true);\n     addBuilderOption({\n         selector: \".test-options-target\",\n         template: xml`"
+      },
+      {
+        "sha": "b3c91f996bcf133268b93e4cc52ec3f876fbb8dc",
+        "filename": "addons/html_editor/models/ir_ui_view.py",
+        "status": "modified",
+        "additions": 3,
+        "deletions": 308,
+        "changes": 311,
+        "blob_url": "https://github.com/odoo/odoo/blob/d957f6965384ab66557c9622a9f7cd6a4f06dfe9/addons%2Fhtml_editor%2Fmodels%2Fir_ui_view.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/d957f6965384ab66557c9622a9f7cd6a4f06dfe9/addons%2Fhtml_editor%2Fmodels%2Fir_ui_view.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_editor%2Fmodels%2Fir_ui_view.py?ref=d957f6965384ab66557c9622a9f7cd6a4f06dfe9",
+        "patch": "@@ -1,322 +1,17 @@\n # Part of Odoo. See LICENSE file for full copyright and licensing details.\n \n-import copy\n import logging\n-from lxml import etree, html\n+from lxml import etree\n \n-from odoo import api, models, _\n-from odoo.exceptions import ValidationError, MissingError\n-from odoo.addons.base.models.ir_ui_view import MOVABLE_BRANDING\n+from odoo import api, models\n+from odoo.exceptions import MissingError\n \n _logger = logging.getLogger(__name__)\n \n-EDITING_ATTRIBUTES = MOVABLE_BRANDING + [\n-    'data-oe-type',\n-    'data-oe-expression',\n-    'data-oe-translation-id',\n-    'data-note-id'\n-]\n-\n \n class IrUiView(models.Model):\n     _inherit = 'ir.ui.view'\n \n-    def _get_cleaned_non_editing_attributes(self, attributes):\n-        \"\"\"\n-        Returns a new mapping of attributes -> value without the parts that are\n-        not meant to be saved (branding, editing classes, ...). Note that\n-        classes are meant to be cleaned on the client side before saving as\n-        mostly linked to the related options (so we are not supposed to know\n-        which to remove here).\n-\n-        :param attributes: a mapping of attributes -> value\n-        :return: a new mapping of attributes -> value\n-        \"\"\"\n-        attributes = {k: v for k, v in attributes if k not in EDITING_ATTRIBUTES}\n-        if 'class' in attributes:\n-            classes = attributes['class'].split()\n-            attributes['class'] = ' '.join([c for c in classes if c != 'o_editable'])\n-        if attributes.get('contenteditable') == 'true':\n-            del attributes['contenteditable']\n-        return attributes\n-\n-    # ------------------------------------------------------\n-    # Save from html\n-    # ------------------------------------------------------\n-\n-    @api.model\n-    def extract_embedded_fields(self, arch):\n-        return arch.xpath('//*[@data-oe-model != \"ir.ui.view\"]')\n-\n-    @api.model\n-    def extract_oe_structures(self, arch):\n-        return arch.xpath('//*[hasclass(\"oe_structure\")][contains(@id, \"oe_structure\")]')\n-\n-    @api.model\n-    def get_default_lang_code(self):\n-        return False\n-\n-    @api.model\n-    def save_embedded_field(self, el):\n-        Model = self.env[el.get('data-oe-model')]\n-        field = el.get('data-oe-field')\n-\n-        model = 'ir.qweb.field.' + el.get('data-oe-type')\n-        converter = self.env[model] if model in self.env else self.env['ir.qweb.field']\n-\n-        try:\n-            value = converter.from_html(Model, Model._fields[field], el)\n-            if value is not None:\n-                # TODO: batch writes?\n-                record = Model.browse(int(el.get('data-oe-id')))\n-                if not self.env.context.get('lang') and self.get_default_lang_code():\n-                    record.with_context(lang=self.get_default_lang_code()).write({field: value})\n-                else:\n-                    record.write({field: value})\n-\n-                if callable(Model._fields[field].translate):\n-                    self._copy_custom_snippet_translations(record, field)\n-\n-        except (ValueError, TypeError):\n-            raise ValidationError(_(\n-                \"Invalid field value for %(field_name)s: %(value)s\",\n-                field_name=Model._fields[field].string,\n-                value=el.text_content().strip(),\n-            ))\n-\n-    def save_oe_structure(self, el):\n-        self.ensure_one()\n-\n-        if el.get('id') in self.key:\n-            # Do not inherit if the oe_structure already has its own inheriting view\n-            return False\n-\n-        arch = etree.Element('data')\n-        xpath = etree.Element('xpath', expr=\"//*[hasclass('oe_structure')][@id='{}']\".format(el.get('id')), position=\"replace\")\n-        arch.append(xpath)\n-        attributes = self._get_cleaned_non_editing_attributes(el.attrib.items())\n-        structure = etree.Element(el.tag, attrib=attributes)\n-        structure.text = el.text\n-        xpath.append(structure)\n-        for child in el.iterchildren(tag=etree.Element):\n-            structure.append(copy.deepcopy(child))\n-\n-        vals = {\n-            'inherit_id': self.id,\n-            'name': '%s (%s)' % (self.name, el.get('id')),\n-            'arch': etree.tostring(arch, encoding='unicode'),\n-            'key': '%s_%s' % (self.key, el.get('id')),\n-            'type': 'qweb',\n-            'mode': 'extension',\n-        }\n-        vals.update(self._save_oe_structure_hook())\n-        oe_structure_view = self.env['ir.ui.view'].create(vals)\n-        self._copy_custom_snippet_translations(oe_structure_view, 'arch_db')\n-\n-        return True\n-\n-    @api.model\n-    def _copy_custom_snippet_translations(self, record, html_field):\n-        \"\"\" Given a ``record`` and its HTML ``field``, detect any\n-        usage of a custom snippet and copy its translations.\n-        \"\"\"\n-        lang_value = record[html_field]\n-        if not lang_value:\n-            return\n-\n-        try:\n-            tree = html.fromstring(lang_value)\n-        except etree.ParserError as e:\n-            raise ValidationError(str(e))\n-\n-        for custom_snippet_el in tree.xpath('//*[hasclass(\"s_custom_snippet\")]'):\n-            custom_snippet_name = custom_snippet_el.get('data-name')\n-            custom_snippet_view = self.search([('name', '=', custom_snippet_name)], limit=1)\n-            if custom_snippet_view:\n-                self._copy_field_terms_translations(custom_snippet_view, 'arch_db', record, html_field)\n-\n-    @api.model\n-    def _copy_field_terms_translations(self, records_from, name_field_from, record_to, name_field_to):\n-        \"\"\" Copy model terms translations from ``records_from.name_field_from``\n-        to ``record_to.name_field_to`` for all activated languages if the term\n-        in ``record_to.name_field_to`` is untranslated (the term matches the\n-        one in the current language).\n-\n-        For instance, copy the translations of a\n-        ``product.template.html_description`` field to a ``ir.ui.view.arch_db``\n-        field.\n-\n-        The method takes care of read and write access of both records/fields.\n-        \"\"\"\n-        record_to.check_access('write')\n-        field_from = records_from._fields[name_field_from]\n-        field_to = record_to._fields[name_field_to]\n-        record_to._check_field_access(field_to, 'write')\n-\n-        error_callable_msg = \"'translate' property of field %r is not callable\"\n-        if not callable(field_from.translate):\n-            raise TypeError(error_callable_msg % field_from)\n-        if not callable(field_to.translate):\n-            raise TypeError(error_callable_msg % field_to)\n-        if not field_to.store:\n-            raise ValueError(\"Field %r is not stored\" % field_to)\n-\n-        # This will also implicitly check for `read` access rights\n-        if not record_to[name_field_to] or not any(records_from.mapped(name_field_from)):\n-            return\n-\n-        lang_env = self.env.lang or 'en_US'\n-        langs = {lang for lang, _ in self.env['res.lang'].get_installed()}\n-\n-        # 1. Get translations\n-        records_from.flush_model([name_field_from])\n-        existing_translation_dictionary = field_to.get_translation_dictionary(\n-            record_to[name_field_to],\n-            {lang: record_to.with_context(prefetch_langs=True, lang=lang)[name_field_to] for lang in langs if lang != lang_env}\n-        )\n-        extra_translation_dictionary = {}\n-        for record_from in records_from:\n-            extra_translation_dictionary.update(field_from.get_translation_dictionary(\n-                record_from[name_field_from],\n-                {lang: record_from.with_context(prefetch_langs=True, lang=lang)[name_field_from] for lang in langs if lang != lang_env}\n-            ))\n-        for term, extra_translation_values in extra_translation_dictionary.items():\n-            existing_translation_values = existing_translation_dictionary.setdefault(term, {})\n-            # Update only default translation values that aren't customized by the user.\n-            for lang, extra_translation in extra_translation_values.items():\n-                if existing_translation_values.get(lang, term) == term:\n-                    existing_translation_values[lang] = extra_translation\n-        translation_dictionary = existing_translation_dictionary\n-\n-        # The `en_US` jsonb value should always be set, even if english is not\n-        # installed. If we don't do this, the custom snippet `arch_db` will only\n-        # have a `fr_BE` key but no `en_US` key.\n-        langs.add('en_US')\n-\n-        # 2. Set translations\n-        new_value = {\n-            lang: field_to.translate(lambda term: translation_dictionary.get(term, {}).get(lang), record_to[name_field_to])\n-            for lang in langs\n-        }\n-        record_to.env.cache.update_raw(record_to, field_to, [new_value], dirty=True)\n-        # Call `write` to trigger compute etc (`modified()`)\n-        record_to[name_field_to] = new_value[lang_env]\n-\n-    @api.model\n-    def _save_oe_structure_hook(self):\n-        return {}\n-\n-    @api.model\n-    def _are_archs_equal(self, arch1, arch2):\n-        # Note that comparing the strings would not be ok as attributes order\n-        # must not be relevant\n-        if arch1.tag != arch2.tag:\n-            return False\n-        if arch1.text != arch2.text:\n-            return False\n-        if arch1.tail != arch2.tail:\n-            return False\n-        if arch1.attrib != arch2.attrib:\n-            return False\n-        if len(arch1) != len(arch2):\n-            return False\n-        return all(self._are_archs_equal(arch1, arch2) for arch1, arch2 in zip(arch1, arch2))\n-\n-    @api.model\n-    def _get_allowed_root_attrs(self):\n-        return ['style', 'class', 'target', 'href']\n-\n-    def replace_arch_section(self, section_xpath, replacement, replace_tail=False):\n-        # the root of the arch section shouldn't actually be replaced as it's\n-        # not really editable itself, only the content truly is editable.\n-        self.ensure_one()\n-        arch = etree.fromstring(self.arch.encode('utf-8'))\n-        # => get the replacement root\n-        if not section_xpath:\n-            root = arch\n-        else:\n-            # ensure there's only one match\n-            [root] = arch.xpath(section_xpath)\n-\n-        root.text = replacement.text\n-\n-        # We need to replace some attrib for styles changes on the root element\n-        for attribute in self._get_allowed_root_attrs():\n-            if attribute in replacement.attrib:\n-                root.attrib[attribute] = replacement.attrib[attribute]\n-            elif attribute in root.attrib:\n-                del root.attrib[attribute]\n-\n-        # Note: after a standard edition, the tail *must not* be replaced\n-        if replace_tail:\n-            root.tail = replacement.tail\n-        # replace all children\n-        del root[:]\n-        for child in replacement:\n-            root.append(copy.deepcopy(child))\n-\n-        return arch\n-\n-    @api.model\n-    def to_field_ref(self, el):\n-        # filter out meta-information inserted in the document\n-        attributes = {k: v for k, v in el.attrib.items()\n-                           if not k.startswith('data-oe-')}\n-        attributes['t-field'] = el.get('data-oe-expression')\n-\n-        out = html.html_parser.makeelement(el.tag, attrib=attributes)\n-        out.tail = el.tail\n-        return out\n-\n-    @api.model\n-    def to_empty_oe_structure(self, el):\n-        out = html.html_parser.makeelement(el.tag, attrib=el.attrib)\n-        out.tail = el.tail\n-        return out\n-\n-    @api.model\n-    def _set_noupdate(self):\n-        self.sudo().mapped('model_data_id').write({'noupdate': True})\n-\n-    def save(self, value, xpath=None):\n-        \"\"\" Update a view section. The view section may embed fields to write\n-\n-        Note that `self` record might not exist when saving an embed field\n-\n-        :param str xpath: valid xpath to the tag to replace\n-        \"\"\"\n-        self.ensure_one()\n-\n-        arch_section = html.fromstring(\n-            value, parser=html.HTMLParser(encoding='utf-8'))\n-\n-        if xpath is None:\n-            # value is an embedded field on its own, not a view section\n-            self.save_embedded_field(arch_section)\n-            return\n-\n-        for el in self.extract_embedded_fields(arch_section):\n-            self.save_embedded_field(el)\n-\n-            # transform embedded field back to t-field\n-            el.getparent().replace(el, self.to_field_ref(el))\n-\n-        for el in self.extract_oe_structures(arch_section):\n-            if self.save_oe_structure(el):\n-                # empty oe_structure in parent view\n-                empty = self.to_empty_oe_structure(el)\n-                if el == arch_section:\n-                    arch_section = empty\n-                else:\n-                    el.getparent().replace(el, empty)\n-\n-        new_arch = self.replace_arch_section(xpath, arch_section)\n-        old_arch = etree.fromstring(self.arch.encode('utf-8'))\n-        if not self._are_archs_equal(old_arch, new_arch):\n-            self._set_noupdate()\n-            self.write({'arch': etree.tostring(new_arch, encoding='unicode')})\n-            self._copy_custom_snippet_translations(self, 'arch_db')\n-\n     @api.model\n     def _view_get_inherited_children(self, view):\n         if self.env.context.get('no_primary_children', False):"
+      },
+      {
+        "sha": "579677f7ad7b8fc7b78583f27b3235351edd5504",
+        "filename": "addons/html_editor/tests/test_views.py",
+        "status": "modified",
+        "additions": 0,
+        "deletions": 31,
+        "changes": 31,
+        "blob_url": "https://github.com/odoo/odoo/blob/d957f6965384ab66557c9622a9f7cd6a4f06dfe9/addons%2Fhtml_editor%2Ftests%2Ftest_views.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/d957f6965384ab66557c9622a9f7cd6a4f06dfe9/addons%2Fhtml_editor%2Ftests%2Ftest_views.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_editor%2Ftests%2Ftest_views.py?ref=d957f6965384ab66557c9622a9f7cd6a4f06dfe9",
+        "patch": "@@ -31,34 +31,3 @@ def test_infinite_inherit_loop(self):\n         })\n         # Test for RecursionError: maximum recursion depth exceeded in this function\n         View._views_get(self.first_view)\n-\n-    def test_oe_structure_as_inherited_view(self):\n-        View = self.env['ir.ui.view']\n-\n-        base = View.create({\n-            'name': 'Test View oe_structure',\n-            'type': 'qweb',\n-            'arch': \"\"\"<xpath expr='//t[@t-call=\"html_editor.test_first_view\"]' position='after'>\n-                        <div class=\"oe_structure\" id='oe_structure_test_view_oe_structure'/>\n-                    </xpath>\"\"\",\n-            'key': 'html_editor.oe_structure_view',\n-            'inherit_id': self.second_view.id\n-        })\n-\n-        # check view mode\n-        self.assertEqual(base.mode, 'extension')\n-\n-        # update content of the oe_structure\n-        value = '''<div class=\"oe_structure\" id=\"oe_structure_test_view_oe_structure\" data-oe-id=\"%s\"\n-                         data-oe-xpath=\"/div\" data-oe-model=\"ir.ui.view\" data-oe-field=\"arch\">\n-                        <p>Hello World!</p>\n-                   </div>''' % base.id\n-\n-        base.save(value=value, xpath='/xpath/div')\n-\n-        self.assertEqual(len(base.inherit_children_ids), 1)\n-        self.assertEqual(base.inherit_children_ids.mode, 'extension')\n-        self.assertIn(\n-            '<p>Hello World!</p>',\n-            base.inherit_children_ids.get_combined_arch(),\n-        )"
+      },
+      {
+        "sha": "100bf988caac4be934fe40f902a469372fd6fe0f",
+        "filename": "addons/website/models/ir_ui_view.py",
+        "status": "modified",
+        "additions": 290,
+        "deletions": 7,
+        "changes": 297,
+        "blob_url": "https://github.com/odoo/odoo/blob/d957f6965384ab66557c9622a9f7cd6a4f06dfe9/addons%2Fwebsite%2Fmodels%2Fir_ui_view.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/d957f6965384ab66557c9622a9f7cd6a4f06dfe9/addons%2Fwebsite%2Fmodels%2Fir_ui_view.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fmodels%2Fir_ui_view.py?ref=d957f6965384ab66557c9622a9f7cd6a4f06dfe9",
+        "patch": "@@ -1,18 +1,27 @@\n # Part of Odoo. See LICENSE file for full copyright and licensing details.\n \n+import copy\n import logging\n import uuid\n import werkzeug\n from lxml import etree, html\n \n \n-from odoo import api, fields, models\n-from odoo.exceptions import AccessError, MissingError\n+from odoo import api, fields, models, _\n+from odoo.exceptions import AccessError, MissingError, ValidationError\n from odoo.fields import Domain\n from odoo.http import request\n+from odoo.addons.base.models.ir_ui_view import MOVABLE_BRANDING\n \n _logger = logging.getLogger(__name__)\n \n+EDITING_ATTRIBUTES = MOVABLE_BRANDING + [\n+    'data-oe-type',\n+    'data-oe-expression',\n+    'data-oe-translation-id',\n+    'data-note-id'\n+]\n+\n \n class IrUiView(models.Model):\n     _name = 'ir.ui.view'\n@@ -464,14 +473,255 @@ def get_default_lang_code(self):\n             lang_code = self.env['website'].browse(website_id).default_lang_id.code\n             return lang_code\n         else:\n-            return super().get_default_lang_code()\n+            return False\n \n     def _read_template_keys(self):\n         return super()._read_template_keys() + ['website_id']\n \n+    # ------------------------------------------------------\n+    # Save from html\n+    # ------------------------------------------------------\n+\n+    def _get_cleaned_non_editing_attributes(self, attributes):\n+        \"\"\"\n+        Returns a new mapping of attributes -> value without the parts that are\n+        not meant to be saved (branding, editing classes, ...). Note that\n+        classes are meant to be cleaned on the client side before saving as\n+        mostly linked to the related options (so we are not supposed to know\n+        which to remove here).\n+\n+        :param attributes: a mapping of attributes -> value\n+        :return: a new mapping of attributes -> value\n+        \"\"\"\n+        attributes = {k: v for k, v in attributes if k not in EDITING_ATTRIBUTES}\n+        if 'class' in attributes:\n+            classes = attributes['class'].split()\n+            attributes['class'] = ' '.join([c for c in classes if c != 'o_editable'])\n+        if attributes.get('contenteditable') == 'true':\n+            del attributes['contenteditable']\n+        return attributes\n+\n+    @api.model\n+    def extract_embedded_fields(self, arch):\n+        return arch.xpath('//*[@data-oe-model != \"ir.ui.view\"]')\n+\n+    @api.model\n+    def extract_oe_structures(self, arch):\n+        return arch.xpath('//*[hasclass(\"oe_structure\")][contains(@id, \"oe_structure\")]')\n+\n+    @api.model\n+    def save_embedded_field(self, el):\n+        Model = self.env[el.get('data-oe-model')]\n+        field = el.get('data-oe-field')\n+\n+        model = 'ir.qweb.field.' + el.get('data-oe-type')\n+        converter = self.env[model] if model in self.env else self.env['ir.qweb.field']\n+\n+        try:\n+            value = converter.from_html(Model, Model._fields[field], el)\n+            if value is not None:\n+                # TODO: batch writes?\n+                record = Model.browse(int(el.get('data-oe-id')))\n+                if not self.env.context.get('lang') and self.get_default_lang_code():\n+                    record.with_context(lang=self.get_default_lang_code()).write({field: value})\n+                else:\n+                    record.write({field: value})\n+\n+                if callable(Model._fields[field].translate):\n+                    self._copy_custom_snippet_translations(record, field)\n+\n+        except (ValueError, TypeError):\n+            raise ValidationError(_(\n+                \"Invalid field value for %(field_name)s: %(value)s\",\n+                field_name=Model._fields[field].string,\n+                value=el.text_content().strip(),\n+            ))\n+\n+    def save_oe_structure(self, el):\n+        self.ensure_one()\n+\n+        if el.get('id') in self.key:\n+            # Do not inherit if the oe_structure already has its own inheriting view\n+            return False\n+\n+        arch = etree.Element('data')\n+        xpath = etree.Element('xpath', expr=\"//*[hasclass('oe_structure')][@id='{}']\".format(el.get('id')), position=\"replace\")\n+        arch.append(xpath)\n+        attributes = self._get_cleaned_non_editing_attributes(el.attrib.items())\n+        structure = etree.Element(el.tag, attrib=attributes)\n+        structure.text = el.text\n+        xpath.append(structure)\n+        for child in el.iterchildren(tag=etree.Element):\n+            structure.append(copy.deepcopy(child))\n+\n+        vals = {\n+            'inherit_id': self.id,\n+            'name': '%s (%s)' % (self.name, el.get('id')),\n+            'arch': etree.tostring(arch, encoding='unicode'),\n+            'key': '%s_%s' % (self.key, el.get('id')),\n+            'type': 'qweb',\n+            'mode': 'extension',\n+        }\n+        vals.update(self._save_oe_structure_hook())\n+        oe_structure_view = self.env['ir.ui.view'].create(vals)\n+        self._copy_custom_snippet_translations(oe_structure_view, 'arch_db')\n+\n+        return True\n+\n+    @api.model\n+    def _copy_custom_snippet_translations(self, record, html_field):\n+        \"\"\" Given a ``record`` and its HTML ``field``, detect any\n+        usage of a custom snippet and copy its translations.\n+        \"\"\"\n+        lang_value = record[html_field]\n+        if not lang_value:\n+            return\n+\n+        try:\n+            tree = html.fromstring(lang_value)\n+        except etree.ParserError as e:\n+            raise ValidationError(str(e))\n+\n+        for custom_snippet_el in tree.xpath('//*[hasclass(\"s_custom_snippet\")]'):\n+            custom_snippet_name = custom_snippet_el.get('data-name')\n+            custom_snippet_view = self.search([('name', '=', custom_snippet_name)], limit=1)\n+            if custom_snippet_view:\n+                self._copy_field_terms_translations(custom_snippet_view, 'arch_db', record, html_field)\n+\n+    @api.model\n+    def _copy_field_terms_translations(self, records_from, name_field_from, record_to, name_field_to):\n+        \"\"\" Copy model terms translations from ``records_from.name_field_from``\n+        to ``record_to.name_field_to`` for all activated languages if the term\n+        in ``record_to.name_field_to`` is untranslated (the term matches the\n+        one in the current language).\n+\n+        For instance, copy the translations of a\n+        ``product.template.html_description`` field to a ``ir.ui.view.arch_db``\n+        field.\n+\n+        The method takes care of read and write access of both records/fields.\n+        \"\"\"\n+        record_to.check_access('write')\n+        field_from = records_from._fields[name_field_from]\n+        field_to = record_to._fields[name_field_to]\n+        record_to._check_field_access(field_to, 'write')\n+\n+        error_callable_msg = \"'translate' property of field %r is not callable\"\n+        if not callable(field_from.translate):\n+            raise TypeError(error_callable_msg % field_from)\n+        if not callable(field_to.translate):\n+            raise TypeError(error_callable_msg % field_to)\n+        if not field_to.store:\n+            raise ValueError(\"Field %r is not stored\" % field_to)\n+\n+        # This will also implicitly check for `read` access rights\n+        if not record_to[name_field_to] or not any(records_from.mapped(name_field_from)):\n+            return\n+\n+        lang_env = self.env.lang or 'en_US'\n+        langs = {lang for lang, _ in self.env['res.lang'].get_installed()}\n+\n+        # 1. Get translations\n+        records_from.flush_model([name_field_from])\n+        existing_translation_dictionary = field_to.get_translation_dictionary(\n+            record_to[name_field_to],\n+            {lang: record_to.with_context(prefetch_langs=True, lang=lang)[name_field_to] for lang in langs if lang != lang_env}\n+        )\n+        extra_translation_dictionary = {}\n+        for record_from in records_from:\n+            extra_translation_dictionary.update(field_from.get_translation_dictionary(\n+                record_from[name_field_from],\n+                {lang: record_from.with_context(prefetch_langs=True, lang=lang)[name_field_from] for lang in langs if lang != lang_env}\n+            ))\n+        for term, extra_translation_values in extra_translation_dictionary.items():\n+            existing_translation_values = existing_translation_dictionary.setdefault(term, {})\n+            # Update only default translation values that aren't customized by the user.\n+            for lang, extra_translation in extra_translation_values.items():\n+                if existing_translation_values.get(lang, term) == term:\n+                    existing_translation_values[lang] = extra_translation\n+        translation_dictionary = existing_translation_dictionary\n+\n+        # The `en_US` jsonb value should always be set, even if english is not\n+        # installed. If we don't do this, the custom snippet `arch_db` will only\n+        # have a `fr_BE` key but no `en_US` key.\n+        langs.add('en_US')\n+\n+        # 2. Set translations\n+        new_value = {\n+            lang: field_to.translate(lambda term: translation_dictionary.get(term, {}).get(lang), record_to[name_field_to])\n+            for lang in langs\n+        }\n+        record_to.env.cache.update_raw(record_to, field_to, [new_value], dirty=True)\n+        # Call `write` to trigger compute etc (`modified()`)\n+        record_to[name_field_to] = new_value[lang_env]\n+\n+    @api.model\n+    def _are_archs_equal(self, arch1, arch2):\n+        # Note that comparing the strings would not be ok as attributes order\n+        # must not be relevant\n+        if arch1.tag != arch2.tag:\n+            return False\n+        if arch1.text != arch2.text:\n+            return False\n+        if arch1.tail != arch2.tail:\n+            return False\n+        if arch1.attrib != arch2.attrib:\n+            return False\n+        if len(arch1) != len(arch2):\n+            return False\n+        return all(self._are_archs_equal(arch1, arch2) for arch1, arch2 in zip(arch1, arch2))\n+\n+    def replace_arch_section(self, section_xpath, replacement, replace_tail=False):\n+        # the root of the arch section shouldn't actually be replaced as it's\n+        # not really editable itself, only the content truly is editable.\n+        self.ensure_one()\n+        arch = etree.fromstring(self.arch.encode('utf-8'))\n+        # => get the replacement root\n+        if not section_xpath:\n+            root = arch\n+        else:\n+            # ensure there's only one match\n+            [root] = arch.xpath(section_xpath)\n+\n+        root.text = replacement.text\n+\n+        # We need to replace some attrib for styles changes on the root element\n+        for attribute in self._get_allowed_root_attrs():\n+            if attribute in replacement.attrib:\n+                root.attrib[attribute] = replacement.attrib[attribute]\n+            elif attribute in root.attrib:\n+                del root.attrib[attribute]\n+\n+        # Note: after a standard edition, the tail *must not* be replaced\n+        if replace_tail:\n+            root.tail = replacement.tail\n+        # replace all children\n+        del root[:]\n+        for child in replacement:\n+            root.append(copy.deepcopy(child))\n+\n+        return arch\n+\n+    @api.model\n+    def to_field_ref(self, el):\n+        # filter out meta-information inserted in the document\n+        attributes = {k: v for k, v in el.attrib.items()\n+                           if not k.startswith('data-oe-')}\n+        attributes['t-field'] = el.get('data-oe-expression')\n+\n+        out = html.html_parser.makeelement(el.tag, attrib=attributes)\n+        out.tail = el.tail\n+        return out\n+\n+    @api.model\n+    def to_empty_oe_structure(self, el):\n+        out = html.html_parser.makeelement(el.tag, attrib=el.attrib)\n+        out.tail = el.tail\n+        return out\n+\n     @api.model\n     def _save_oe_structure_hook(self):\n-        res = super()._save_oe_structure_hook()\n+        res = {}\n         res['website_id'] = self.env['website'].get_current_website().id\n         return res\n \n@@ -482,9 +732,15 @@ def _set_noupdate(self):\n         In that case, we don't want to flag the generic view as noupdate.\n         '''\n         if not self.env.context.get('website_id'):\n-            super()._set_noupdate()\n+            self.sudo().mapped('model_data_id').write({'noupdate': True})\n \n     def save(self, value, xpath=None):\n+        \"\"\" Update a view section. The view section may embed fields to write\n+\n+        Note that `self` record might not exist when saving an embed field\n+\n+        :param str xpath: valid xpath to the tag to replace\n+        \"\"\"\n         self.ensure_one()\n         current_website = self.env['website'].get_current_website()\n         # xpath condition is important to be sure we are editing a view and not\n@@ -500,13 +756,40 @@ def save(self, value, xpath=None):\n             ], limit=1)\n             if website_specific_view:\n                 self = website_specific_view\n-        super().save(value, xpath=xpath)\n+        arch_section = html.fromstring(value)\n+\n+        if xpath is None:\n+            # value is an embedded field on its own, not a view section\n+            self.save_embedded_field(arch_section)\n+            return\n+\n+        for el in self.extract_embedded_fields(arch_section):\n+            self.save_embedded_field(el)\n+\n+            # transform embedded field back to t-field\n+            el.getparent().replace(el, self.to_field_ref(el))\n+\n+        for el in self.extract_oe_structures(arch_section):\n+            if self.save_oe_structure(el):\n+                # empty oe_structure in parent view\n+                empty = self.to_empty_oe_structure(el)\n+                if el == arch_section:\n+                    arch_section = empty\n+                else:\n+                    el.getparent().replace(el, empty)\n+\n+        new_arch = self.replace_arch_section(xpath, arch_section)\n+        old_arch = etree.fromstring(self.arch.encode('utf-8'))\n+        if not self._are_archs_equal(old_arch, new_arch):\n+            self._set_noupdate()\n+            self.write({'arch': etree.tostring(new_arch, encoding='unicode')})\n+            self._copy_custom_snippet_translations(self, 'arch_db')\n \n     @api.model\n     def _get_allowed_root_attrs(self):\n         # Related to these options:\n         # background-video, background-shapes, parallax, visibility\n-        return super()._get_allowed_root_attrs() + [\n+        return ['style', 'class', 'target', 'href'] + [\n             'data-bg-video-src', 'data-shape', 'data-scroll-background-ratio',\n             'data-visibility', 'data-visibility-id', 'data-visibility-selectors',\n         ] + ["
+      },
+      {
+        "sha": "fba26624e9f4084e3c4e03a87c424ecc19d6047a",
+        "filename": "addons/website/static/src/builder/plugins/save_translation_plugin.js",
+        "status": "modified",
+        "additions": 2,
+        "deletions": 2,
+        "changes": 4,
+        "blob_url": "https://github.com/odoo/odoo/blob/d957f6965384ab66557c9622a9f7cd6a4f06dfe9/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fplugins%2Fsave_translation_plugin.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/d957f6965384ab66557c9622a9f7cd6a4f06dfe9/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fplugins%2Fsave_translation_plugin.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fplugins%2Fsave_translation_plugin.js?ref=d957f6965384ab66557c9622a9f7cd6a4f06dfe9",
+        "patch": "@@ -4,7 +4,7 @@ import { rpc } from \"@web/core/network/rpc\";\n \n export class SaveTranslationPlugin extends Plugin {\n     static id = \"saveTranslation\";\n-    static dependencies = [\"savePlugin\"];\n+    static dependencies = [\"websiteSavePlugin\"];\n \n     resources = {\n         save_elements_overrides: withSequence(20, this.saveTranslationElements.bind(this)),\n@@ -32,7 +32,7 @@ export class SaveTranslationPlugin extends Plugin {\n                 translations,\n             });\n         }\n-        await this.dependencies.savePlugin.saveView(els[0], false);\n+        await this.dependencies.websiteSavePlugin.saveView(els[0], false);\n         return true;\n     }\n "
+      },
+      {
+        "sha": "0915470350e7135e4781d064667426d7cccffacc",
+        "filename": "addons/website/static/src/builder/plugins/website_save_plugin.js",
+        "status": "added",
+        "additions": 44,
+        "deletions": 0,
+        "changes": 44,
+        "blob_url": "https://github.com/odoo/odoo/blob/d957f6965384ab66557c9622a9f7cd6a4f06dfe9/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fplugins%2Fwebsite_save_plugin.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/d957f6965384ab66557c9622a9f7cd6a4f06dfe9/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fplugins%2Fwebsite_save_plugin.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fplugins%2Fwebsite_save_plugin.js?ref=d957f6965384ab66557c9622a9f7cd6a4f06dfe9",
+        "patch": "@@ -0,0 +1,44 @@\n+import { escapeTextNodes } from \"@html_builder/utils/escaping\";\n+import { Plugin } from \"@html_editor/plugin\";\n+import { registry } from \"@web/core/registry\";\n+\n+export class WebsiteSavePlugin extends Plugin {\n+    static id = \"websiteSavePlugin\";\n+    static shared = [\"saveView\"];\n+\n+    resources = {\n+        save_element_handlers: this.saveView.bind(this),\n+    };\n+\n+    /**\n+     * Saves one (dirty) element of the page.\n+     *\n+     * @param {HTMLElement} el - the element to save.\n+     */\n+    saveView(el, delayTranslations = true) {\n+        const viewID = Number(el.dataset[\"oeId\"]);\n+        if (!viewID) {\n+            return;\n+        }\n+\n+        let context = {};\n+        if (this.services.website) {\n+            const delay = delayTranslations ? { delay_translations: true } : {};\n+            context = {\n+                website_id: this.services.website.currentWebsite.id,\n+                lang: this.services.website.currentWebsite.metadata.lang,\n+                ...delay,\n+            };\n+        }\n+\n+        escapeTextNodes(el);\n+        return this.services.orm.call(\n+            \"ir.ui.view\",\n+            \"save\",\n+            [viewID, el.outerHTML, (!el.dataset[\"oeExpression\"] && el.dataset[\"oeXpath\"]) || null],\n+            { context }\n+        );\n+    }\n+}\n+\n+registry.category(\"website-plugins\").add(WebsiteSavePlugin.id, WebsiteSavePlugin);"
+      },
+      {
+        "sha": "7037c4cba63a22234ecf8f6181cb402a0776461d",
+        "filename": "addons/website/static/src/builder/website_builder.js",
+        "status": "modified",
+        "additions": 2,
+        "deletions": 0,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/d957f6965384ab66557c9622a9f7cd6a4f06dfe9/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fwebsite_builder.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/d957f6965384ab66557c9622a9f7cd6a4f06dfe9/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fwebsite_builder.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fwebsite_builder.js?ref=d957f6965384ab66557c9622a9f7cd6a4f06dfe9",
+        "patch": "@@ -42,6 +42,7 @@ import { MonetaryFieldPlugin } from \"@html_builder/plugins/monetary_field_plugin\n import { Many2OneOptionPlugin } from \"@html_builder/plugins/many2one_option_plugin\";\n import { CustomizeTranslationTab } from \"@website/builder/plugins/translation_tab/customize_translation_tab\";\n import { CustomizeTranslationTabPlugin } from \"./plugins/translation_tab/customize_translation_tab_plugin\";\n+import { WebsiteSavePlugin } from \"@website/builder/plugins/website_save_plugin\";\n \n const TRANSLATION_PLUGINS = [\n     BuilderOptionsTranslationPlugin,\n@@ -71,6 +72,7 @@ const TRANSLATION_PLUGINS = [\n     MonetaryFieldPlugin,\n     Many2OneOptionPlugin,\n     CustomizeTranslationTabPlugin,\n+    WebsiteSavePlugin,\n ];\n \n export class WebsiteBuilder extends Component {"
+      },
+      {
+        "sha": "18c02e1bae120cefe686220caedd790133882ad9",
+        "filename": "addons/website/tests/test_views.py",
+        "status": "modified",
+        "additions": 43,
+        "deletions": 0,
+        "changes": 43,
+        "blob_url": "https://github.com/odoo/odoo/blob/d957f6965384ab66557c9622a9f7cd6a4f06dfe9/addons%2Fwebsite%2Ftests%2Ftest_views.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/d957f6965384ab66557c9622a9f7cd6a4f06dfe9/addons%2Fwebsite%2Ftests%2Ftest_views.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Ftests%2Ftest_views.py?ref=d957f6965384ab66557c9622a9f7cd6a4f06dfe9",
+        "patch": "@@ -407,6 +407,49 @@ def test_save_escaped_text(self):\n             'text node characters wrongly unescaped when rendering'\n         )\n \n+    def test_oe_structure_as_inherited_view(self):\n+        View = self.env['ir.ui.view']\n+        View.create({\n+            'name': 'Test View 1',\n+            'type': 'qweb',\n+            'arch': '<div>Hello World</div>',\n+            'key': 'website.test_first_view',\n+        })\n+        second_view = View.create({\n+            'name': 'Test View 2',\n+            'type': 'qweb',\n+            'arch': '<div><t t-call=\"website.test_first_view\"/></div>',\n+            'key': 'website.test_second_view',\n+        })\n+\n+        base = View.create({\n+            'name': 'Test View oe_structure',\n+            'type': 'qweb',\n+            'arch': \"\"\"<xpath expr='//t[@t-call=\"website.test_first_view\"]' position='after'>\n+                        <div class=\"oe_structure\" id='oe_structure_test_view_oe_structure'/>\n+                    </xpath>\"\"\",\n+            'key': 'website.oe_structure_view',\n+            'inherit_id': second_view.id\n+        })\n+\n+        # check view mode\n+        self.assertEqual(base.mode, 'extension')\n+\n+        # update content of the oe_structure\n+        value = '''<div class=\"oe_structure\" id=\"oe_structure_test_view_oe_structure\" data-oe-id=\"%s\"\n+                         data-oe-xpath=\"/div\" data-oe-model=\"ir.ui.view\" data-oe-field=\"arch\">\n+                        <p>Hello World!</p>\n+                   </div>''' % base.id\n+\n+        base.with_context(website_id=1).save(value=value, xpath='/xpath/div')\n+\n+        self.assertEqual(len(base.with_context(website_id=1).inherit_children_ids), 1)\n+        self.assertEqual(base.with_context(website_id=1).inherit_children_ids.mode, 'extension')\n+        self.assertIn(\n+            '<p>Hello World!</p>',\n+            base.with_context(website_id=1).inherit_children_ids.get_combined_arch(),\n+        )\n+\n     def test_save_oe_structure_with_attr(self):\n         \"\"\" Test saving oe_structure with attributes \"\"\"\n         view = self.env['ir.ui.view'].create({"
+      }
+    ]
+  },
+  {
+    "sha": "65f677be1d4450a36929b9f9dbd8c17e9a34e3e3",
+    "node_id": "C_kwDOAS1I7NoAKDY1ZjY3N2JlMWQ0NDUwYTM2OTI5YjlmOWRiZDhjMTdlOWEzNGUzZTM",
+    "commit": {
+      "author": {
+        "name": "chdh-odoo",
+        "email": "chdh@odoo.com",
+        "date": "2025-10-15T05:43:56Z"
+      },
+      "committer": {
+        "name": "chdh-odoo",
+        "email": "chdh@odoo.com",
+        "date": "2025-10-22T13:00:35Z"
+      },
+      "message": "[IMP] website: update about us footer using gpt\n\nThe existing \"About Us\" footer templates are static. We integrated\nGPT-generated text to update the footer automatically when the user\ncomes from the configurator flow.\n\nKey changes:\n1. We use the `_process_snippet` method to retrieve text(placeholders)\nfrom the template.\n2. These placeholders are passed to GPT, which generates AI-generated\ntext.\n3. The `_update_snippet_content` method replaces the existing text with\nthe AI-generated text.\n4. Finally, we update the `arch_db` view with the modified content.\n\nHere, while updating the footer content, we first check if a\nwebsite-specific view exists. If it does, we choose that arch to update\notherwise, we fall back to the generic view.\nThis is necessary because, in earlier steps, we may have already created\nor modified website-specific footer views (for example, when updating\nthe footer links for certain templates).\n\nThis commit ensures that the footer content is modified when the user\ncomes from the configurator flow.\n\ntask-4484445\n\ncloses odoo/odoo#199786\n\nSigned-off-by: Benoit Socias (bso) <bso@odoo.com>",
+      "tree": {
+        "sha": "078a0d4fcd55ea256555c41d5c3bfcc9dc6e72ea",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/078a0d4fcd55ea256555c41d5c3bfcc9dc6e72ea"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/65f677be1d4450a36929b9f9dbd8c17e9a34e3e3",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/65f677be1d4450a36929b9f9dbd8c17e9a34e3e3",
+    "html_url": "https://github.com/odoo/odoo/commit/65f677be1d4450a36929b9f9dbd8c17e9a34e3e3",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/65f677be1d4450a36929b9f9dbd8c17e9a34e3e3/comments",
+    "author": {
+      "login": "chdh-odoo",
+      "id": 190337672,
+      "node_id": "U_kgDOC1hSiA",
+      "avatar_url": "https://avatars.githubusercontent.com/u/190337672?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/chdh-odoo",
+      "html_url": "https://github.com/chdh-odoo",
+      "followers_url": "https://api.github.com/users/chdh-odoo/followers",
+      "following_url": "https://api.github.com/users/chdh-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/chdh-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/chdh-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/chdh-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/chdh-odoo/orgs",
+      "repos_url": "https://api.github.com/users/chdh-odoo/repos",
+      "events_url": "https://api.github.com/users/chdh-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/chdh-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "chdh-odoo",
+      "id": 190337672,
+      "node_id": "U_kgDOC1hSiA",
+      "avatar_url": "https://avatars.githubusercontent.com/u/190337672?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/chdh-odoo",
+      "html_url": "https://github.com/chdh-odoo",
+      "followers_url": "https://api.github.com/users/chdh-odoo/followers",
+      "following_url": "https://api.github.com/users/chdh-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/chdh-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/chdh-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/chdh-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/chdh-odoo/orgs",
+      "repos_url": "https://api.github.com/users/chdh-odoo/repos",
+      "events_url": "https://api.github.com/users/chdh-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/chdh-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "d957f6965384ab66557c9622a9f7cd6a4f06dfe9",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/d957f6965384ab66557c9622a9f7cd6a4f06dfe9",
+        "html_url": "https://github.com/odoo/odoo/commit/d957f6965384ab66557c9622a9f7cd6a4f06dfe9"
+      }
+    ],
+    "stats": {
+      "total": 26,
+      "additions": 24,
+      "deletions": 2
+    },
+    "files": [
+      {
+        "sha": "86f1c5c0dea6f9c956ce120ab5a5ffdebce8e516",
+        "filename": "addons/website/models/website.py",
+        "status": "modified",
+        "additions": 24,
+        "deletions": 2,
+        "changes": 26,
+        "blob_url": "https://github.com/odoo/odoo/blob/65f677be1d4450a36929b9f9dbd8c17e9a34e3e3/addons%2Fwebsite%2Fmodels%2Fwebsite.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/65f677be1d4450a36929b9f9dbd8c17e9a34e3e3/addons%2Fwebsite%2Fmodels%2Fwebsite.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fmodels%2Fwebsite.py?ref=65f677be1d4450a36929b9f9dbd8c17e9a34e3e3",
+        "patch": "@@ -851,9 +851,10 @@ def configurator_apply(self, **kwargs):\n         # through module overrides of `configurator_get_footer_links`.\n         footer_links = website.configurator_get_footer_links()\n         footer_ids = [\n-            'website.template_footer_contact',\n+            'website.template_footer_contact', 'website.template_footer_headline',\n             'website.footer_custom', 'website.template_footer_links',\n             'website.template_footer_minimalist', 'website.template_footer_mega', 'website.template_footer_mega_columns', 'website.template_footer_mega_links',\n+            'website.template_footer_mega_cards', 'website.template_footer_descriptive', 'website.template_footer_centered', 'website.template_footer_call_to_action',\n         ]\n         for footer_id in footer_ids:\n             view_id = self.env['website'].viewref(footer_id)\n@@ -870,7 +871,6 @@ def configurator_apply(self, **kwargs):\n                 else:\n                     el = arch_string.xpath(\"//t[@t-set='configurator_footer_links']\")\n                     if not el:\n-                        logger.warning(\"No 'configurator_footer_links' found in view %s\", footer_id)\n                         continue\n                     el[0].attrib['t-value'] = json.dumps(footer_links)\n                     view_id.with_context(website_id=website.id).write({'arch_db': etree.tostring(arch_string)})\n@@ -910,6 +910,14 @@ def configurator_apply(self, **kwargs):\n                 generated_content.update(snippet_generated_content)\n                 translated_content.update(snippet_translated_content)\n \n+        # Extract placeholders from footers\n+        for footer_id in footer_ids:\n+            view_id = self.env['website'].viewref(footer_id, raise_if_not_found=False)\n+            if view_id and view_id.arch_db:\n+                html_text_processor, placeholders = html_text_processor._process_snippet(view_id.arch_db, view_id.arch_db)\n+                for placeholder in placeholders:\n+                    generated_content[placeholder] = ''\n+\n         translated_ratio = html_text_processor._calculate_translation_ratio(generated_content, translated_content)\n         if translated_ratio > 0.8:\n             try:\n@@ -987,6 +995,20 @@ def configurator_apply(self, **kwargs):\n                 'website_id': website.id,\n             })\n \n+        # Configure the footers\n+        for key in footer_ids:\n+            generic_view = self.env['website'].viewref(key)\n+            current_website_footer_view = self.env['ir.ui.view'].with_context(active_test=False).search(\n+                [('key', '=', key), ('website_id', '=', website.id)], limit=1\n+            )\n+            # Use the website-specific view if exists, otherwise use the generic\n+            # view\n+            view_to_update = current_website_footer_view or generic_view\n+            if generic_view and view_to_update:\n+                el = html_text_processor._update_snippet_content(generated_content, key, view_to_update.arch_db)\n+                updated_view = etree.tostring(el, encoding='unicode')\n+                generic_view.with_context(website_id=website.id).write({'arch_db': updated_view})\n+\n         # Configure the images\n         images = custom_resources.get('images', {})\n         names = self.env['ir.model.data'].search(["
+      }
+    ]
+  },
+  {
+    "sha": "82e927a5ea994d148d859fd1ce4e458f72e2cb1a",
+    "node_id": "C_kwDOAS1I7NoAKDgyZTkyN2E1ZWE5OTRkMTQ4ZDg1OWZkMWNlNGU0NThmNzJlMmNiMWE",
+    "commit": {
+      "author": {
+        "name": "Nicolas Lempereur",
+        "email": "nle@odoo.com",
+        "date": "2025-10-15T16:48:50Z"
+      },
+      "committer": {
+        "name": "Nicolas Lempereur",
+        "email": "nle@odoo.com",
+        "date": "2025-10-22T14:54:44Z"
+      },
+      "message": "[FIX] website: configurator dropdown working on iOS safari\n\nScenario:\n\n- go to /website/configurator on safari iOS (ipad, iphone, \u2026)\n- configure the website\n\nResult: the dropdown are not selecting a value\n\nCause: 7a291d59909b2ee57111ddec35a20a2302291f29 fixed the issue on\ndesktop safari by using pointerdown and pointerup handler, and handling\nthe dropdown hiding in the pointerup. This work since events happen in\norder:\n\npointerdown -> focusout -> pointerup -> focusin\n\nBut on iOS safari the order is:\n\npointerdown -> pointerup -> focusout -> focusin\n\nthat is not taken into account by the fix.\n\nFix: change the safari fix to close the dropdown on a focusin on another\nelement following a focusout of a dropdown.\n\nopw-5129288\n\ncloses odoo/odoo#232662\n\nX-original-commit: 7c2f1eeb372e28b70555dab61a3df773527a49a9\nSigned-off-by: Robin Lejeune (role) <role@odoo.com>",
+      "tree": {
+        "sha": "a71910827c2fb614e0cb6b3475c328ab2ead39b7",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/a71910827c2fb614e0cb6b3475c328ab2ead39b7"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/82e927a5ea994d148d859fd1ce4e458f72e2cb1a",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/82e927a5ea994d148d859fd1ce4e458f72e2cb1a",
+    "html_url": "https://github.com/odoo/odoo/commit/82e927a5ea994d148d859fd1ce4e458f72e2cb1a",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/82e927a5ea994d148d859fd1ce4e458f72e2cb1a/comments",
+    "author": {
+      "login": "nle-odoo",
+      "id": 9977887,
+      "node_id": "MDQ6VXNlcjk5Nzc4ODc=",
+      "avatar_url": "https://avatars.githubusercontent.com/u/9977887?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/nle-odoo",
+      "html_url": "https://github.com/nle-odoo",
+      "followers_url": "https://api.github.com/users/nle-odoo/followers",
+      "following_url": "https://api.github.com/users/nle-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/nle-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/nle-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/nle-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/nle-odoo/orgs",
+      "repos_url": "https://api.github.com/users/nle-odoo/repos",
+      "events_url": "https://api.github.com/users/nle-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/nle-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "nle-odoo",
+      "id": 9977887,
+      "node_id": "MDQ6VXNlcjk5Nzc4ODc=",
+      "avatar_url": "https://avatars.githubusercontent.com/u/9977887?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/nle-odoo",
+      "html_url": "https://github.com/nle-odoo",
+      "followers_url": "https://api.github.com/users/nle-odoo/followers",
+      "following_url": "https://api.github.com/users/nle-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/nle-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/nle-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/nle-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/nle-odoo/orgs",
+      "repos_url": "https://api.github.com/users/nle-odoo/repos",
+      "events_url": "https://api.github.com/users/nle-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/nle-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "9f7990f832e61f7b03b0a902b6b0434b164b3854",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/9f7990f832e61f7b03b0a902b6b0434b164b3854",
+        "html_url": "https://github.com/odoo/odoo/commit/9f7990f832e61f7b03b0a902b6b0434b164b3854"
+      }
+    ],
+    "stats": {
+      "total": 46,
+      "additions": 19,
+      "deletions": 27
+    },
+    "files": [
+      {
+        "sha": "467901660e7a97db50d36126c9f2ae70132430f6",
+        "filename": "addons/website/static/src/client_actions/configurator/configurator.js",
+        "status": "modified",
+        "additions": 15,
+        "deletions": 20,
+        "changes": 35,
+        "blob_url": "https://github.com/odoo/odoo/blob/82e927a5ea994d148d859fd1ce4e458f72e2cb1a/addons%2Fwebsite%2Fstatic%2Fsrc%2Fclient_actions%2Fconfigurator%2Fconfigurator.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/82e927a5ea994d148d859fd1ce4e458f72e2cb1a/addons%2Fwebsite%2Fstatic%2Fsrc%2Fclient_actions%2Fconfigurator%2Fconfigurator.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fclient_actions%2Fconfigurator%2Fconfigurator.js?ref=82e927a5ea994d148d859fd1ce4e458f72e2cb1a",
+        "patch": "@@ -187,7 +187,7 @@ export class DescriptionScreen extends Component {\n             }\n         }, () => [this.state.selectedType, this.state.selectedIndustry]);\n \n-        this.dropdownSafariHack = false;\n+        this.safariHackFocusedOutDropdown = null;\n     }\n \n     onMounted() {\n@@ -359,37 +359,32 @@ export class DescriptionScreen extends Component {\n             this.props.navigate(ROUTES.paletteSelectionScreen);\n         }\n     }\n+    onConfiguratorScreenFocusin(ev) {\n+        // On safari, hide the previously focused out dropdown if focusin is\n+        // outside of it\n+        if (isBrowserSafari() && this.safariHackFocusedOutDropdown) {\n+            if (ev.target.closest(\".dropdown\") !== this.safariHackFocusedOutDropdown) {\n+                window.Dropdown.getOrCreateInstance(this.safariHackFocusedOutDropdown).hide();\n+            }\n+            this.safariHackFocusedOutDropdown = null;\n+        }\n+    }\n     /**\n      * Hide the dropdown once the focus isn't contained within it anymore.\n      *\n      * @param {FocusEvent} ev\n      */\n     onDropdownFocusout(ev) {\n-        if (this.dropdownSafariHack) {\n+        // On safari, we are missing relatedTarget because we can't focus on a\n+        // button, so we delay dropdown hiding to focusin of next element\n+        if (isBrowserSafari()) {\n+            this.safariHackFocusedOutDropdown = ev.currentTarget;\n             return;\n         }\n         if (ev.relatedTarget?.closest(\".dropdown\") !== ev.currentTarget) {\n             window.Dropdown.getOrCreateInstance(ev.currentTarget).hide();\n         }\n     }\n-    // Because of focus problems with safari on buttons, we need to block the focusout\n-    // until the pointer is up.\n-    onDropdownPointerDown() {\n-        if (isBrowserSafari()) {\n-            this.dropdownSafariHack = true;\n-        }\n-    }\n-    onDropdownPointerUp(ev) {\n-        if (!isBrowserSafari()) {\n-            return;\n-        }\n-        const dropdown = ev.currentTarget;\n-        this.dropdownSafariHack = false;\n-        const active = document.activeElement;\n-        if (!active || !dropdown.contains(active)) {\n-            window.Dropdown.getOrCreateInstance(dropdown).hide();\n-        }\n-    }\n \n     onAutocompleteInput({ inputValue }) {\n         if (!inputValue) {"
+      },
+      {
+        "sha": "e0a34586e4d3b87d536bb446d22307b073ccc331",
+        "filename": "addons/website/static/src/client_actions/configurator/configurator.xml",
+        "status": "modified",
+        "additions": 4,
+        "deletions": 7,
+        "changes": 11,
+        "blob_url": "https://github.com/odoo/odoo/blob/82e927a5ea994d148d859fd1ce4e458f72e2cb1a/addons%2Fwebsite%2Fstatic%2Fsrc%2Fclient_actions%2Fconfigurator%2Fconfigurator.xml",
+        "raw_url": "https://github.com/odoo/odoo/raw/82e927a5ea994d148d859fd1ce4e458f72e2cb1a/addons%2Fwebsite%2Fstatic%2Fsrc%2Fclient_actions%2Fconfigurator%2Fconfigurator.xml",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fclient_actions%2Fconfigurator%2Fconfigurator.xml?ref=82e927a5ea994d148d859fd1ce4e458f72e2cb1a",
+        "patch": "@@ -24,15 +24,14 @@\n </t>\n \n <t t-name=\"website.Configurator.DescriptionScreen\">\n-    <div class=\"o_configurator_screen h-100 d-flex flex-column o_description_screen\">\n+    <div class=\"o_configurator_screen h-100 d-flex flex-column o_description_screen\"\n+         t-on-focusin=\"onConfiguratorScreenFocusin\">\n         <div class=\"o_configurator_screen_content d-flex h-100 flex-grow-1\">\n             <div class=\"container align-self-center\">\n                 <div class=\"o_configurator_typing_text d-inline d-md-block mb-md-2 mb-lg-4 o_configurator_show\">\n                     <span>I want </span>\n                     <div t-attf-class=\"dropdown o_configurator_type_dd d-inline-block {{state.selectedType ? 'o_step_completed' : 'o_step_todo show'}}\"\n-                         t-on-focusout=\"onDropdownFocusout\"\n-                         t-on-pointerdown=\"onDropdownPointerDown\"\n-                         t-on-pointerup=\"onDropdownPointerUp\">\n+                         t-on-focusout=\"onDropdownFocusout\">\n                         <button id=\"selectTypeToggle\"\n                                 class=\"o_btn_reset w-100 px-2\"\n                                 data-bs-toggle=\"dropdown\"\n@@ -85,9 +84,7 @@\n                 <div t-if=\"state.selectedType and state.selectedIndustry\" class=\"o_configurator_typing_text d-inline d-md-block mb-md-2 mb-lg-4 o_configurator_show\">\n                     <span>with the main objective to </span>\n                     <div t-attf-class=\"dropdown d-inline-block o_configurator_purpose_dd {{state.selectedPurpose ? 'o_step_completed' : 'o_step_todo'}}\"\n-                         t-on-focusout=\"onDropdownFocusout\"\n-                         t-on-pointerdown=\"onDropdownPointerDown\"\n-                         t-on-pointerup=\"onDropdownPointerUp\">\n+                         t-on-focusout=\"onDropdownFocusout\">\n                         <button id=\"selectPurposeToggle\"\n                                 class=\"o_btn_reset w-100 px-2\"\n                                 data-bs-toggle=\"dropdown\""
+      }
+    ]
+  },
+  {
+    "sha": "3071ce47799648ab90f3e4e0d4723dc13870356c",
+    "node_id": "C_kwDOAS1I7NoAKDMwNzFjZTQ3Nzk5NjQ4YWI5MGYzZTRlMGQ0NzIzZGMxMzg3MDM1NmM",
+    "commit": {
+      "author": {
+        "name": "Chrysanthe (chgo)",
+        "email": "chgo@odoo.com",
+        "date": "2025-07-01T06:09:39Z"
+      },
+      "committer": {
+        "name": "Chrysanthe (chgo)",
+        "email": "chgo@odoo.com",
+        "date": "2025-10-22T14:54:48Z"
+      },
+      "message": "[FIX] website: prevent `.o_tag` from overriding `.badge` font size\n\nPrior to Commit[1], the front-end badges using `.badge.o_tag` were\nreceiving a `12px` font size, which came from a rule defined in portal.\nThis looked fine, although odd, since a style from portal was affecting\nthe entire front end.\n\nAfter Commit[1], this rule no longer exists, meaning that `.o_tag` now\nfalls back to `0.875rem` (14px by default), while standard badges use a\ndefault font size of `0.75em` (12px by default)\n\nSince using `.badge.o_tag` never allowed overriding the `font-size` value,\nwe fixed the issue by assigning the `--badge-font-size` CSS variable\ndirectly to the badge definition, ensuring the correct visual result.\n\n[1]: https://github.com/odoo/odoo/commit/8f8a370a84d136f3d2316eb1a55c7168b7ae6ccf#diff-23677f06a9aaf2e3395e957cfb9580ce6fcc9aba2635b560fe8f15fa27707313L29\n\ntask-4900376\n\ncloses odoo/odoo#232667\n\nX-original-commit: 2348c3fc300cec30d03e89e47a8e100fce61c856\nSigned-off-by: Outagant Mehdi (mou) <mou@odoo.com>\nSigned-off-by: Chrysanthe Gomr\u00e9e (chgo) <chgo@odoo.com>",
+      "tree": {
+        "sha": "0d6123072ffc6ee1cc45cf87fc68b67368915f79",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/0d6123072ffc6ee1cc45cf87fc68b67368915f79"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/3071ce47799648ab90f3e4e0d4723dc13870356c",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/3071ce47799648ab90f3e4e0d4723dc13870356c",
+    "html_url": "https://github.com/odoo/odoo/commit/3071ce47799648ab90f3e4e0d4723dc13870356c",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/3071ce47799648ab90f3e4e0d4723dc13870356c/comments",
+    "author": {
+      "login": "chgo-odoo",
+      "id": 128030743,
+      "node_id": "U_kgDOB6GYFw",
+      "avatar_url": "https://avatars.githubusercontent.com/u/128030743?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/chgo-odoo",
+      "html_url": "https://github.com/chgo-odoo",
+      "followers_url": "https://api.github.com/users/chgo-odoo/followers",
+      "following_url": "https://api.github.com/users/chgo-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/chgo-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/chgo-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/chgo-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/chgo-odoo/orgs",
+      "repos_url": "https://api.github.com/users/chgo-odoo/repos",
+      "events_url": "https://api.github.com/users/chgo-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/chgo-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "chgo-odoo",
+      "id": 128030743,
+      "node_id": "U_kgDOB6GYFw",
+      "avatar_url": "https://avatars.githubusercontent.com/u/128030743?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/chgo-odoo",
+      "html_url": "https://github.com/chgo-odoo",
+      "followers_url": "https://api.github.com/users/chgo-odoo/followers",
+      "following_url": "https://api.github.com/users/chgo-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/chgo-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/chgo-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/chgo-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/chgo-odoo/orgs",
+      "repos_url": "https://api.github.com/users/chgo-odoo/repos",
+      "events_url": "https://api.github.com/users/chgo-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/chgo-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "b63423b65fd14225ad5bed53261a53999b59b7a9",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/b63423b65fd14225ad5bed53261a53999b59b7a9",
+        "html_url": "https://github.com/odoo/odoo/commit/b63423b65fd14225ad5bed53261a53999b59b7a9"
+      }
+    ],
+    "stats": {
+      "total": 1,
+      "additions": 1,
+      "deletions": 0
+    },
+    "files": [
+      {
+        "sha": "7c36360e2e4b7a119198d92e50cdd8b62b5d1dd3",
+        "filename": "addons/website/static/src/scss/website.scss",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 0,
+        "changes": 1,
+        "blob_url": "https://github.com/odoo/odoo/blob/3071ce47799648ab90f3e4e0d4723dc13870356c/addons%2Fwebsite%2Fstatic%2Fsrc%2Fscss%2Fwebsite.scss",
+        "raw_url": "https://github.com/odoo/odoo/raw/3071ce47799648ab90f3e4e0d4723dc13870356c/addons%2Fwebsite%2Fstatic%2Fsrc%2Fscss%2Fwebsite.scss",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fscss%2Fwebsite.scss?ref=3071ce47799648ab90f3e4e0d4723dc13870356c",
+        "patch": "@@ -729,6 +729,7 @@ font[class*='bg-'] {\n     background: var(--badge-bg, var(--background-color)) !important;\n     color: var(--badge-color, var(--color)) !important;\n     border: $border-width solid var(--badge-border-color) !important;\n+    font-size: var(--badge-font-size);\n \n     // Similarly to list-group-item-x and alert-* classes, override text-bg-*\n     // classes behavior when used on badges."
+      }
+    ]
+  },
+  {
+    "sha": "708b336fba8abed927843ea8843eacc6e4551555",
+    "node_id": "C_kwDOAS1I7NoAKDcwOGIzMzZmYmE4YWJlZDkyNzg0M2VhODg0M2VhY2M2ZTQ1NTE1NTU",
+    "commit": {
+      "author": {
+        "name": "Gorash",
+        "email": "chm@odoo.com",
+        "date": "2025-10-15T14:50:45Z"
+      },
+      "committer": {
+        "name": "Raphael Collet",
+        "email": "rco@odoo.com",
+        "date": "2025-10-22T18:18:38Z"
+      },
+      "message": "[FIX] test_website_modules: Adjust performance tests for /shop (frontend)\n\nThe performance tests for the /shop page were adjusted to account for\nvariations in the number of SQL queries caused by:\n- Product configurations (taxes, pricelists) from demo data.\n- The installation of specific modules (addons) (Community or Enterprise).\n\nTo prevent unjustified test failures, necessary dependencies were added\nand the expected query count is now conditional.\n\nThe main objective is to ensure that the number of queries does not\nincrease over time, as any rise negatively impacts the loading time of\nthe /shop page.\n\nThe logging performed by the website performance tests has been enhanced\nto quickly provide the difference (diff) in the query count, which\nfacilitates debugging.\n\ncloses odoo/odoo#232717\n\nX-original-commit: 0edfccd27381b6032b304d08038c3e7ea6b95b90\nSigned-off-by: Raphael Collet <rco@odoo.com>",
+      "tree": {
+        "sha": "7fa52a6e7ba3edcbad715f5f113fb81fee7df6b6",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/7fa52a6e7ba3edcbad715f5f113fb81fee7df6b6"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/708b336fba8abed927843ea8843eacc6e4551555",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/708b336fba8abed927843ea8843eacc6e4551555",
+    "html_url": "https://github.com/odoo/odoo/commit/708b336fba8abed927843ea8843eacc6e4551555",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/708b336fba8abed927843ea8843eacc6e4551555/comments",
+    "author": {
+      "login": "Gorash",
+      "id": 2284563,
+      "node_id": "MDQ6VXNlcjIyODQ1NjM=",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2284563?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/Gorash",
+      "html_url": "https://github.com/Gorash",
+      "followers_url": "https://api.github.com/users/Gorash/followers",
+      "following_url": "https://api.github.com/users/Gorash/following{/other_user}",
+      "gists_url": "https://api.github.com/users/Gorash/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/Gorash/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/Gorash/subscriptions",
+      "organizations_url": "https://api.github.com/users/Gorash/orgs",
+      "repos_url": "https://api.github.com/users/Gorash/repos",
+      "events_url": "https://api.github.com/users/Gorash/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/Gorash/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "rco-odoo",
+      "id": 7578141,
+      "node_id": "MDQ6VXNlcjc1NzgxNDE=",
+      "avatar_url": "https://avatars.githubusercontent.com/u/7578141?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/rco-odoo",
+      "html_url": "https://github.com/rco-odoo",
+      "followers_url": "https://api.github.com/users/rco-odoo/followers",
+      "following_url": "https://api.github.com/users/rco-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/rco-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/rco-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/rco-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/rco-odoo/orgs",
+      "repos_url": "https://api.github.com/users/rco-odoo/repos",
+      "events_url": "https://api.github.com/users/rco-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/rco-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "884d827c4c3b3183b557b9687f4ae14d3efe4f20",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/884d827c4c3b3183b557b9687f4ae14d3efe4f20",
+        "html_url": "https://github.com/odoo/odoo/commit/884d827c4c3b3183b557b9687f4ae14d3efe4f20"
+      }
+    ],
+    "stats": {
+      "total": 204,
+      "additions": 173,
+      "deletions": 31
+    },
+    "files": [
+      {
+        "sha": "85c7d2d1e4f999a39c6b50df0e7af4abe16dd846",
+        "filename": "addons/test_website_modules/__manifest__.py",
+        "status": "modified",
+        "additions": 2,
+        "deletions": 0,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/708b336fba8abed927843ea8843eacc6e4551555/addons%2Ftest_website_modules%2F__manifest__.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/708b336fba8abed927843ea8843eacc6e4551555/addons%2Ftest_website_modules%2F__manifest__.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Ftest_website_modules%2F__manifest__.py?ref=708b336fba8abed927843ea8843eacc6e4551555",
+        "patch": "@@ -17,6 +17,8 @@\n         'website_slides',\n         'website_livechat',\n         'website_crm_iap_reveal',\n+        'website_sale_comparison',\n+        'website_sale_wishlist',\n     ],\n     'installable': True,\n     'assets': {"
+      },
+      {
+        "sha": "0687f37c9efcd56f401130484fbdd058724e8ddb",
+        "filename": "addons/test_website_modules/tests/test_performance.py",
+        "status": "modified",
+        "additions": 150,
+        "deletions": 28,
+        "changes": 178,
+        "blob_url": "https://github.com/odoo/odoo/blob/708b336fba8abed927843ea8843eacc6e4551555/addons%2Ftest_website_modules%2Ftests%2Ftest_performance.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/708b336fba8abed927843ea8843eacc6e4551555/addons%2Ftest_website_modules%2Ftests%2Ftest_performance.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Ftest_website_modules%2Ftests%2Ftest_performance.py?ref=708b336fba8abed927843ea8843eacc6e4551555",
+        "patch": "@@ -8,6 +8,7 @@\n from PIL import Image\n \n import odoo\n+from odoo.fields import Command\n from odoo.tests import tagged\n \n from odoo.addons.website.tests.test_performance import TestWebsitePerformanceCommon\n@@ -30,6 +31,16 @@ def setUpClass(cls):\n             'url': f'{cls.base_url()}/web/image/website.s_banner_default_image.jpg',\n         })\n \n+        cats = cls.env['product.public.category'].create([{\n+            'name': 'Level 0',\n+        }, {\n+            'name': 'Level 1',\n+        }, {\n+            'name': 'Level 2',\n+        }])\n+        cats[2].parent_id = cats[1].id\n+        cats[1].parent_id = cats[0].id\n+\n         # First image (blue) for the template.\n         color_blue = '#4169E1'\n         name_blue = 'Royal Blue'\n@@ -75,6 +86,7 @@ def setUpClass(cls):\n             'sale_ok': True,\n             'website_published': True,\n             'website_sequence': 1,\n+            'public_categ_ids': [Command.link(cats[2].id)],\n         })\n \n         cls.productB = cls.env['product.product'].create({\n@@ -83,12 +95,14 @@ def setUpClass(cls):\n             'sale_ok': True,\n             'website_published': True,\n             'image_1920': red_image,\n+            'website_sequence': -10,\n         })\n \n         cls.templateC = cls.env['product.template'].create({\n             'name': 'Test Remove Image',\n             'image_1920': blue_image,\n-            'website_sequence': 1,\n+            'website_sequence': -10,\n+            'public_categ_ids': [Command.link(cats[1].id)],\n         })\n         cls.productC = cls.templateC.product_variant_ids[0]\n         cls.productC.write({\n@@ -111,9 +125,21 @@ def setUpClass(cls):\n                 'name': f'Product test {i}',\n                 'list_price': 100,\n                 'sale_ok': True,\n-                'website_published': True,\n                 'image_1920': red_image,\n+                'website_sequence': -9,\n+                'attribute_line_ids': [\n+                    Command.create({\n+                        'attribute_id': cls.product_attribute.id,\n+                        'value_ids': [Command.set(cls.product_attribute.value_ids.ids)],\n+                    }),\n+                ],\n             })\n+            variant = template.product_variant_ids[0]\n+            if i % 5:\n+                variant.website_published = True\n+            if i % 4:\n+                variant.website_sequence = -7\n+\n             images = [{\n                 'name': 'Template image',\n                 'image_1920': blue_image,\n@@ -122,23 +148,47 @@ def setUpClass(cls):\n                 images.append({\n                     'name': 'Variant image',\n                     'image_1920': red_image,\n-                    'product_variant_id': template.product_variant_ids[0].id,\n+                    'product_variant_id': variant.id,\n                 })\n+            cls.env['product.image'].create(images)\n+\n+        fpos = cls.env[\"account.fiscal.position\"].create({\n+            'name': 'Fiscal Position BE',\n+            'country_id': cls.env.ref('base.be').id,\n+            'auto_apply': True,\n+            'sequence': -1,\n+        })\n+        usd = cls.env.ref('base.USD')\n+        cls.env['product.pricelist'].create({\n+            'name': 'Custom pricelist (TEST)',\n+            'currency_id': usd.id,\n+            'sequence': -1,\n+            'item_ids': [(0, 0, {\n+                'base': 'list_price',\n+                'applied_on': '1_product',\n+                'product_tmpl_id': cls.templateC.id,\n+                'price_discount': 20,\n+                'min_quantity': 2,\n+                'compute_price': 'formula',\n+            })],\n+        })\n+        tax_group = cls.env['account.tax.group'].create({'name': 'Test 6%'})\n+        cls.env['account.tax'].create({\n+                'name': \"Test 6%\",\n+                'fiscal_position_ids': fpos,\n+                'amount': 6,\n+                'price_include_override': 'tax_included',\n+                'type_tax_use': 'sale',\n+                'amount_type': 'percent',\n+                'country_id': cls.env.ref('base.us').id,\n+                'tax_group_id': tax_group.id,\n+        })\n \n     def setUp(self):\n         super().setUp()\n         self.session = None\n         self.env['website'].search([]).channel_id = False\n \n-    def test_perf_sql_queries_shop(self):\n-        html = self.url_open('/shop').text\n-        self.assertIn(f'<img src=\"/web/image/product.product/{self.productC.id}/', html)\n-        self.assertIn(f'<img src=\"/web/image/product.template/{self.productA.product_tmpl_id.id}/', html)\n-        self.assertIn(f'<img src=\"/web/image/product.image/{self.product_images.ids[1]}/', html)\n-\n-        # Test in community: 36\n-        self.assertLessEqual(self._get_url_hot_query('/shop'), 37)  # To increase this number you must ask the permission to al\n-\n     def _get_cart_quantity(self):\n         return int(re.search(\n             r'my_cart_quantity.*?>([0-9.]+)</sup>',\n@@ -239,25 +289,97 @@ def _allow_to_use_cache(request):\n         expected_query_count = sum(select_tables_perf.values())\n         self._check_url_hot_query(self.page.url, expected_query_count, select_tables_perf, {})\n \n+    def _get_queries_shop(self):\n+        html = self.url_open('/shop').text\n+        self.assertIn(f'<img src=\"/web/image/product.product/{self.productC.id}/', html)\n+        self.assertIn(f'<img src=\"/web/image/product.template/{self.productA.product_tmpl_id.id}/', html)\n+        self.assertIn(f'<img src=\"/web/image/product.image/{self.product_images.ids[1]}/', html)\n+\n+        query_count = 52  # To increase this number you must ask the permission to al\n+        queries = {\n+            'orm_signaling_registry': 1,\n+            'website': 2,\n+            'res_company': 2,\n+            'product_pricelist': 4,\n+            'product_template': 6,\n+            'product_tag': 1,\n+            'product_public_category': 6,\n+            'product_product': 1,\n+            'product_template_attribute_line': 3,\n+            'res_users': 1,\n+            'res_partner': 2,\n+            'product_category': 1,\n+            'product_pricelist_item': 2,\n+            'account_tax': 1,\n+            'res_currency': 1,\n+            'account_account_tag': 1,\n+            'product_ribbon': 1,\n+            'product_attribute_value': 3,\n+            'product_attribute': 1,\n+            'ir_attachment': 4,\n+            'product_image': 3,\n+            'product_template_attribute_value': 1,\n+            'ir_ui_view': 2,\n+            'website_menu': 1,\n+            'website_page': 1,\n+        }\n+\n+        addons = tuple(self.env.registry._init_modules) + (self.env.context.get('install_module'),)\n+        if 'website_helpdesk' in addons:\n+            query_count += 1\n+            queries['helpdesk_team'] = 1\n+        if 'website_sale_subscription' in addons:\n+            query_count += 1\n+            queries['product_product'] += 1\n+\n+        tax = self.env.ref('account.1_sale_tax_template', raise_if_not_found=False)\n+        if tax and tax.name == '15%':\n+            query_count += 2\n+            queries['account_tax_repartition_line'] = 2\n+\n+        if self._has_demo_data():\n+            query_count += 5\n+            queries['product_template'] += 1\n+            queries['product_product'] += 2\n+            queries['ir_attachment'] += 1\n+            queries['product_ribbon'] += 1\n+        else:\n+            query_count += 3\n+            queries['product_template_attribute_value'] += 3\n+\n+        # To increase the query count you must ask the permission to al\n+        return query_count, queries\n+\n+    def _has_demo_data(self):\n+        return bool(self.env['ir.module.module'].search_count([('demo', '=', True)]))\n+\n+    def test_perf_sql_queries_shop(self):\n+        # To increase the query count you must ask the permission to al\n+        query_count, queries = self._get_queries_shop()\n+\n+        if self._has_demo_data():\n+            query_count += 3\n+            queries['account_tax'] += 1\n+            queries['account_account_tag'] += 2\n+\n+        self.assertEqual(sum(queries.values()), query_count, 'Please learn to count.')\n+        self._check_url_hot_query('/shop', query_count, queries)\n+\n \n @tagged('post_install', '-at_install')\n-class TestWebsiteAllPerformancePostInstall(TestWebsiteAllPerformance):\n+class TestWebsiteAllPerformanceShop(TestWebsiteAllPerformance):\n \n     def test_perf_sql_queries_shop(self):\n-        tax_group = self.env['account.tax.group'].create({'name': 'Tax 15%'})\n-        tax = self.env['account.tax'].create({\n-            'name': 'Tax 15%',\n-            'amount': 15,\n-            'type_tax_use': 'sale',\n-            'tax_group_id': tax_group.id,\n-            'country_id': self.env.company.country_id.id,\n-        })\n-        self.productB.taxes_id = tax\n+        # To increase the query count you must ask the permission to al\n+        query_count, queries = self._get_queries_shop()\n \n-        html = self.url_open('/shop').text\n-        self.assertIn(f'<img src=\"/web/image/product.product/{self.productC.id}/', html)\n-        self.assertIn(f'<img src=\"/web/image/product.template/{self.productA.product_tmpl_id.id}/', html)\n-        self.assertIn(f'<img src=\"/web/image/product.image/{self.product_images.ids[1]}/', html)\n+        query_count += 3\n+        queries['account_tax'] += 1\n+        queries['account_account_tag'] += 2\n+\n+        if self._has_demo_data():\n+            query_count += 1\n+            queries['product_attribute_value'] += 1\n \n-        # Test in community: 45\n-        self.assertLessEqual(self._get_url_hot_query('/shop'), 47)  # To increase this number you must ask the permission to al\n+        self.assertEqual(sum(queries.values()), query_count, 'Please learn to count.')\n+        self._check_url_hot_query('/shop', query_count, queries)"
+      },
+      {
+        "sha": "b1ce4bc635f3d925e5870649d2c62bf3a77e0b89",
+        "filename": "addons/website/tests/test_performance.py",
+        "status": "modified",
+        "additions": 21,
+        "deletions": 3,
+        "changes": 24,
+        "blob_url": "https://github.com/odoo/odoo/blob/708b336fba8abed927843ea8843eacc6e4551555/addons%2Fwebsite%2Ftests%2Ftest_performance.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/708b336fba8abed927843ea8843eacc6e4551555/addons%2Fwebsite%2Ftests%2Ftest_performance.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Ftests%2Ftest_performance.py?ref=708b336fba8abed927843ea8843eacc6e4551555",
+        "patch": "@@ -93,11 +93,29 @@ def _check_url_hot_query(self, url, expected_query_count, select_tables_perf=Non\n                 _logger.warning(\"Query type %s for query %s is not supported by _check_url_hot_query\", query_type, query)\n             log_target.setdefault(table, 0)\n             log_target[table] = log_target[table] + 1\n+\n+        if not select_tables_perf:\n+            select_tables_perf = {}\n+        select = {}\n+        for key in (set(sql_from_tables) | set(select_tables_perf)):\n+            value = sql_from_tables.get(key, 0) - select_tables_perf.get(key, 0)\n+            if value:\n+                select[key] = value\n+\n+        if not insert_tables_perf:\n+            insert_tables_perf = {}\n+        insert = {}\n+        for key in (set(sql_into_tables) | set(insert_tables_perf)):\n+            value = sql_into_tables.get(key, 0) - insert_tables_perf.get(key, 0)\n+            if value:\n+                insert[key] = value\n+\n         if query_count != expected_query_count:\n-            msq = f\"Expected {expected_query_count} queries but {query_count} where ran: {query_separator}{queries}{query_separator}\"\n+            msq = f\"Expected {expected_query_count} queries but {query_count} where ran:\\nDiff of select queries: {select}\\nDiff of insert queries: {insert}{query_separator}{queries}{query_separator}\"\n             self.fail(msq)\n-        self.assertEqual(sql_from_tables, select_tables_perf or {}, f'Select queries does not match: {query_separator}{queries}{query_separator}')\n-        self.assertEqual(sql_into_tables, insert_tables_perf or {}, f'Insert queries does not match: {query_separator}{queries}{query_separator}')\n+\n+        self.assertDictEqual(sql_from_tables, select_tables_perf, f'Select queries does not match: {select}{query_separator}{queries}{query_separator}')\n+        self.assertDictEqual(sql_into_tables, insert_tables_perf, f'Insert queries does not match: {insert}{query_separator}{queries}{query_separator}')\n \n \n @tagged('at_install', '-post_install')  # LEGACY at_install"
+      }
+    ]
+  },
+  {
+    "sha": "7f1ddba17a19cab22f6106ecc6a3624f67101c21",
+    "node_id": "C_kwDOAS1I7NoAKDdmMWRkYmExN2ExOWNhYjIyZjYxMDZlY2M2YTM2MjRmNjcxMDFjMjE",
+    "commit": {
+      "author": {
+        "name": "sben-odoo",
+        "email": "sben@odoo.com",
+        "date": "2025-10-09T13:02:31Z"
+      },
+      "committer": {
+        "name": "sben-odoo",
+        "email": "sben@odoo.com",
+        "date": "2025-10-23T12:07:37Z"
+      },
+      "message": "[FIX] html_builder: prevent image shape selection traceback\n\nSteps to reproduce:\n===================\n1. Drop a snippet having an image with a shape (e.g. \"Intro Pill\",\n\"Images Mosaic\", ...).\n2. Try to change the image shape.\n\u2192 Traceback occurs.\n\nThis issue also happens when clicking on images with shapes that\nwere added in previous versions.\nCause:\n======\nBefore the refactoring, shape URLs started with `web_editor`, but now\n`html_builder` is expected.\nThis mismatch causes the shape to be considered invalid when parsed,\nleading to a traceback.\n\nThe issue was introduced by this PR:\nhttps://github.com/odoo/odoo/pull/222471\n\nSolution:\n=========\nEnsure backward compatibility by allowing shapes using the old\n`web_editor` path to remain functional after the migration to\n`html_builder`.\n\nopw-5149998\n\ncloses odoo/odoo#232811\n\nX-original-commit: 76c2213835dc6acd358305573ecd5fb5b625bc93\nSigned-off-by: Souk\u00e9ina Bojabza (sobo) <sobo@odoo.com>\nSigned-off-by: Saif Allah Ben Khalil (sben) <sben@odoo.com>",
+      "tree": {
+        "sha": "ed4ee557194632ca822f0511e760d50367b91ae0",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/ed4ee557194632ca822f0511e760d50367b91ae0"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/7f1ddba17a19cab22f6106ecc6a3624f67101c21",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/7f1ddba17a19cab22f6106ecc6a3624f67101c21",
+    "html_url": "https://github.com/odoo/odoo/commit/7f1ddba17a19cab22f6106ecc6a3624f67101c21",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/7f1ddba17a19cab22f6106ecc6a3624f67101c21/comments",
+    "author": {
+      "login": "sben-odoo",
+      "id": 208037942,
+      "node_id": "U_kgDODGZoNg",
+      "avatar_url": "https://avatars.githubusercontent.com/u/208037942?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/sben-odoo",
+      "html_url": "https://github.com/sben-odoo",
+      "followers_url": "https://api.github.com/users/sben-odoo/followers",
+      "following_url": "https://api.github.com/users/sben-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/sben-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/sben-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/sben-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/sben-odoo/orgs",
+      "repos_url": "https://api.github.com/users/sben-odoo/repos",
+      "events_url": "https://api.github.com/users/sben-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/sben-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "sben-odoo",
+      "id": 208037942,
+      "node_id": "U_kgDODGZoNg",
+      "avatar_url": "https://avatars.githubusercontent.com/u/208037942?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/sben-odoo",
+      "html_url": "https://github.com/sben-odoo",
+      "followers_url": "https://api.github.com/users/sben-odoo/followers",
+      "following_url": "https://api.github.com/users/sben-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/sben-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/sben-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/sben-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/sben-odoo/orgs",
+      "repos_url": "https://api.github.com/users/sben-odoo/repos",
+      "events_url": "https://api.github.com/users/sben-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/sben-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "02169808e607ec38f28609ce9924d141cb02c204",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/02169808e607ec38f28609ce9924d141cb02c204",
+        "html_url": "https://github.com/odoo/odoo/commit/02169808e607ec38f28609ce9924d141cb02c204"
+      }
+    ],
+    "stats": {
+      "total": 18,
+      "additions": 11,
+      "deletions": 7
+    },
+    "files": [
+      {
+        "sha": "e15c497fa46f41f919ddda52617b1b3c8c5b5d71",
+        "filename": "addons/html_builder/static/src/plugins/image/image_shape_option.js",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 4,
+        "changes": 5,
+        "blob_url": "https://github.com/odoo/odoo/blob/7f1ddba17a19cab22f6106ecc6a3624f67101c21/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fplugins%2Fimage%2Fimage_shape_option.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/7f1ddba17a19cab22f6106ecc6a3624f67101c21/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fplugins%2Fimage%2Fimage_shape_option.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fplugins%2Fimage%2Fimage_shape_option.js?ref=7f1ddba17a19cab22f6106ecc6a3624f67101c21",
+        "patch": "@@ -18,10 +18,7 @@ export class ImageShapeOption extends BaseOptionComponent {\n         this.imageShapeOption = this.env.editor.shared.imageShapeOption;\n         this.toRatio = toRatio;\n         this.state = useDomState((editingElement) => {\n-            let shape = editingElement.dataset.shape;\n-            if (shape) {\n-                shape = shape.replace(\"web_editor\", \"html_builder\");\n-            }\n+            const shape = editingElement.dataset.shape;\n             return {\n                 hasShape: !!shape && !this.imageShapeOption.isTechnicalShape(shape),\n                 shapeLabel: this.imageShapeOption.getShapeLabel(shape),"
+      },
+      {
+        "sha": "1d7232f0b196eb00dca499418bb9e21b86aefb02",
+        "filename": "addons/html_builder/static/src/plugins/image/image_shape_option_plugin.js",
+        "status": "modified",
+        "additions": 10,
+        "deletions": 3,
+        "changes": 13,
+        "blob_url": "https://github.com/odoo/odoo/blob/7f1ddba17a19cab22f6106ecc6a3624f67101c21/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fplugins%2Fimage%2Fimage_shape_option_plugin.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/7f1ddba17a19cab22f6106ecc6a3624f67101c21/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fplugins%2Fimage%2Fimage_shape_option_plugin.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fplugins%2Fimage%2Fimage_shape_option_plugin.js?ref=7f1ddba17a19cab22f6106ecc6a3624f67101c21",
+        "patch": "@@ -61,6 +61,11 @@ export class ImageShapeOptionPlugin extends Plugin {\n     setup() {\n         this.shapeSvgTextCache = {};\n         this.imageShapes = this.makeImageShapes();\n+        // Compatibility with old shapes.\n+        for (const shapeId of Object.keys(this.imageShapes)) {\n+            const oldShapeId = shapeId.replace(\"html_builder\", \"web_editor\");\n+            this.imageShapes[oldShapeId] = this.imageShapes[shapeId];\n+        }\n     }\n     async canHaveHoverEffect(imgEl) {\n         const dataset = Object.assign({}, imgEl.dataset, await loadImageInfo(imgEl));\n@@ -90,13 +95,15 @@ export class ImageShapeOptionPlugin extends Plugin {\n         return isImageSupportedForProcessing(getMimetype(img, dataset));\n     }\n     async getShapeSvgText(shapeName) {\n-        let shapeSvgText = this.shapeSvgTextCache[shapeName];\n+        // Compatibility with old shapes.\n+        const shape = shapeName.replace(\"web_editor\", \"html_builder\");\n+        let shapeSvgText = this.shapeSvgTextCache[shape];\n         if (shapeSvgText) {\n             return shapeSvgText;\n         }\n-        const shapeURL = getShapeURL(shapeName);\n+        const shapeURL = getShapeURL(shape);\n         shapeSvgText = await (await fetch(shapeURL)).text();\n-        this.shapeSvgTextCache[shapeName] = shapeSvgText;\n+        this.shapeSvgTextCache[shape] = shapeSvgText;\n         return shapeSvgText;\n     }\n     async loadShape(img, newData = {}) {"
+      }
+    ]
+  },
+  {
+    "sha": "f4436d4f8400995dcf382107d93cd95d9f625335",
+    "node_id": "C_kwDOAS1I7NoAKGY0NDM2ZDRmODQwMDk5NWRjZjM4MjEwN2Q5M2NkOTVkOWY2MjUzMzU",
+    "commit": {
+      "author": {
+        "name": "Augustin (duau)",
+        "email": "duau@odoo.com",
+        "date": "2025-10-15T15:27:36Z"
+      },
+      "committer": {
+        "name": "Augustin (duau)",
+        "email": "duau@odoo.com",
+        "date": "2025-10-23T21:04:10Z"
+      },
+      "message": "[FIX] html_editor, html_builder: fix shape animation speed option\n\nSteps to reproduce:\n- Drop a snippet\n- Add an animated background shape (e.g. Rainy 05)\n- Use the slider to change the speed\n- Nothing happens\n\nThis commit is adapting `CSS_ANIMATION_RULE_REGEX` as it was too\nrestrictive, the space after the colon is now optional.\n\ntask-5170549\n\ncloses odoo/odoo#232909\n\nX-original-commit: 5215a76567964adb0478f7c1f04248f494709005\nSigned-off-by: Benjamin Vray (bvr) <bvr@odoo.com>\nSigned-off-by: Augustin Dupin (duau) <duau@odoo.com>",
+      "tree": {
+        "sha": "acf5630b4c5e4d0f2eb804d4d0fd4534551cf8d8",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/acf5630b4c5e4d0f2eb804d4d0fd4534551cf8d8"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/f4436d4f8400995dcf382107d93cd95d9f625335",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/f4436d4f8400995dcf382107d93cd95d9f625335",
+    "html_url": "https://github.com/odoo/odoo/commit/f4436d4f8400995dcf382107d93cd95d9f625335",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/f4436d4f8400995dcf382107d93cd95d9f625335/comments",
+    "author": {
+      "login": "duau-odoo",
+      "id": 199088574,
+      "node_id": "U_kgDOC93Zvg",
+      "avatar_url": "https://avatars.githubusercontent.com/u/199088574?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/duau-odoo",
+      "html_url": "https://github.com/duau-odoo",
+      "followers_url": "https://api.github.com/users/duau-odoo/followers",
+      "following_url": "https://api.github.com/users/duau-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/duau-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/duau-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/duau-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/duau-odoo/orgs",
+      "repos_url": "https://api.github.com/users/duau-odoo/repos",
+      "events_url": "https://api.github.com/users/duau-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/duau-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "duau-odoo",
+      "id": 199088574,
+      "node_id": "U_kgDOC93Zvg",
+      "avatar_url": "https://avatars.githubusercontent.com/u/199088574?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/duau-odoo",
+      "html_url": "https://github.com/duau-odoo",
+      "followers_url": "https://api.github.com/users/duau-odoo/followers",
+      "following_url": "https://api.github.com/users/duau-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/duau-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/duau-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/duau-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/duau-odoo/orgs",
+      "repos_url": "https://api.github.com/users/duau-odoo/repos",
+      "events_url": "https://api.github.com/users/duau-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/duau-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "002fb39c43cc355505cfb98dacffc0c4794910fd",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/002fb39c43cc355505cfb98dacffc0c4794910fd",
+        "html_url": "https://github.com/odoo/odoo/commit/002fb39c43cc355505cfb98dacffc0c4794910fd"
+      }
+    ],
+    "stats": {
+      "total": 12,
+      "additions": 6,
+      "deletions": 6
+    },
+    "files": [
+      {
+        "sha": "849d6856bc852161e45824c46db7fd802357f5b3",
+        "filename": "addons/html_builder/static/src/plugins/image/image_shape_option_plugin.js",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/f4436d4f8400995dcf382107d93cd95d9f625335/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fplugins%2Fimage%2Fimage_shape_option_plugin.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/f4436d4f8400995dcf382107d93cd95d9f625335/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fplugins%2Fimage%2Fimage_shape_option_plugin.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fplugins%2Fimage%2Fimage_shape_option_plugin.js?ref=f4436d4f8400995dcf382107d93cd95d9f625335",
+        "patch": "@@ -28,7 +28,7 @@ import { getMimetype } from \"@html_editor/utils/image\";\n // regex patterns in Python are slightly different from those in JavaScript.\n // See : controllers/main.py\n const CSS_ANIMATION_RULE_REGEX =\n-    /(?<declaration>animation(?:-duration)?: .*?)(?<value>(?:\\d+(?:\\.\\d+)?)|(?:\\.\\d+))(?<unit>ms|s)(?<separator>\\s|;|\"|$)/gm;\n+    /(?<declaration>animation(?:-duration)?:\\s*.*?)(?<value>(?:\\d+(?:\\.\\d+)?)|(?:\\.\\d+))(?<unit>ms|s)(?<separator>\\s|;|\"|$)/gm;\n const SVG_DUR_TIMECOUNT_VAL_REGEX =\n     /(?<attribute_name>\\sdur=\"\\s*)(?<value>(?:\\d+(?:\\.\\d+)?)|(?:\\.\\d+))(?<unit>h|min|ms|s)?\\s*\"/gm;\n const CSS_ANIMATION_RATIO_REGEX = /(--animation_ratio: (?<ratio>\\d*(\\.\\d+)?));/m;"
+      },
+      {
+        "sha": "4c61087db327e622b28ab48a8f078932d804768f",
+        "filename": "addons/html_editor/controllers/main.py",
+        "status": "modified",
+        "additions": 5,
+        "deletions": 5,
+        "changes": 10,
+        "blob_url": "https://github.com/odoo/odoo/blob/f4436d4f8400995dcf382107d93cd95d9f625335/addons%2Fhtml_editor%2Fcontrollers%2Fmain.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/f4436d4f8400995dcf382107d93cd95d9f625335/addons%2Fhtml_editor%2Fcontrollers%2Fmain.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_editor%2Fcontrollers%2Fmain.py?ref=f4436d4f8400995dcf382107d93cd95d9f625335",
+        "patch": "@@ -34,10 +34,10 @@\n # regex patterns in Python are slightly different from those in JavaScript.\n \n CSS_ANIMATION_RULE_REGEX = (\n-        r\"(?P<declaration>animation(-duration)?: .*?)\"\n-        + r\"(?P<value>(\\d+(\\.\\d+)?)|(\\.\\d+))\"\n-        + r\"(?P<unit>ms|s)\"\n-        + r\"(?P<separator>\\s|;|\\\"|$)\"\n+        r\"(?P<declaration>animation(-duration)?:\\s*.*?)\"\n+        r\"(?P<value>(\\d+(\\.\\d+)?)|(\\.\\d+))\"\n+        r\"(?P<unit>ms|s)\"\n+        r\"(?P<separator>\\s|;|\\\"|$)\"\n )\n SVG_DUR_TIMECOUNT_VAL_REGEX = (\n         r\"(?P<attribute_name>\\sdur=\\\"\\s*)\"\n@@ -205,7 +205,7 @@ def callback_css_animation_ratio(match):\n             )\n         else:\n             regex = r\"<svg .*>\"\n-            declaration = f\"--animation-ratio: {ratio}\"\n+            declaration = f\"--animation_ratio: {ratio}\"\n             subst = (\"\\\\g<0>\\n\\t<style>\\n\\t\\t:root { \\n\\t\\t\\t\" +\n                      declaration +\n                      \";\\n\\t\\t}\\n\\t</style>\")"
+      }
+    ]
+  },
+  {
+    "sha": "3e9b2fcabeba28e685a748d5f542362284faa317",
+    "node_id": "C_kwDOAS1I7NoAKDNlOWIyZmNhYmViYTI4ZTY4NWE3NDhkNWY1NDIzNjIyODRmYWEzMTc",
+    "commit": {
+      "author": {
+        "name": "Nicolas Lempereur",
+        "email": "nle@odoo.com",
+        "date": "2025-08-20T12:19:03Z"
+      },
+      "committer": {
+        "name": "Nicolas Lempereur",
+        "email": "nle@odoo.com",
+        "date": "2025-10-24T00:10:38Z"
+      },
+      "message": "[FIX] http_routing,website: use request lang for dynamic bundle\n\nScenario to reproduce from 18.0:\n\n- install right-to-left (eg. arabic) language on website\n- open a portal record with chatter (eg. /my/invoices/1)\n- switch to right-to-left language\n- scroll horizontally to the left\n\nResult: there is a huge amount of whitespace scrollable to the left.\n\nCause:\n\nIn 18.0, the chatter has an hidden textarea .o-mail-Composer-fake with\nposition \"left: -10000px; top: -10000px;\".\n\nBut the chatter assets (portal.assets_chatter_style) are called\ndynamically with getBundle which is using the session lang instead of\nthe website lang.\n\nSo the bundle is gotten with the wrong lang and the CSS is not rtlcss'ed\nand this create big whitespace to the left of the page.\n\nFix: set the website request language when getting bundle for the\nfrontend.\n\nNote: this PR also create a TestLangUrlCommon to prevent TestLangUrl\ntests of being run a second time in TestControllerRedirect.\n\nopw-5013485\n\ncloses odoo/odoo#232901\n\nX-original-commit: 3dadb15555b96ad22dfd2799c05415f07b03d027\nSigned-off-by: Quentin Smetz (qsm) <qsm@odoo.com>\nSigned-off-by: Nicolas Lempereur (nle) <nle@odoo.com>",
+      "tree": {
+        "sha": "74354c108511add2579c7ab278dc4b97fb207dd0",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/74354c108511add2579c7ab278dc4b97fb207dd0"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/3e9b2fcabeba28e685a748d5f542362284faa317",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/3e9b2fcabeba28e685a748d5f542362284faa317",
+    "html_url": "https://github.com/odoo/odoo/commit/3e9b2fcabeba28e685a748d5f542362284faa317",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/3e9b2fcabeba28e685a748d5f542362284faa317/comments",
+    "author": {
+      "login": "nle-odoo",
+      "id": 9977887,
+      "node_id": "MDQ6VXNlcjk5Nzc4ODc=",
+      "avatar_url": "https://avatars.githubusercontent.com/u/9977887?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/nle-odoo",
+      "html_url": "https://github.com/nle-odoo",
+      "followers_url": "https://api.github.com/users/nle-odoo/followers",
+      "following_url": "https://api.github.com/users/nle-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/nle-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/nle-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/nle-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/nle-odoo/orgs",
+      "repos_url": "https://api.github.com/users/nle-odoo/repos",
+      "events_url": "https://api.github.com/users/nle-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/nle-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "nle-odoo",
+      "id": 9977887,
+      "node_id": "MDQ6VXNlcjk5Nzc4ODc=",
+      "avatar_url": "https://avatars.githubusercontent.com/u/9977887?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/nle-odoo",
+      "html_url": "https://github.com/nle-odoo",
+      "followers_url": "https://api.github.com/users/nle-odoo/followers",
+      "following_url": "https://api.github.com/users/nle-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/nle-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/nle-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/nle-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/nle-odoo/orgs",
+      "repos_url": "https://api.github.com/users/nle-odoo/repos",
+      "events_url": "https://api.github.com/users/nle-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/nle-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "478574a09ebfa6b8c434bd511ae4c88f39a3fe2f",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/478574a09ebfa6b8c434bd511ae4c88f39a3fe2f",
+        "html_url": "https://github.com/odoo/odoo/commit/478574a09ebfa6b8c434bd511ae4c88f39a3fe2f"
+      }
+    ],
+    "stats": {
+      "total": 23,
+      "additions": 19,
+      "deletions": 4
+    },
+    "files": [
+      {
+        "sha": "d508ceb82321dbda60e7fcdc1554b74eb17d3c49",
+        "filename": "addons/http_routing/models/ir_http.py",
+        "status": "modified",
+        "additions": 3,
+        "deletions": 0,
+        "changes": 3,
+        "blob_url": "https://github.com/odoo/odoo/blob/3e9b2fcabeba28e685a748d5f542362284faa317/addons%2Fhttp_routing%2Fmodels%2Fir_http.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/3e9b2fcabeba28e685a748d5f542362284faa317/addons%2Fhttp_routing%2Fmodels%2Fir_http.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhttp_routing%2Fmodels%2Fir_http.py?ref=3e9b2fcabeba28e685a748d5f542362284faa317",
+        "patch": "@@ -266,6 +266,9 @@ def _get_default_lang(cls) -> LangData:\n     def get_frontend_session_info(self) -> dict:\n         session_info = super(IrHttp, self).get_frontend_session_info()\n \n+        if request.is_frontend:\n+            lang = request.lang.code\n+            session_info['bundle_params']['lang'] = lang\n         session_info.update({\n             'translationURL': '/website/translations',\n         })"
+      },
+      {
+        "sha": "683e3aab3fa365856fa37dce6218019744f996ff",
+        "filename": "addons/website/tests/test_lang_url.py",
+        "status": "modified",
+        "additions": 16,
+        "deletions": 4,
+        "changes": 20,
+        "blob_url": "https://github.com/odoo/odoo/blob/3e9b2fcabeba28e685a748d5f542362284faa317/addons%2Fwebsite%2Ftests%2Ftest_lang_url.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/3e9b2fcabeba28e685a748d5f542362284faa317/addons%2Fwebsite%2Ftests%2Ftest_lang_url.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Ftests%2Ftest_lang_url.py?ref=3e9b2fcabeba28e685a748d5f542362284faa317",
+        "patch": "@@ -8,10 +8,9 @@\n from odoo.tests import HttpCase, tagged\n \n \n-@tagged('-at_install', 'post_install')\n-class TestLangUrl(HttpCase):\n+class TestLangUrlCommon(HttpCase):\n     def setUp(self):\n-        super(TestLangUrl, self).setUp()\n+        super().setUp()\n \n         # Simulate multi lang without loading translations\n         self.website = self.env.ref('website.default_website')\n@@ -20,6 +19,9 @@ def setUp(self):\n         self.website.language_ids = self.env.ref('base.lang_en') + self.lang_fr\n         self.website.default_lang_id = self.env.ref('base.lang_en')\n \n+\n+@tagged('-at_install', 'post_install')\n+class TestLangUrl(TestLangUrlCommon):\n     def test_01_url_lang(self):\n         with MockRequest(self.env, website=self.website):\n             self.assertEqual(self.env['ir.http']._url_for('', '[lang]'), '/[lang]/mockrequest', \"`[lang]` is used to be replaced in the url_return after installing a language, it should not be replaced or removed.\")\n@@ -61,6 +63,7 @@ def test_04_url_cook_lang_not_available(self):\n             if match:\n                 session_info = json.loads(session_info_str[:-1])\n                 self.assertEqual(session_info['user_context']['lang'], 'en_US', \"ensure english was loaded\")\n+                self.assertEqual(session_info['bundle_params']['lang'], 'en_US', \"ensure bundle use english\")\n                 break\n         else:\n             raise ValueError('Session info not found in web page')\n@@ -78,6 +81,15 @@ def test_04_url_cook_lang_not_available(self):\n             doc = lxml.html.document_fromstring(r.text)\n             self.assertEqual(doc.get('lang'), 'fr-FR', \"Ensure contactus did not soft crash + loaded in correct lang\")\n \n+        for line in r.text.splitlines():\n+            _, match, session_info_str = line.partition('odoo.__session_info__ = ')\n+            if match:\n+                session_info = json.loads(session_info_str[:-1])\n+                self.assertEqual(session_info['bundle_params']['lang'], 'fr_FR', \"ensure bundle use french\")\n+                break\n+        else:\n+            raise ValueError('Session info not found in web page')\n+\n     def test_05_invalid_ipv6_url(self):\n         view = self.env['ir.ui.view'].create({\n             'name': 'Base',\n@@ -111,7 +123,7 @@ def test_07_nolang_prefix_underscore(self):\n \n \n @tagged('-at_install', 'post_install')\n-class TestControllerRedirect(TestLangUrl):\n+class TestControllerRedirect(TestLangUrlCommon):\n     def setUp(self):\n         self.page = self.env['website.page'].create({\n             'name': 'Test View',"
+      }
+    ]
+  },
+  {
+    "sha": "a34db9d13c4cacfde158619471c70ad91adb7b75",
+    "node_id": "C_kwDOAS1I7NoAKGEzNGRiOWQxM2M0Y2FjZmRlMTU4NjE5NDcxYzcwYWQ5MWFkYjdiNzU",
+    "commit": {
+      "author": {
+        "name": "Aaron Bohy",
+        "email": "aab@odoo.com",
+        "date": "2025-10-15T11:22:27Z"
+      },
+      "committer": {
+        "name": "Aaron Bohy",
+        "email": "aab@odoo.com",
+        "date": "2025-10-24T07:11:14Z"
+      },
+      "message": "[FIX] web: race conditions when d&d in kanban\n\nOn a grouped kanban view displaying a lot of records (i.e. with a\nlot of columns and a lot of records by column), drag and drop\nseveral records from the same column quick multiple times. Before\nthis commit, different crashes could occur.\n\nThe first category of crashes concern the sortable hook. It called\nthe onDrop callback even if the dragged element was no longer in\nthe DOM (which occurs if there's a re-rendering while the user is\ndragging). This has been fixed in the hook, and tested.\n\nAnother crash could arise in kanban (in the model). If the user\ndropped the card while there was a scheduled/ongoing re-rendering,\ni.e. at a specific moment where the model isn't synchronized with\nthe DOM, the dropped card was still in the DOM, but it's associated\ndatapoint was no longer referenced in hte model. In that case, we\ncan do nothing but cancel the d&d. Note that this couldn't be\ntested, as reproducing the exact behavior (typically having a slow\nrendering due to the number of cards to render) isn't possible in\na unit test, where user interactions are done programmatically.\n\nTask~5167650\n\ncloses odoo/odoo#232934\n\nX-original-commit: f94375b272a00e411c4e3e5a5d01cb5efda929ea\nSigned-off-by: Julien Mougenot (jum) <jum@odoo.com>\nSigned-off-by: Aaron Bohy (aab) <aab@odoo.com>",
+      "tree": {
+        "sha": "1e7accee536cbcf3bfdc94dfc9315ea109278ad5",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/1e7accee536cbcf3bfdc94dfc9315ea109278ad5"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/a34db9d13c4cacfde158619471c70ad91adb7b75",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/a34db9d13c4cacfde158619471c70ad91adb7b75",
+    "html_url": "https://github.com/odoo/odoo/commit/a34db9d13c4cacfde158619471c70ad91adb7b75",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/a34db9d13c4cacfde158619471c70ad91adb7b75/comments",
+    "author": {
+      "login": "aab-odoo",
+      "id": 9432572,
+      "node_id": "MDQ6VXNlcjk0MzI1NzI=",
+      "avatar_url": "https://avatars.githubusercontent.com/u/9432572?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/aab-odoo",
+      "html_url": "https://github.com/aab-odoo",
+      "followers_url": "https://api.github.com/users/aab-odoo/followers",
+      "following_url": "https://api.github.com/users/aab-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/aab-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/aab-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/aab-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/aab-odoo/orgs",
+      "repos_url": "https://api.github.com/users/aab-odoo/repos",
+      "events_url": "https://api.github.com/users/aab-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/aab-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "aab-odoo",
+      "id": 9432572,
+      "node_id": "MDQ6VXNlcjk0MzI1NzI=",
+      "avatar_url": "https://avatars.githubusercontent.com/u/9432572?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/aab-odoo",
+      "html_url": "https://github.com/aab-odoo",
+      "followers_url": "https://api.github.com/users/aab-odoo/followers",
+      "following_url": "https://api.github.com/users/aab-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/aab-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/aab-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/aab-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/aab-odoo/orgs",
+      "repos_url": "https://api.github.com/users/aab-odoo/repos",
+      "events_url": "https://api.github.com/users/aab-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/aab-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "d4c637b0ac6c61402130cc1986e36528ad885c8e",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/d4c637b0ac6c61402130cc1986e36528ad885c8e",
+        "html_url": "https://github.com/odoo/odoo/commit/d4c637b0ac6c61402130cc1986e36528ad885c8e"
+      }
+    ],
+    "stats": {
+      "total": 102,
+      "additions": 101,
+      "deletions": 1
+    },
+    "files": [
+      {
+        "sha": "ce02193d9d8cc91a9332ad3faed2c8d66afddce9",
+        "filename": "addons/html_builder/static/src/core/drag_and_drop_plugin.js",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 0,
+        "changes": 1,
+        "blob_url": "https://github.com/odoo/odoo/blob/a34db9d13c4cacfde158619471c70ad91adb7b75/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fcore%2Fdrag_and_drop_plugin.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/a34db9d13c4cacfde158619471c70ad91adb7b75/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fcore%2Fdrag_and_drop_plugin.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fcore%2Fdrag_and_drop_plugin.js?ref=a34db9d13c4cacfde158619471c70ad91adb7b75",
+        "patch": "@@ -128,6 +128,7 @@ export class DragAndDropPlugin extends Plugin {\n             elements: elementsSelector,\n             scrollingElement,\n             handle: handleSelector,\n+            allowDisconnected: true, // To be challenged in master\n             enable: () => !!document.querySelector(\".o_move_handle\") || this.dragStarted, // Still needed ?\n             dropzones: () => dropzoneEls,\n             helper: ({ helperOffset }) => {"
+      },
+      {
+        "sha": "dff3a52924c8d3bb256dd66fe39d863b38e62474",
+        "filename": "addons/web/static/src/core/utils/draggable_hook_builder.js",
+        "status": "modified",
+        "additions": 8,
+        "deletions": 1,
+        "changes": 9,
+        "blob_url": "https://github.com/odoo/odoo/blob/a34db9d13c4cacfde158619471c70ad91adb7b75/addons%2Fweb%2Fstatic%2Fsrc%2Fcore%2Futils%2Fdraggable_hook_builder.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/a34db9d13c4cacfde158619471c70ad91adb7b75/addons%2Fweb%2Fstatic%2Fsrc%2Fcore%2Futils%2Fdraggable_hook_builder.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fweb%2Fstatic%2Fsrc%2Fcore%2Futils%2Fdraggable_hook_builder.js?ref=a34db9d13c4cacfde158619471c70ad91adb7b75",
+        "patch": "@@ -86,6 +86,7 @@ const DRAGGABLE_CLASS = \"o_draggable\";\n export const DRAGGED_CLASS = \"o_dragged\";\n \n const DEFAULT_ACCEPTED_PARAMS = {\n+    allowDisconnected: [Boolean], // do not use, introduced for stable versions, to challenge in master\n     enable: [Boolean, Function],\n     preventDrag: [Function],\n     ref: [Object],\n@@ -100,6 +101,7 @@ const DEFAULT_ACCEPTED_PARAMS = {\n     iframeWindow: [Object, Function],\n };\n const DEFAULT_DEFAULT_PARAMS = {\n+    allowDisconnected: false,\n     elements: `.${DRAGGABLE_CLASS}`,\n     enable: true,\n     preventDrag: () => false,\n@@ -574,7 +576,10 @@ export function makeDraggableHook(hookParams) {\n                 if (state.dragging) {\n                     preventClick = true;\n                     if (!inErrorState) {\n-                        if (target) {\n+                        if (\n+                            target &&\n+                            (params.allowDisconnected || ctx.current.element.isConnected)\n+                        ) {\n                             callBuildHandler(\"onDrop\", { target });\n                         }\n                         callBuildHandler(\"onDragEnd\");\n@@ -785,6 +790,8 @@ export function makeDraggableHook(hookParams) {\n                         return;\n                     }\n                     dragStart();\n+                } else if (!params.allowDisconnected && !ctx.current.element.isConnected) {\n+                    return dragEnd(null);\n                 }\n \n                 if (ctx.followCursor) {"
+      },
+      {
+        "sha": "2292bda49b073c1b08b4fa4ab81979f391eee329",
+        "filename": "addons/web/static/src/views/kanban/kanban_renderer.js",
+        "status": "modified",
+        "additions": 6,
+        "deletions": 0,
+        "changes": 6,
+        "blob_url": "https://github.com/odoo/odoo/blob/a34db9d13c4cacfde158619471c70ad91adb7b75/addons%2Fweb%2Fstatic%2Fsrc%2Fviews%2Fkanban%2Fkanban_renderer.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/a34db9d13c4cacfde158619471c70ad91adb7b75/addons%2Fweb%2Fstatic%2Fsrc%2Fviews%2Fkanban%2Fkanban_renderer.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fweb%2Fstatic%2Fsrc%2Fviews%2Fkanban%2Fkanban_renderer.js?ref=a34db9d13c4cacfde158619471c70ad91adb7b75",
+        "patch": "@@ -592,6 +592,12 @@ export class KanbanRenderer extends Component {\n             parent.classList.contains(\"o_kanban_hover\") ||\n             parent.dataset.id === element.parentElement.dataset.id\n         ) {\n+            if (!this.props.list.records.find((r) => r.id === dataRecordId)) {\n+                // Race condition: a new rendering has been scheduled/is ongoing but hasn't been\n+                // applied to the DOM yet, so the user dropped a record that is no longer referenced\n+                // in the model. In that case, we can't to anything else than abort.\n+                return;\n+            }\n             this.toggleProcessing(dataRecordId, true);\n \n             parent?.classList.remove(\"o_kanban_hover\");"
+      },
+      {
+        "sha": "490caf46e0dd2007e7bdf5ee5c98ca8da9f9c88e",
+        "filename": "addons/web/static/tests/core/utils/draggable.test.js",
+        "status": "modified",
+        "additions": 36,
+        "deletions": 0,
+        "changes": 36,
+        "blob_url": "https://github.com/odoo/odoo/blob/a34db9d13c4cacfde158619471c70ad91adb7b75/addons%2Fweb%2Fstatic%2Ftests%2Fcore%2Futils%2Fdraggable.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/a34db9d13c4cacfde158619471c70ad91adb7b75/addons%2Fweb%2Fstatic%2Ftests%2Fcore%2Futils%2Fdraggable.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fweb%2Fstatic%2Ftests%2Fcore%2Futils%2Fdraggable.test.js?ref=a34db9d13c4cacfde158619471c70ad91adb7b75",
+        "patch": "@@ -433,3 +433,39 @@ test(\"Focusing is not lost after clicking\", async () => {\n     await contains(\".item\").click();\n     expect(\".item\").toBeFocused();\n });\n+\n+test(\"allowDisconnected option\", async () => {\n+    class List extends Component {\n+        static template = xml`\n+            <div t-ref=\"root\" class=\"root\">\n+                <button class=\"handle\" t-if=\"state.hasHandle\">Handle</button>\n+                <ul class=\"list list-unstyled m-0 d-flex flex-column\">\n+                    <li t-foreach=\"[1, 2, 3]\" t-as=\"i\" t-key=\"i\" t-esc=\"i\" class=\"item w-50 h-100\" />\n+                </ul>\n+            </div>`;\n+        static props = [\"*\"];\n+        setup() {\n+            this.state = useState({ hasHandle: true });\n+            useDraggable({\n+                ref: useRef(\"root\"),\n+                elements: \".handle\",\n+                allowDisconnected: true,\n+                onDragStart: () => {\n+                    expect.step(\"start\");\n+                    this.state.hasHandle = false;\n+                },\n+                onDragEnd: () => expect.step(\"end\"),\n+                onDrop: () => expect.step(\"drop\"), // should be called as allowDisconnected\n+            });\n+        }\n+    }\n+\n+    await mountWithCleanup(List);\n+    const { moveTo, drop } = await contains(\".handle\").drag();\n+    expect.verifySteps([\"start\"]);\n+    await animationFrame();\n+    expect(\".handle\").toHaveCount(0);\n+    await moveTo(\".item:nth-child(2)\");\n+    await drop();\n+    expect.verifySteps([\"drop\", \"end\"]);\n+});"
+      },
+      {
+        "sha": "33261e0fd14cc2fa6a252054722520d860f2a906",
+        "filename": "addons/web/static/tests/core/utils/sortable.test.js",
+        "status": "modified",
+        "additions": 50,
+        "deletions": 0,
+        "changes": 50,
+        "blob_url": "https://github.com/odoo/odoo/blob/a34db9d13c4cacfde158619471c70ad91adb7b75/addons%2Fweb%2Fstatic%2Ftests%2Fcore%2Futils%2Fsortable.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/a34db9d13c4cacfde158619471c70ad91adb7b75/addons%2Fweb%2Fstatic%2Ftests%2Fcore%2Futils%2Fsortable.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fweb%2Fstatic%2Ftests%2Fcore%2Futils%2Fsortable.test.js?ref=a34db9d13c4cacfde158619471c70ad91adb7b75",
+        "patch": "@@ -628,3 +628,53 @@ test(\"clone option\", async () => {\n     await contains(\".item:first-child\").dragAndDrop(\".item:nth-child(2)\");\n     expect(\".placeholder:not(.item)\").toHaveCount(0);\n });\n+\n+test(\"dragged element is removed from the DOM while being dragged\", async () => {\n+    class List extends Component {\n+        static props = [\"*\"];\n+        static template = xml`\n+            <div t-ref=\"root\" class=\"root\">\n+                <ul class=\"list\">\n+                    <li t-foreach=\"state.items\" t-as=\"i\" t-key=\"i\" t-esc=\"i\" class=\"item\" />\n+                </ul>\n+            </div>`;\n+        setup() {\n+            this.state = useState({\n+                items: [1, 2, 3],\n+            });\n+            useSortable({\n+                ref: useRef(\"root\"),\n+                elements: \".item\",\n+                onDragStart() {\n+                    expect.step(\"start\");\n+                },\n+                onDragEnd() {\n+                    expect.step(\"end\");\n+                },\n+                onDrop() {\n+                    expect.step(\"drop\"); // should not be called\n+                },\n+            });\n+        }\n+    }\n+\n+    const list = await mountWithCleanup(List);\n+\n+    expect(\".item:visible\").toHaveCount(3);\n+    expect(\".o_dragged\").toHaveCount(0);\n+    expect.verifySteps([]);\n+\n+    const { drop, moveTo } = await contains(\".item:first-child\").drag();\n+    expect(\".o_dragged\").toHaveCount(1);\n+    expect.verifySteps([\"start\"]);\n+\n+    await moveTo(\".item:nth-child(2)\");\n+    expect(\".o_dragged\").toHaveCount(1);\n+\n+    list.state.items = [3, 4];\n+    await animationFrame();\n+    expect(\".item:visible\").toHaveCount(2);\n+    expect(\".o_dragged\").toHaveCount(0);\n+    await drop();\n+    expect.verifySteps([\"end\"]);\n+});"
+      }
+    ]
+  },
+  {
+    "sha": "78d406ce5456dc20c10e884d8abd76458bb78e22",
+    "node_id": "C_kwDOAS1I7NoAKDc4ZDQwNmNlNTQ1NmRjMjBjMTBlODg0ZDhhYmQ3NjQ1OGJiNzhlMjI",
+    "commit": {
+      "author": {
+        "name": "krip-odoo",
+        "email": "krip@odoo.com",
+        "date": "2025-07-18T12:20:11Z"
+      },
+      "committer": {
+        "name": "qsm-odoo",
+        "email": "qsm@odoo.com",
+        "date": "2025-10-24T15:16:17Z"
+      },
+      "message": "[FIX] website: prevent deleting fields used in website forms\n\nThe system crashes when a user tries to edit a website form field and\nthat field has already been deleted from the model.\n\nSteps to produce:\n- Install the 'website' module.\n- Create a new custom field on a model(for example, a field on the\n  `mail.mail` model).\n- Website > edit > add Form widget to a page, and configure it to use\n  the 'mail.mail' model.\n- Add the newly created custom field to the form and save the page.\n- Now, delete the custom field which is created previously.\n- Return to the website page > edit > mark the deleted field as\n  required, and attempt to save the changes.\n\nError:\nValueError: Unable to whitelist field(s) [''] for model 'mail.mail'.\n\nRoot cause:\n- At [1], we can see that in the current version, it only logs an error\n  using the logger but in later versions it raises a ValueError instead.\n\nSolution:\n- This fix prevents a field from being deleted if it is actively used in\n  any website form.\n- It adds a validation check that blocks the deletion and raises\n  an error, forcing the user to remove the field from the form first.\n\n[1]: https://github.com/odoo/odoo/blob/d4f424d731fa93ccd232d0def0a7612997345ef7/addons/website/models/website_form.py#L123-L126\n\nsentry-5689731444\n\ncloses odoo/odoo#233036\n\nX-original-commit: 98e82dbdf368ab1d6b20c5861ce79b63f87e0164\nSigned-off-by: Quentin Smetz (qsm) <qsm@odoo.com>",
+      "tree": {
+        "sha": "85f5f1e6ba24565bbec02bfb55eb84c64b01b7c5",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/85f5f1e6ba24565bbec02bfb55eb84c64b01b7c5"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/78d406ce5456dc20c10e884d8abd76458bb78e22",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/78d406ce5456dc20c10e884d8abd76458bb78e22",
+    "html_url": "https://github.com/odoo/odoo/commit/78d406ce5456dc20c10e884d8abd76458bb78e22",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/78d406ce5456dc20c10e884d8abd76458bb78e22/comments",
+    "author": {
+      "login": "krip-odoo",
+      "id": 197602583,
+      "node_id": "U_kgDOC8ctFw",
+      "avatar_url": "https://avatars.githubusercontent.com/u/197602583?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/krip-odoo",
+      "html_url": "https://github.com/krip-odoo",
+      "followers_url": "https://api.github.com/users/krip-odoo/followers",
+      "following_url": "https://api.github.com/users/krip-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/krip-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/krip-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/krip-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/krip-odoo/orgs",
+      "repos_url": "https://api.github.com/users/krip-odoo/repos",
+      "events_url": "https://api.github.com/users/krip-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/krip-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "qsm-odoo",
+      "id": 10338094,
+      "node_id": "MDQ6VXNlcjEwMzM4MDk0",
+      "avatar_url": "https://avatars.githubusercontent.com/u/10338094?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/qsm-odoo",
+      "html_url": "https://github.com/qsm-odoo",
+      "followers_url": "https://api.github.com/users/qsm-odoo/followers",
+      "following_url": "https://api.github.com/users/qsm-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/qsm-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/qsm-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/qsm-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/qsm-odoo/orgs",
+      "repos_url": "https://api.github.com/users/qsm-odoo/repos",
+      "events_url": "https://api.github.com/users/qsm-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/qsm-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "78f7ec91fbc0e143332434a19bb5960add341e74",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/78f7ec91fbc0e143332434a19bb5960add341e74",
+        "html_url": "https://github.com/odoo/odoo/commit/78f7ec91fbc0e143332434a19bb5960add341e74"
+      }
+    ],
+    "stats": {
+      "total": 68,
+      "additions": 61,
+      "deletions": 7
+    },
+    "files": [
+      {
+        "sha": "aaf3e57d5ac87a6940c976fc834e140e646bc30a",
+        "filename": "addons/website/models/website_form.py",
+        "status": "modified",
+        "additions": 24,
+        "deletions": 1,
+        "changes": 25,
+        "blob_url": "https://github.com/odoo/odoo/blob/78d406ce5456dc20c10e884d8abd76458bb78e22/addons%2Fwebsite%2Fmodels%2Fwebsite_form.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/78d406ce5456dc20c10e884d8abd76458bb78e22/addons%2Fwebsite%2Fmodels%2Fwebsite_form.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fmodels%2Fwebsite_form.py?ref=78d406ce5456dc20c10e884d8abd76458bb78e22",
+        "patch": "@@ -2,7 +2,10 @@\n \n from ast import literal_eval\n \n-from odoo import models, fields, api, SUPERUSER_ID\n+from lxml import etree\n+\n+from odoo import SUPERUSER_ID, _, api, fields, models\n+from odoo.exceptions import ValidationError\n from odoo.fields import Domain\n from odoo.http import request\n \n@@ -143,6 +146,26 @@ def init(self):\n         self.env.cr.execute('ALTER TABLE ir_model_fields '\n                          ' ALTER COLUMN website_form_blacklisted SET DEFAULT true')\n \n+    @api.ondelete(at_uninstall=False)\n+    def _check_if_used_in_website_form(self):\n+        \"\"\"Prevent field deletion if used in a website form.\"\"\"\n+        for field in self:\n+            for model_name, field_name in self.env['website']._get_html_fields():\n+                domain = [(field_name, 'ilike', f'data-model_name=\"{field.model}\"')]\n+                records = self.env[model_name].with_context(active_test=False).search(domain)\n+                for record in records:\n+                    arch_parsed = etree.fromstring(record[field_name])\n+                    xpath_selector = f'//form[@data-model_name=\"{field.model}\"]//*[@name=\"{field.name}\"]'\n+                    if arch_parsed.xpath(xpath_selector):\n+                        raise ValidationError(_(\n+                            \"The field '%(field)s' cannot be deleted because it is referenced in a website view.\\n\"\n+                            \"Model: %(model)s\\n\"\n+                            \"View: %(view)s\",\n+                            field=field.name,\n+                            model=field.model,\n+                            view=record.display_name,\n+                        ))\n+\n     @api.model\n     def formbuilder_whitelist(self, model, fields):\n         \"\"\""
+      },
+      {
+        "sha": "1e5df4d33fefe0f3898e7909c667caf2c5ee1952",
+        "filename": "addons/website/tests/test_website_form_editor.py",
+        "status": "modified",
+        "additions": 37,
+        "deletions": 6,
+        "changes": 43,
+        "blob_url": "https://github.com/odoo/odoo/blob/78d406ce5456dc20c10e884d8abd76458bb78e22/addons%2Fwebsite%2Ftests%2Ftest_website_form_editor.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/78d406ce5456dc20c10e884d8abd76458bb78e22/addons%2Fwebsite%2Ftests%2Ftest_website_form_editor.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Ftests%2Ftest_website_form_editor.py?ref=78d406ce5456dc20c10e884d8abd76458bb78e22",
+        "patch": "@@ -1,14 +1,13 @@\n # Part of Odoo. See LICENSE file for full copyright and licensing details.\n \n-import psycopg2\n-from unittest.mock import patch\n-\n+from odoo.exceptions import ValidationError\n from odoo.http import request\n+from odoo.tests.common import TransactionCase, tagged\n+\n from odoo.addons.base.tests.common import HttpCaseWithUserPortal\n-from odoo.addons.website.controllers.form import WebsiteForm\n from odoo.addons.http_routing.tests.common import MockRequest\n-from odoo.tests.common import tagged, TransactionCase\n-import unittest\n+from odoo.addons.website.controllers.form import WebsiteForm\n+\n \n @tagged('post_install', '-at_install')\n class TestWebsiteFormEditor(HttpCaseWithUserPortal):\n@@ -70,9 +69,20 @@ def test_website_form_nested_forms(self):\n     def test_website_form_duplicate_field_ids(self):\n         self.start_tour('/', 'website_form_duplicate_field_ids', login='admin')\n \n+\n @tagged('post_install', '-at_install')\n class TestWebsiteForm(TransactionCase):\n \n+    def setUp(self):\n+        super().setUp()\n+        self.partner_model = self.env['ir.model'].search([('model', '=', 'res.partner')])\n+        self.test_field = self.env['ir.model.fields'].create({\n+            'name': 'x_test_field',\n+            'model_id': self.partner_model.id,\n+            'ttype': 'char',\n+            'field_description': 'test',\n+        })\n+\n     def test_website_form_html_escaping(self):\n         website = self.env['website'].browse(1)\n         WebsiteFormController = WebsiteForm()\n@@ -111,3 +121,24 @@ def dummy_insert_record(*args, **kwargs):\n             self.assertEqual(response.status_code, 200)\n             self.assertTrue(response.data.startswith(b'{\"id\":'))\n         test_sp.close(rollback=True)\n+\n+    def test_cannot_delete_field_used_in_website_form(self):\n+        \"\"\"\n+        Test that deleting a field used in a website form raises a ValidationError.\n+        \"\"\"\n+        self.env['ir.ui.view'].create({\n+            'name': 'Test Form for Deletion Constraint',\n+            'type': 'qweb',\n+            'arch_db': f'''\n+                <template id=\"test_form_template_for_deletion\">\n+                    <form action=\"/website/form/\" data-model_name=\"res.partner\">\n+                        <label for=\"my_input\">Test Input</label>\n+                        <input type=\"text\" name=\"{self.test_field.name}\" id=\"my_input\"/>\n+                        <button type=\"submit\">Submit</button>\n+                    </form>\n+                </template>\n+            ''',\n+        })\n+        with self.assertRaises(ValidationError):\n+            self.test_field.unlink()\n+        self.assertTrue(self.test_field.exists())"
+      }
+    ]
+  },
+  {
+    "sha": "ba8d1f60b82ffeada0b222481706a5c65623020d",
+    "node_id": "C_kwDOAS1I7NoAKGJhOGQxZjYwYjgyZmZlYWRhMGIyMjI0ODE3MDZhNWM2NTYyMzAyMGQ",
+    "commit": {
+      "author": {
+        "name": "Antoine (anso)",
+        "email": "anso@odoo.com",
+        "date": "2025-01-23T16:31:49Z"
+      },
+      "committer": {
+        "name": "Antoine (anso)",
+        "email": "anso@odoo.com",
+        "date": "2025-10-24T18:53:36Z"
+      },
+      "message": "[IMP] website(_links): redesign the default contact page\n\nThe \"Contact us\" page has been reworked to better showcase the\ncapabilities of the website builder and to rely on modern snippets.\n\nThis commit also removes the \"company infos\" section, following user\nfeedback that expected it to update automatically when company info\nwas changed in the backend.\n\ntask-3685590\n\ncloses odoo/odoo#229088\n\nSigned-off-by: Outagant Mehdi (mou) <mou@odoo.com>",
+      "tree": {
+        "sha": "1d1645d4700016a42aa733dfde7fb00bc6d3b377",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/1d1645d4700016a42aa733dfde7fb00bc6d3b377"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/ba8d1f60b82ffeada0b222481706a5c65623020d",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/ba8d1f60b82ffeada0b222481706a5c65623020d",
+    "html_url": "https://github.com/odoo/odoo/commit/ba8d1f60b82ffeada0b222481706a5c65623020d",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/ba8d1f60b82ffeada0b222481706a5c65623020d/comments",
+    "author": {
+      "login": "anso-odoo",
+      "id": 110090660,
+      "node_id": "U_kgDOBo_ZpA",
+      "avatar_url": "https://avatars.githubusercontent.com/u/110090660?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/anso-odoo",
+      "html_url": "https://github.com/anso-odoo",
+      "followers_url": "https://api.github.com/users/anso-odoo/followers",
+      "following_url": "https://api.github.com/users/anso-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/anso-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/anso-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/anso-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/anso-odoo/orgs",
+      "repos_url": "https://api.github.com/users/anso-odoo/repos",
+      "events_url": "https://api.github.com/users/anso-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/anso-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "anso-odoo",
+      "id": 110090660,
+      "node_id": "U_kgDOBo_ZpA",
+      "avatar_url": "https://avatars.githubusercontent.com/u/110090660?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/anso-odoo",
+      "html_url": "https://github.com/anso-odoo",
+      "followers_url": "https://api.github.com/users/anso-odoo/followers",
+      "following_url": "https://api.github.com/users/anso-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/anso-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/anso-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/anso-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/anso-odoo/orgs",
+      "repos_url": "https://api.github.com/users/anso-odoo/repos",
+      "events_url": "https://api.github.com/users/anso-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/anso-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "131bdf66b8191d40d3f7c77b38f83a8ce7d7dc10",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/131bdf66b8191d40d3f7c77b38f83a8ce7d7dc10",
+        "html_url": "https://github.com/odoo/odoo/commit/131bdf66b8191d40d3f7c77b38f83a8ce7d7dc10"
+      }
+    ],
+    "stats": {
+      "total": 202,
+      "additions": 149,
+      "deletions": 53
+    },
+    "files": [
+      {
+        "sha": "4d764d084220629c28e8c3a8595b2ad34d44d9e0",
+        "filename": "addons/html_editor/static/src/scss/html_editor.frontend.scss",
+        "status": "modified",
+        "additions": 19,
+        "deletions": 6,
+        "changes": 25,
+        "blob_url": "https://github.com/odoo/odoo/blob/ba8d1f60b82ffeada0b222481706a5c65623020d/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fscss%2Fhtml_editor.frontend.scss",
+        "raw_url": "https://github.com/odoo/odoo/raw/ba8d1f60b82ffeada0b222481706a5c65623020d/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fscss%2Fhtml_editor.frontend.scss",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fscss%2Fhtml_editor.frontend.scss?ref=ba8d1f60b82ffeada0b222481706a5c65623020d",
+        "patch": "@@ -54,12 +54,7 @@\n         }\n \n         &.o_grid_item_image img {\n-            // See BORDER_VARIABLES_RULES_EXTENSION\n-            border-radius:\n-                calc(var(--box-border-top-left-radius, 0px) - max(var(--box-border-top-width, 0px), var(--box-border-left-width, 0px)))\n-                calc(var(--box-border-top-right-radius, 0px) - max(var(--box-border-top-width, 0px), var(--box-border-right-width, 0px)))\n-                calc(var(--box-border-bottom-right-radius, 0px) - max(var(--box-border-bottom-width, 0px), var(--box-border-right-width, 0px)))\n-                calc(var(--box-border-bottom-left-radius, 0px) - max(var(--box-border-bottom-width, 0px), var(--box-border-left-width, 0px)));\n+            @extend %o-we-inner-border-radius;\n         }\n     }\n }\n@@ -219,3 +214,21 @@ body.editor_enable:not(.o_basic_theme) .odoo-editor-editable {\n         @extend %box-border-radius-rules;\n     }\n }\n+\n+// For border with all 4 edges of equal value the max function is useless,\n+// but in case the border is uneven it approximates the correct roundness\n+// See BORDER_VARIABLES_RULES_EXTENSION\n+//\n+// --box-border-XXX-(radius|width) : editor Round Corners user input\n+// --box-border-(radius|width) : rounded-XXX classes\n+// --border-(radius|width) : theme (+ default bootstrap)\n+//\n+// Generic rule for inner elements to inherit a parent's border-radius\n+// without requiring overflow: hidden on the parent.\n+%o-we-inner-border-radius {\n+    border-radius:\n+        calc(var(--box-border-top-left-radius, 0px) - max(var(--box-border-top-width, 0px), var(--box-border-left-width, 0px)))\n+        calc(var(--box-border-top-right-radius, 0px) - max(var(--box-border-top-width, 0px), var(--box-border-right-width, 0px)))\n+        calc(var(--box-border-bottom-right-radius, 0px) - max(var(--box-border-bottom-width, 0px), var(--box-border-right-width, 0px)))\n+        calc(var(--box-border-bottom-left-radius, 0px) - max(var(--box-border-bottom-width, 0px), var(--box-border-left-width, 0px)));\n+}"
+      },
+      {
+        "sha": "cbf97c5b7803afa84a0ef15bd312b2f946e460c8",
+        "filename": "addons/website/data/website_data.xml",
+        "status": "modified",
+        "additions": 117,
+        "deletions": 45,
+        "changes": 162,
+        "blob_url": "https://github.com/odoo/odoo/blob/ba8d1f60b82ffeada0b222481706a5c65623020d/addons%2Fwebsite%2Fdata%2Fwebsite_data.xml",
+        "raw_url": "https://github.com/odoo/odoo/raw/ba8d1f60b82ffeada0b222481706a5c65623020d/addons%2Fwebsite%2Fdata%2Fwebsite_data.xml",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fdata%2Fwebsite_data.xml?ref=ba8d1f60b82ffeada0b222481706a5c65623020d",
+        "patch": "@@ -32,22 +32,14 @@\n             }\"/>\n             <span class=\"hidden\" data-for=\"contactus_form\" t-att-data-values=\"contactus_form_values\"/>\n             <div id=\"wrap\" class=\"oe_structure oe_empty\">\n-                <section class=\"s_title parallax s_parallax_is_fixed bg-black-50 pt24 pb24\" data-vcss=\"001\" data-snippet=\"s_title\" data-scroll-background-ratio=\"1\">\n-                    <span class=\"s_parallax_bg_wrap\">\n-                        <span class=\"s_parallax_bg oe_img_bg\" style=\"background-image: url('/web/image/website.s_parallax_default_image'); background-position: 50% 0;\"/>\n-                    </span>\n-                    <div class=\"o_we_bg_filter bg-black-50\"/>\n+                <section class=\"s_form_aside pt48 pb120\" data-snippet=\"s_form_aside\" data-name=\"Form Aside\" data-oe-shape-data=\"{'shape': 'html_builder/Connections/14', 'colors': {'c5': 'o-color-1'}, 'showOnMobile': true}\" style=\"position: relative;\">\n+                    <div class=\"o_we_shape o_html_builder_Connections_14 o_shape_show_mobile\" style=\"background-image: url('/html_editor/shape/html_builder/Connections/14.svg?c5=o-color-1');\"/>\n                     <div class=\"container\">\n-                        <h1>Contact us</h1>\n-                    </div>\n-                </section>\n-                <section class=\"s_text_block pt40 pb40 o_colored_level \" data-snippet=\"s_text_block\">\n-                    <div class=\"container s_allow_columns\">\n                         <div class=\"row\">\n-                            <div class=\"col-lg-7 mt-4 mt-lg-0\">\n+                            <div class=\"col-12 col-lg-6 order-lg-0\" style=\"order: 1;\">\n+                                <h1 class=\"h2-fs\">Contact us</h1>\n                                 <p class=\"lead\">\n-                                    Contact us about anything related to our company or services.<br/>\n-                                    We'll do our best to get back to you as soon as possible.\n+                                    Contact us about anything related to our company or services.\n                                 </p>\n                                 <section class=\"s_website_form\" data-vcss=\"001\" data-snippet=\"s_website_form\">\n                                     <div class=\"container\">\n@@ -58,40 +50,41 @@\n                                                         <span class=\"s_website_form_label_content\">Name</span>\n                                                         <span class=\"s_website_form_mark\"> *</span>\n                                                     </label>\n-                                                    <input id=\"contact1\" type=\"text\" class=\"form-control s_website_form_input\" name=\"name\" required=\"\" data-fill-with=\"name\"/>\n+                                                    <input id=\"contact1\" type=\"text\" placeholder=\"John Doe\" class=\"form-control s_website_form_input\" name=\"name\" required=\"\" data-fill-with=\"name\"/>\n                                                 </div>\n                                                 <div class=\"mb-3 col-lg-6 s_website_form_field s_website_form_custom\" data-type=\"char\" data-name=\"Field\">\n                                                     <label class=\"s_website_form_label\" style=\"width: 200px\" for=\"contact2\">\n                                                         <span class=\"s_website_form_label_content\">Phone Number</span>\n                                                     </label>\n-                                                    <input id=\"contact2\" type=\"tel\" class=\"form-control s_website_form_input\" name=\"phone\" data-fill-with=\"phone\"/>\n+                                                    <input id=\"contact2\" type=\"tel\" placeholder=\"+1 555-555-5556\" class=\"form-control s_website_form_input\" name=\"phone\" data-fill-with=\"phone\"/>\n                                                 </div>\n                                                 <div class=\"mb-3 col-lg-6 s_website_form_field s_website_form_required s_website_form_model_required\" data-type=\"email\" data-name=\"Field\">\n                                                     <label class=\"s_website_form_label\" style=\"width: 200px\" for=\"contact3\">\n                                                         <span class=\"s_website_form_label_content\">Email</span>\n                                                         <span class=\"s_website_form_mark\"> *</span>\n                                                     </label>\n-                                                    <input id=\"contact3\" type=\"email\" class=\"form-control s_website_form_input\" name=\"email_from\" required=\"\" data-fill-with=\"email\"/>\n+                                                    <input id=\"contact3\" type=\"email\" placeholder=\"example@mail.com\" class=\"form-control s_website_form_input\" name=\"email_from\" required=\"\" data-fill-with=\"email\"/>\n                                                 </div>\n                                                 <div class=\"mb-3 col-lg-6 s_website_form_field s_website_form_custom\" data-type=\"char\" data-name=\"Field\">\n                                                     <label class=\"s_website_form_label\" style=\"width: 200px\" for=\"contact4\">\n                                                         <span class=\"s_website_form_label_content\">Company</span>\n                                                     </label>\n-                                                    <input id=\"contact4\" type=\"text\" class=\"form-control s_website_form_input\" name=\"company\" data-fill-with=\"commercial_company_name\"/>\n+                                                    <input id=\"contact4\" type=\"text\" placeholder=\"ACME Corp\" class=\"form-control s_website_form_input\" name=\"company\" data-fill-with=\"commercial_company_name\"/>\n                                                 </div>\n                                                 <div class=\"mb-3 col-12 s_website_form_field s_website_form_required s_website_form_model_required\" data-type=\"char\" data-name=\"Field\">\n                                                     <label class=\"s_website_form_label\" style=\"width: 200px\" for=\"contact5\">\n                                                         <span class=\"s_website_form_label_content\">Subject</span>\n                                                         <span class=\"s_website_form_mark\"> *</span>\n                                                     </label>\n-                                                    <input id=\"contact5\" type=\"text\" class=\"form-control s_website_form_input\" name=\"subject\" required=\"\"/>\n+                                                    <input id=\"contact5\" type=\"text\" placeholder=\"Describe your request\" class=\"form-control s_website_form_input\" name=\"subject\" required=\"\"/>\n                                                 </div>\n                                                 <div class=\"mb-3 col-12 s_website_form_field s_website_form_custom s_website_form_required\" data-type=\"text\" data-name=\"Field\">\n                                                     <label class=\"s_website_form_label\" style=\"width: 200px\" for=\"contact6\">\n-                                                        <span class=\"s_website_form_label_content\">Question</span>\n+                                                        <span class=\"s_website_form_label_content\">Message</span>\n                                                         <span class=\"s_website_form_mark\"> *</span>\n                                                     </label>\n-                                                    <textarea id=\"contact6\" class=\"form-control s_website_form_input\" name=\"description\" required=\"\" rows=\"8\"></textarea>\n+                                                    <textarea id=\"contact6\" placeholder=\"Write down your message\" class=\"form-control s_website_form_input\" name=\"description\" required=\"\" rows=\"6\"></textarea>\n+                                                    <div class=\"s_website_form_field_description small form-text text-muted\">We typically respond within 1-2 business days.</div>\n                                                 </div>\n                                                 <div class=\"mb-3 col-12 s_website_form_field s_website_form_dnone\">\n                                                     <div class=\"row s_col_no_resize s_col_no_bgcolor\">\n@@ -105,21 +98,111 @@\n                                                 </div>\n                                                 <div class=\"mb-0 py-2 col-12 s_website_form_submit s_website_form_no_submit_label text-end\" data-name=\"Submit Button\">\n                                                     <div style=\"width: 200px;\" class=\"s_website_form_label\"/>\n-                                                    <a href=\"#\" role=\"button\" class=\"btn btn-primary s_website_form_send\">Submit</a>\n                                                     <span id=\"s_website_form_result\"></span>\n+                                                    <a href=\"#\" role=\"button\" class=\"btn btn-primary s_website_form_send\">Send Message</a>\n                                                 </div>\n                                             </div>\n                                         </form>\n                                     </div>\n                                 </section>\n                             </div>\n-                            <div class=\"col-lg-4 offset-lg-1 mt-4 mt-lg-0\">\n-                                <h5>My Company</h5>\n-                                <ul class=\"list-unstyled mb-0 ps-2\">\n-                                    <li><i class=\"fa fa-map-marker fa-fw me-2\"/><span class=\"o_force_ltr\">3575 Fake Buena Vista Avenue</span></li>\n-                                    <li><i class=\"fa fa-phone fa-fw me-2\"/><span class=\"o_force_ltr\">+1 555-555-5556</span></li>\n-                                    <li><i class=\"fa fa-1x fa-fw fa-envelope me-2\"/><span>info@yourcompany.example.com</span></li>\n-                                </ul>\n+                            <div class=\"col-12 col-lg-5 offset-lg-1 pt0 pb32 order-lg-0\" style=\"order: 0;\">\n+                                <img src=\"/web/image/website.s_form_aside_default_image\" class=\"img img-fluid rounded\" alt=\"\"/>\n+                            </div>\n+                        </div>\n+                    </div>\n+                </section>\n+                <section class=\"s_title o_cc o_cc4 pt136 pb128\" data-vcss=\"001\" data-snippet=\"s_title\" data-name=\"Title\">\n+                    <div class=\"container\">\n+                        <h2 class=\"display-4-fs\" style=\"text-align: center;\">50,000+ companies use our services <br/>to grow their businesses.</h2>\n+                        <p class=\"lead\" style=\"text-align: center;\">Join us and make your company a better place.</p>\n+                    </div>\n+                </section>\n+                <section class=\"s_faq_list pt120 pb56\" data-snippet=\"s_faq_list\" data-name=\"FAQ List\" data-oe-shape-data=\"{'shape': 'html_builder/Connections/14', 'colors': {'c5': 'o-color-1'}, 'flip': ['y'], 'showOnMobile': true}\">\n+                    <div class=\"o_we_shape o_html_builder_Connections_14 o_shape_show_mobile\" style=\"background-image: url('/html_editor/shape/html_builder/Connections/14.svg?c5=o-color-1&amp;flip=y'); background-position: 50% 0%;\"/>\n+                    <div class=\"container\">\n+                        <div class=\"row s_nb_column_fixed\">\n+                            <div class=\"col-lg-12 pb24\">\n+                                <h2 class=\"h3-fs\">Need help?</h2>\n+                                <p class=\"lead\">In this section, you can address common questions efficiently.</p>\n+                            </div>\n+                            <div class=\"col-lg-4 pt16 pb16\">\n+                                <h3 class=\"h6-fs\"><strong>What sets us apart?</strong></h3>\n+                                <p>We deliver personalized solutions, ensuring that every customer receives top-tier service tailored to their needs.</p>\n+                            </div>\n+                            <div class=\"col-lg-4 pt16 pb16\">\n+                                <h3 class=\"h6-fs\"><strong>Is the website user-friendly?</strong></h3>\n+                                <p>Our website is designed for easy navigation, allowing you to find the information you need quickly and efficiently.</p>\n+                            </div>\n+                            <div class=\"col-lg-4 pt16 pb16\">\n+                                <h3 class=\"h6-fs\"><strong>Can you trust our partners?</strong></h3>\n+                                <p>We collaborate with trusted, high-quality partners to bring you reliable and top-notch products and services.</p>\n+                            </div>\n+                            <div class=\"col-lg-4 pt16 pb16\">\n+                                <h3 class=\"h6-fs\"><strong>What support do we offer?</strong></h3>\n+                                <p>We provide 24/7 support through various channels, including live chat, email, and phone, to assist with any queries.</p>\n+                            </div>\n+                            <div class=\"col-lg-4 pt16 pb16\">\n+                                <h3 class=\"h6-fs\"><strong>How is your data secured?</strong></h3>\n+                                <p>Your data is protected by advanced encryption and security protocols, keeping your personal information safe.</p>\n+                            </div>\n+                            <div class=\"col-lg-4 pt16 pb16\">\n+                                <h3 class=\"h6-fs\"><strong>Are links to other websites approved?</strong></h3>\n+                                <p>Although this Website may be linked to other websites, we are not, directly or indirectly, implying any approval.</p>\n+                            </div>\n+                        </div>\n+                    </div>\n+                </section>\n+                <div class=\"s_hr pt32 pb32\" data-snippet=\"s_hr\" data-name=\"Separator\">\n+                    <hr class=\"w-100 mx-auto\"/>\n+                </div>\n+                <section class=\"s_accordion_image pt64 pb120\" data-snippet=\"s_accordion_image\" data-name=\"Accordion Image\">\n+                    <div class=\"container\">\n+                        <div class=\"row align-items-start\">\n+                            <div class=\"col-lg-7 pt16\">\n+                                <section class=\"s_map pt248 pb248 rounded-3\" data-map-type=\"m\" data-map-zoom=\"12\" data-snippet=\"s_map\" data-map-address=\"250 Executive Park Blvd, Suite 3400 San Francisco California (US) United States\" data-name=\"Map\">\n+                                    <div class=\"map_container o_not_editable\">\n+                                        <div class=\"css_non_editable_mode_hidden\">\n+                                            <div class=\"missing_option_warning alert alert-info rounded-0 fade show d-none d-print-none\">\n+                                                An address must be specified for a map to be embedded\n+                                            </div>\n+                                        </div>\n+                                        <iframe class=\"s_map_embedded o_not_editable\" src=\"https://maps.google.com/maps?q=250%20Executive%20Park%20Blvd%2C%20Suite%203400%20San%20Francisco%20California%20(US)%20United%20States&amp;t=m&amp;z=12&amp;ie=UTF8&amp;iwloc=&amp;output=embed\" width=\"100%\" height=\"100%\" frameborder=\"0\" scrolling=\"no\" marginheight=\"0\" marginwidth=\"0\" aria-label=\"Map\"></iframe>\n+                                        <div class=\"s_map_color_filter\"></div>\n+                                    </div>\n+                                </section>\n+                            </div>\n+                            <div class=\"col-lg-4 offset-lg-1 pt24\">\n+                                <h2 class=\"h3-fs\">Come Visit Us</h2>\n+                                <p class=\"lead\">Easy ways to reach us, no matter your favorite transport.</p>\n+                                <div class=\"s_accordion\" data-snippet=\"s_accordion\" data-name=\"Accordion\" data-vcss=\"000\">\n+                                    <div id=\"o_contactus_accordion\" class=\"s_accordion_highlight accordion\">\n+                                        <div class=\"accordion-item position-relative z-1\" data-name=\"Accordion Item\">\n+                                            <button type=\"button\" id=\"o_contactus_accordion_btn_1\" class=\"accordion-header accordion-button justify-content-between gap-2 bg-transparent h6-fs fw-bold text-decoration-none text-reset transition-none\" data-bs-target=\"#o_contactus_accordion_1\" aria-controls=\"o_contactus_accordion_1\" data-bs-toggle=\"collapse\" aria-expanded=\"true\"><span class=\"flex-grow-1\">By Train</span></button>\n+                                            <div id=\"o_contactus_accordion_1\" class=\"accordion-collapse collapse show\" data-bs-parent=\"#o_contactus_accordion\" role=\"region\" aria-labelledby=\"o_contactus_accordion_btn_1\">\n+                                                <div class=\"accordion-body\">\n+                                                    <p>Take BART to Balboa Park Station. From there, board the 29 bus toward Bayview and get off at Executive Park. The building at 250 Executive Park Blvd, Suite 3400, is just a short walk from the stop.</p>\n+                                                </div>\n+                                            </div>\n+                                        </div>\n+                                        <div class=\"accordion-item position-relative z-1\" data-name=\"Accordion Item\">\n+                                            <button type=\"button\" id=\"o_contactus_accordion_btn_2\" class=\"accordion-header accordion-button collapsed justify-content-between gap-2 bg-transparent h6-fs fw-bold text-decoration-none text-reset transition-none\" data-bs-target=\"#o_contactus_accordion_2\" aria-controls=\"o_contactus_accordion_2\" data-bs-toggle=\"collapse\" aria-expanded=\"false\"><span class=\"flex-grow-1\">By Car</span></button>\n+                                            <div id=\"o_contactus_accordion_2\" class=\"accordion-collapse collapse\" data-bs-parent=\"#o_contactus_accordion\" role=\"region\" aria-labelledby=\"o_contactus_accordion_btn_2\">\n+                                                <div class=\"accordion-body\">\n+                                                    <p>From downtown San Francisco, follow US-101 South and exit at Bayshore Boulevard. Turn left onto Executive Park Blvd, then continue straight until you reach 250 Executive Park Blvd. Parking is available on-site near Suite 3400.</p>\n+                                                </div>\n+                                            </div>\n+                                        </div>\n+                                        <div class=\"accordion-item position-relative z-1\" data-name=\"Accordion Item\">\n+                                            <button type=\"button\" id=\"o_contactus_accordion_btn_3\" class=\"accordion-header accordion-button collapsed justify-content-between gap-2 bg-transparent h6-fs fw-bold text-decoration-none text-reset transition-none\" data-bs-target=\"#o_contactus_accordion_3\" aria-controls=\"o_contactus_accordion_3\" data-bs-toggle=\"collapse\" aria-expanded=\"false\"><span class=\"flex-grow-1\">By Bike</span></button>\n+                                            <div id=\"o_contactus_accordion_3\" class=\"accordion-collapse collapse\" data-bs-parent=\"#o_contactus_accordion\" role=\"region\" aria-labelledby=\"o_contactus_accordion_btn_3\">\n+                                                <div class=\"accordion-body\">\n+                                                    <p>Cyclists can follow the Bay Trail south from downtown and connect through Geneva Avenue. Head toward Executive Park Blvd, where bike racks are available at 250 Executive Park Blvd, Suite 3400.</p>\n+                                                </div>\n+                                            </div>\n+                                        </div>\n+                                    </div>\n+                                </div>\n                             </div>\n                         </div>\n                     </div>\n@@ -139,25 +222,14 @@\n             <t name=\"Thanks (Contact us)\" t-name=\"website.contactus_thanks\">\n                 <t t-call=\"website.layout\">\n                     <div id=\"wrap\" class=\"oe_structure oe_empty\">\n-                        <section class=\"s_text_block pt40 pb40 o_colored_level \" data-snippet=\"s_text_block\">\n+                        <section class=\"s_text_block pt80 pb80\" data-snippet=\"s_text_block\" data-name=\"Thank You Section\">\n                             <div class=\"container s_allow_columns\">\n                                 <div class=\"row\">\n-                                    <div class=\"col-lg-6 offset-lg-1 text-center\">\n-                                        <div class=\"d-inline-block mx-auto p-4\">\n-                                            <i class=\"fa fa-paper-plane fa-2x mb-3 rounded-circle text-bg-success\" role=\"presentation\"/>\n-                                            <h1 class=\"fw-bolder\">Thank You!</h1>\n-                                            <p class=\"lead mb-0\">Your message has been sent.</p>\n-                                            <p class=\"lead\">We will get back to you shortly.</p>\n-                                            <a href=\"/\">Go to Homepage</a>\n-                                        </div>\n-                                    </div>\n-                                    <div class=\"col-lg-4 offset-lg-1\">\n-                                        <h5>My Company</h5>\n-                                        <ul class=\"list-unstyled mb-0 ps-2\">\n-                                            <li><i class=\"fa fa-map-marker fa-fw me-2\"/><span class=\"o_force_ltr\">3575 Fake Buena Vista Avenue</span></li>\n-                                            <li><i class=\"fa fa-phone fa-fw me-2\"/><span class=\"o_force_ltr\">+1 555-555-5556</span></li>\n-                                            <li><i class=\"fa fa-1x fa-fw fa-envelope me-2\"/><span>info@yourcompany.example.com</span></li>\n-                                        </ul>\n+                                    <div class=\"col-lg-12\" style=\"text-align: center;\">\n+                                        <i class=\"fa fa-paper-plane fa-2x mb-3 rounded-circle text-bg-success\" role=\"presentation\"/>\n+                                        <h1 class=\"fw-bolder\">Thank You!</h1>\n+                                        <p class=\"lead\">Your message has been sent. <br/>We will get back to you shortly.</p>\n+                                        <a href=\"/\">Go to Homepage</a>\n                                     </div>\n                                 </div>\n                             </div>"
+      },
+      {
+        "sha": "97619d275d1571931ec02c7fec90e4ca3e92b343",
+        "filename": "addons/website/static/src/builder/plugins/options/map_option.xml",
+        "status": "modified",
+        "additions": 7,
+        "deletions": 0,
+        "changes": 7,
+        "blob_url": "https://github.com/odoo/odoo/blob/ba8d1f60b82ffeada0b222481706a5c65623020d/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fplugins%2Foptions%2Fmap_option.xml",
+        "raw_url": "https://github.com/odoo/odoo/raw/ba8d1f60b82ffeada0b222481706a5c65623020d/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fplugins%2Foptions%2Fmap_option.xml",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fplugins%2Foptions%2Fmap_option.xml?ref=ba8d1f60b82ffeada0b222481706a5c65623020d",
+        "patch": "@@ -55,6 +55,13 @@\n                     'solid': [],\n                 }\"/>\n     </BuilderRow>\n+    <BuilderRow label.translate=\"Roundness\" preview=\"false\">\n+        <BuilderRange\n+            action=\"'setClassRange'\"\n+            actionParam=\"['rounded-0','rounded-1','rounded-2','rounded-3','rounded-4','rounded-5']\"\n+            max=\"5\"\n+        />\n+    </BuilderRow>\n     <BuilderRow label.translate=\"Description\">\n         <BuilderCheckbox action=\"'mapDescription'\"/>\n     </BuilderRow>"
+      },
+      {
+        "sha": "25ca541477edc8915a2bbfc56ca3d5bd511d8ad5",
+        "filename": "addons/website/static/src/snippets/s_map/000.scss",
+        "status": "modified",
+        "additions": 4,
+        "deletions": 0,
+        "changes": 4,
+        "blob_url": "https://github.com/odoo/odoo/blob/ba8d1f60b82ffeada0b222481706a5c65623020d/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_map%2F000.scss",
+        "raw_url": "https://github.com/odoo/odoo/raw/ba8d1f60b82ffeada0b222481706a5c65623020d/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_map%2F000.scss",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fsnippets%2Fs_map%2F000.scss?ref=ba8d1f60b82ffeada0b222481706a5c65623020d",
+        "patch": "@@ -10,6 +10,10 @@ $s-map-desc-hover-alpha: 0.55 !default;\n \n     .map_container {\n         @include o-position-absolute(0, 0, 0, 0);\n+\n+        .s_map_embedded {\n+            @extend %o-we-inner-border-radius;\n+        }\n     }\n     .description {\n         @include o-position-absolute(auto, 0, 0, 0);"
+      },
+      {
+        "sha": "d247ca35dd3ed39eb9e5ba3d7e190646b2f83713",
+        "filename": "addons/website/views/snippets/s_map.xml",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/ba8d1f60b82ffeada0b222481706a5c65623020d/addons%2Fwebsite%2Fviews%2Fsnippets%2Fs_map.xml",
+        "raw_url": "https://github.com/odoo/odoo/raw/ba8d1f60b82ffeada0b222481706a5c65623020d/addons%2Fwebsite%2Fviews%2Fsnippets%2Fs_map.xml",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fviews%2Fsnippets%2Fs_map.xml?ref=ba8d1f60b82ffeada0b222481706a5c65623020d",
+        "patch": "@@ -2,7 +2,7 @@\n <odoo>\n \n <template name=\"Map\" id=\"s_map\">\n-    <section class=\"s_map pb56 pt56\" data-map-type=\"m\" data-map-zoom=\"12\" t-att-data-map-address=\"' '.join(filter(None, (user_id.company_id.street, user_id.company_id.city, user_id.company_id.state_id.display_name, user_id.company_id.country_id.display_name)))\">\n+    <section class=\"s_map pb56 pt56 rounded-3\" data-map-type=\"m\" data-map-zoom=\"12\" t-att-data-map-address=\"' '.join(filter(None, (user_id.company_id.street, user_id.company_id.city, user_id.company_id.state_id.display_name, user_id.company_id.country_id.display_name)))\">\n         <div class=\"map_container o_not_editable\">\n             <div class=\"css_non_editable_mode_hidden\">\n                 <div class=\"missing_option_warning alert alert-info rounded-0 fade show d-none d-print-none\">"
+      },
+      {
+        "sha": "36e0b108d442b8897869f0a33c4c5df7085f3a8e",
+        "filename": "addons/website_links/static/tests/tours/website_links.js",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/ba8d1f60b82ffeada0b222481706a5c65623020d/addons%2Fwebsite_links%2Fstatic%2Ftests%2Ftours%2Fwebsite_links.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/ba8d1f60b82ffeada0b222481706a5c65623020d/addons%2Fwebsite_links%2Fstatic%2Ftests%2Ftours%2Fwebsite_links.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite_links%2Fstatic%2Ftests%2Ftours%2Fwebsite_links.js?ref=ba8d1f60b82ffeada0b222481706a5c65623020d",
+        "patch": "@@ -79,7 +79,7 @@ registry.category(\"web_tour.tours\").add('website_links_tour', {\n         },\n         {\n             content: \"check that we landed on correct page with correct query strings\",\n-            trigger: \".s_title h1:contains(/^Contact us$/)\",\n+            trigger: \".s_form_aside h1:contains(/^Contact us$/)\",\n             run: function () {\n                 const enc = c => encodeURIComponent(c).replace(/%20/g, '+');\n                 const expectedUrl = `/contactus?utm_campaign=${enc(campaignValue)}&utm_source=${enc(sourceValue)}&utm_medium=${enc(mediumValue)}`;"
+      }
+    ]
+  },
+  {
+    "sha": "9bb2a86af6b913884dcafc4e49b202947b911a0d",
+    "node_id": "C_kwDOAS1I7NoAKDliYjJhODZhZjZiOTEzODg0ZGNhZmM0ZTQ5YjIwMjk0N2I5MTFhMGQ",
+    "commit": {
+      "author": {
+        "name": "Sanjay Sharma",
+        "email": "shsa@odoo.com",
+        "date": "2025-09-16T05:48:07Z"
+      },
+      "committer": {
+        "name": "qsm-odoo",
+        "email": "qsm@odoo.com",
+        "date": "2025-10-24T18:53:38Z"
+      },
+      "message": "[FIX] website: use youtube-play icon in social links\n\nReplaced `fa-youtube` with `fa-youtube-play` in both mega menu and\nsocial media snippet templates.\n\nThis ensures consistent display of the YouTube icon across the website\nand aligns with the intended design.\n\ntask-5106944\n\ncloses odoo/odoo#227384\n\nSigned-off-by: Quentin Smetz (qsm) <qsm@odoo.com>",
+      "tree": {
+        "sha": "e1d7f9b73f4b8d11ea548d4846b409fc98fa2429",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/e1d7f9b73f4b8d11ea548d4846b409fc98fa2429"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/9bb2a86af6b913884dcafc4e49b202947b911a0d",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/9bb2a86af6b913884dcafc4e49b202947b911a0d",
+    "html_url": "https://github.com/odoo/odoo/commit/9bb2a86af6b913884dcafc4e49b202947b911a0d",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/9bb2a86af6b913884dcafc4e49b202947b911a0d/comments",
+    "author": {
+      "login": "shsa-odoo",
+      "id": 103405229,
+      "node_id": "U_kgDOBinWrQ",
+      "avatar_url": "https://avatars.githubusercontent.com/u/103405229?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/shsa-odoo",
+      "html_url": "https://github.com/shsa-odoo",
+      "followers_url": "https://api.github.com/users/shsa-odoo/followers",
+      "following_url": "https://api.github.com/users/shsa-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/shsa-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/shsa-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/shsa-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/shsa-odoo/orgs",
+      "repos_url": "https://api.github.com/users/shsa-odoo/repos",
+      "events_url": "https://api.github.com/users/shsa-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/shsa-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "qsm-odoo",
+      "id": 10338094,
+      "node_id": "MDQ6VXNlcjEwMzM4MDk0",
+      "avatar_url": "https://avatars.githubusercontent.com/u/10338094?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/qsm-odoo",
+      "html_url": "https://github.com/qsm-odoo",
+      "followers_url": "https://api.github.com/users/qsm-odoo/followers",
+      "following_url": "https://api.github.com/users/qsm-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/qsm-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/qsm-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/qsm-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/qsm-odoo/orgs",
+      "repos_url": "https://api.github.com/users/qsm-odoo/repos",
+      "events_url": "https://api.github.com/users/qsm-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/qsm-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "ba8d1f60b82ffeada0b222481706a5c65623020d",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/ba8d1f60b82ffeada0b222481706a5c65623020d",
+        "html_url": "https://github.com/odoo/odoo/commit/ba8d1f60b82ffeada0b222481706a5c65623020d"
+      }
+    ],
+    "stats": {
+      "total": 4,
+      "additions": 2,
+      "deletions": 2
+    },
+    "files": [
+      {
+        "sha": "cfcdad715bf1adfe926ac0f0c9dee31a47baff5f",
+        "filename": "addons/website/views/snippets/s_mega_menu_odoo_menu.xml",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/9bb2a86af6b913884dcafc4e49b202947b911a0d/addons%2Fwebsite%2Fviews%2Fsnippets%2Fs_mega_menu_odoo_menu.xml",
+        "raw_url": "https://github.com/odoo/odoo/raw/9bb2a86af6b913884dcafc4e49b202947b911a0d/addons%2Fwebsite%2Fviews%2Fsnippets%2Fs_mega_menu_odoo_menu.xml",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fviews%2Fsnippets%2Fs_mega_menu_odoo_menu.xml?ref=9bb2a86af6b913884dcafc4e49b202947b911a0d",
+        "patch": "@@ -75,7 +75,7 @@\n                             <i class=\"fa fa-2x fa-github m-1 o_editable_media\"/>\n                         </a>\n                         <a href=\"/website/social/youtube\" class=\"s_social_media_youtube me-3 ms-3\" target=\"_blank\" aria-label=\"YouTube\">\n-                            <i class=\"fa fa-2x fa-youtube m-1 o_editable_media\"/>\n+                            <i class=\"fa fa-2x fa-youtube-play m-1 o_editable_media\"/>\n                         </a>\n                         <a href=\"/website/social/instagram\" class=\"s_social_media_instagram me-3 ms-3\" target=\"_blank\" aria-label=\"Instagram\">\n                             <i class=\"fa fa-2x fa-instagram m-1 o_editable_media\"/>"
+      },
+      {
+        "sha": "653cee500e11ca054a7a5e13fd6833983e7cadff",
+        "filename": "addons/website/views/snippets/s_social_media.xml",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/9bb2a86af6b913884dcafc4e49b202947b911a0d/addons%2Fwebsite%2Fviews%2Fsnippets%2Fs_social_media.xml",
+        "raw_url": "https://github.com/odoo/odoo/raw/9bb2a86af6b913884dcafc4e49b202947b911a0d/addons%2Fwebsite%2Fviews%2Fsnippets%2Fs_social_media.xml",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fviews%2Fsnippets%2Fs_social_media.xml?ref=9bb2a86af6b913884dcafc4e49b202947b911a0d",
+        "patch": "@@ -18,7 +18,7 @@ title stay editable after a save (see SOCIAL_MEDIA_TITLE_CONTENTEDITABLE).\n             <i class=\"fa fa-linkedin rounded shadow-sm o_editable_media small_social_icon\"/>\n         </a>\n         <a href=\"/website/social/youtube\" class=\"s_social_media_youtube\" target=\"_blank\" aria-label=\"YouTube\">\n-            <i class=\"fa fa-youtube rounded shadow-sm o_editable_media small_social_icon\"/>\n+            <i class=\"fa fa-youtube-play rounded shadow-sm o_editable_media small_social_icon\"/>\n         </a>\n         <a href=\"/website/social/instagram\" class=\"s_social_media_instagram\" target=\"_blank\" aria-label=\"Instagram\">\n             <i class=\"fa fa-instagram rounded shadow-sm o_editable_media small_social_icon\"/>"
+      }
+    ]
+  },
+  {
+    "sha": "57f7a3537bff44c56928a1db4df413465e92dff7",
+    "node_id": "C_kwDOAS1I7NoAKDU3ZjdhMzUzN2JmZjQ0YzU2OTI4YTFkYjRkZjQxMzQ2NWU5MmRmZjc",
+    "commit": {
+      "author": {
+        "name": "Rahil Ghanchi",
+        "email": "rahg@odoo.com",
+        "date": "2025-08-26T05:34:31Z"
+      },
+      "committer": {
+        "name": "Rahil Ghanchi",
+        "email": "rahg@odoo.com",
+        "date": "2025-10-27T11:03:59Z"
+      },
+      "message": "[IMP] website, html_editor: add option to toggle aspect-ratio\n\nSpecification:\n- Introduced a \"Vertical\" toggle button in the media dialog to switch\nbetween horizontal and vertical view for Instagram, YouTube, Facebook.\n\nAfter this commit:\n- The media dialog includes a \"Vertical\" toggle button for switching\nvideo types.\n- When the \"Vertical\" toggle is ON, the vertical video selector\nis displayed.\n- When the \"Vertical\" toggle is OFF, the regular horizontal selector\nis shown.\n- The \"Vertical\" toggle is hidden when the media dialog is opened for\nselecting a background video.\n- New url for Instagram works well which has reel in it.\nexample: https://www.instagram.com/reel/{video_id}/\n\ntask-4645422\n\nPart-of: odoo/odoo#214124\nSigned-off-by: Benoit Socias (bso) <bso@odoo.com>",
+      "tree": {
+        "sha": "dd9500d3046181cfe4bf8eea22e2c4ec043e9f8e",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/dd9500d3046181cfe4bf8eea22e2c4ec043e9f8e"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/57f7a3537bff44c56928a1db4df413465e92dff7",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/57f7a3537bff44c56928a1db4df413465e92dff7",
+    "html_url": "https://github.com/odoo/odoo/commit/57f7a3537bff44c56928a1db4df413465e92dff7",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/57f7a3537bff44c56928a1db4df413465e92dff7/comments",
+    "author": {
+      "login": "rahg-odoo",
+      "id": 157004424,
+      "node_id": "U_kgDOCVuyiA",
+      "avatar_url": "https://avatars.githubusercontent.com/u/157004424?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/rahg-odoo",
+      "html_url": "https://github.com/rahg-odoo",
+      "followers_url": "https://api.github.com/users/rahg-odoo/followers",
+      "following_url": "https://api.github.com/users/rahg-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/rahg-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/rahg-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/rahg-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/rahg-odoo/orgs",
+      "repos_url": "https://api.github.com/users/rahg-odoo/repos",
+      "events_url": "https://api.github.com/users/rahg-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/rahg-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "rahg-odoo",
+      "id": 157004424,
+      "node_id": "U_kgDOCVuyiA",
+      "avatar_url": "https://avatars.githubusercontent.com/u/157004424?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/rahg-odoo",
+      "html_url": "https://github.com/rahg-odoo",
+      "followers_url": "https://api.github.com/users/rahg-odoo/followers",
+      "following_url": "https://api.github.com/users/rahg-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/rahg-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/rahg-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/rahg-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/rahg-odoo/orgs",
+      "repos_url": "https://api.github.com/users/rahg-odoo/repos",
+      "events_url": "https://api.github.com/users/rahg-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/rahg-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "613a3384fc2070f54d23c3461f15af5b537c60ed",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/613a3384fc2070f54d23c3461f15af5b537c60ed",
+        "html_url": "https://github.com/odoo/odoo/commit/613a3384fc2070f54d23c3461f15af5b537c60ed"
+      }
+    ],
+    "stats": {
+      "total": 150,
+      "additions": 129,
+      "deletions": 21
+    },
+    "files": [
+      {
+        "sha": "b361ddd3e2fc423b341ee4cf5743e881e58fefc5",
+        "filename": "addons/html_editor/controllers/main.py",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/57f7a3537bff44c56928a1db4df413465e92dff7/addons%2Fhtml_editor%2Fcontrollers%2Fmain.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/57f7a3537bff44c56928a1db4df413465e92dff7/addons%2Fhtml_editor%2Fcontrollers%2Fmain.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_editor%2Fcontrollers%2Fmain.py?ref=57f7a3537bff44c56928a1db4df413465e92dff7",
+        "patch": "@@ -351,7 +351,7 @@ def get_image_info(self, src=''):\n     def video_url_data(self, video_url, autoplay=False, loop=False,\n                        hide_controls=False, hide_fullscreen=False,\n                        hide_dm_logo=False, hide_dm_share=False,\n-                       start_from=False):\n+                       start_from=False, **kwargs):\n         return get_video_url_data(\n             video_url, autoplay=autoplay, loop=loop,\n             hide_controls=hide_controls, hide_fullscreen=hide_fullscreen,"
+      },
+      {
+        "sha": "57333adcf27314076f5052c34d347daebcdfd79d",
+        "filename": "addons/html_editor/static/src/main/media/media_dialog/video_selector.js",
+        "status": "modified",
+        "additions": 49,
+        "deletions": 5,
+        "changes": 54,
+        "blob_url": "https://github.com/odoo/odoo/blob/57f7a3537bff44c56928a1db4df413465e92dff7/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fmain%2Fmedia%2Fmedia_dialog%2Fvideo_selector.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/57f7a3537bff44c56928a1db4df413465e92dff7/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fmain%2Fmedia%2Fmedia_dialog%2Fvideo_selector.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fmain%2Fmedia%2Fmedia_dialog%2Fvideo_selector.js?ref=57f7a3537bff44c56928a1db4df413465e92dff7",
+        "patch": "@@ -5,6 +5,7 @@ import { debounce } from \"@web/core/utils/timing\";\n \n import { Component, useState, useRef, onMounted, status } from \"@odoo/owl\";\n import { Switch } from \"@html_editor/components/switch/switch\";\n+import { closestElement } from \"@html_editor/utils/dom_traversal\";\n \n class VideoOption extends Component {\n     static template = \"html_editor.VideoOption\";\n@@ -65,13 +66,16 @@ export class VideoSelector extends Component {\n             platform: null,\n             vimeoPreviews: [],\n             errorMessage: \"\",\n+            isVertical: false,\n         });\n \n         this.PLATFORMS = {\n             youtube: \"youtube\",\n             dailymotion: \"dailymotion\",\n             vimeo: \"vimeo\",\n             youku: \"youku\",\n+            instagram: \"instagram\",\n+            facebook: \"facebook\",\n         };\n \n         this.platformParams = {\n@@ -122,6 +126,15 @@ export class VideoSelector extends Component {\n                 platforms: [this.PLATFORMS.dailymotion],\n                 urlParameter: () => \"sharing-enable=0\",\n             },\n+            is_vertical: {\n+                label: _t(\"Vertical\"),\n+                platforms: [\n+                    this.PLATFORMS.youtube,\n+                    this.PLATFORMS.instagram,\n+                    this.PLATFORMS.facebook,\n+                ],\n+                urlParameter: () => \"vertical\",\n+            },\n             start_from: {\n                 label: _t(\"Start at\"),\n                 platforms: [\n@@ -147,6 +160,10 @@ export class VideoSelector extends Component {\n                     if (!src.includes(\"https:\") && !src.includes(\"http:\")) {\n                         this.state.urlInput = \"https:\" + this.state.urlInput;\n                     }\n+                    this.state.isVertical = !!closestElement(\n+                        this.props.media,\n+                        \".media_iframe_video\"\n+                    )?.dataset.isVertical;\n                     await this.syncOptionsWithUrl();\n                     if (status(this) === \"destroyed\") {\n                         return;\n@@ -193,6 +210,9 @@ export class VideoSelector extends Component {\n     async onChangeOption(optionId) {\n         this.state.options = this.state.options.map((option) => {\n             if (option.id === optionId) {\n+                if (option.id === \"is_vertical\") {\n+                    this.state.isVertical = !this.state.isVertical;\n+                }\n                 // used \"0\" here, to set the initial \"startAt\" value if option is toggled on,\n                 // for other option it works as truthy value.\n                 return { ...option, value: !option.value && \"00:00\" };\n@@ -226,7 +246,7 @@ export class VideoSelector extends Component {\n \n         // Detect if we have an embed code rather than an URL\n         const embedMatch = this.state.urlInput.match(/(src|href)=[\"']?([^\"']+)?/);\n-        if (embedMatch && embedMatch[2].length > 0 && embedMatch[2].indexOf(\"instagram\")) {\n+        if (embedMatch && embedMatch[2]?.length > 0 && embedMatch[2].indexOf(\"instagram\")) {\n             embedMatch[1] = embedMatch[2]; // Instagram embed code is different\n         }\n         const url = embedMatch ? embedMatch[1] : this.state.urlInput;\n@@ -273,6 +293,11 @@ export class VideoSelector extends Component {\n         }\n \n         this.state.src = src;\n+        // Explicitly passing the state so the static `createElements` method,\n+        // which has no access to instance properties, can still use it.\n+        if (params) {\n+            params.isVertical = this.state.isVertical;\n+        }\n         this.props.selectMedia({\n             id: src,\n             src,\n@@ -303,10 +328,18 @@ export class VideoSelector extends Component {\n         return selectedMedia.map((video) => {\n             const div = document.createElement(\"div\");\n             div.dataset.oeExpression = video.src;\n-            div.innerHTML =\n-                '<div class=\"css_editable_mode_display\"></div>' +\n-                '<div class=\"media_iframe_video_size\" contenteditable=\"false\"></div>' +\n-                '<iframe frameborder=\"0\" contenteditable=\"false\" allowfullscreen=\"allowfullscreen\"></iframe>';\n+            const isVertical = !!video.params?.isVertical;\n+            if (isVertical) {\n+                div.dataset.isVertical = \"true\";\n+            }\n+            const sizeClass = isVertical\n+                ? \"media_iframe_video_size_for_vertical\"\n+                : \"media_iframe_video_size\";\n+            div.innerHTML = `\n+                <div class=\"css_editable_mode_display\"></div>\n+                <div class=\"${sizeClass}\" contenteditable=\"false\"></div>\n+                <iframe loading=\"lazy\" frameborder=\"0\" contenteditable=\"false\" allowfullscreen=\"allowfullscreen\"></iframe>\n+            `;\n \n             div.querySelector(\"iframe\").src = video.src;\n             return div;\n@@ -339,6 +372,14 @@ export class VideoSelector extends Component {\n     async syncOptionsWithUrl() {\n         await this.updateVideo();\n         if (!URL.canParse(this.state.urlInput)) {\n+            // For embedded codes, only the vertical option is updated since\n+            // other options rely on URL parameters that can\u2019t be parsed.\n+            this.state.options = this.state.options.map((option) => {\n+                if (option.id === \"is_vertical\") {\n+                    return { ...option, value: this.state.isVertical ? \"1\" : \"\" };\n+                }\n+                return { ...option };\n+            });\n             return;\n         }\n         const parsedUrl = new URL(this.state.urlInput);\n@@ -357,6 +398,9 @@ export class VideoSelector extends Component {\n                 case \"startTime\":\n                     value = urlParams.get(\"startTime\") || urlParams.get(\"start\");\n                     break;\n+                case \"vertical\":\n+                    value = this.state.isVertical ? \"1\" : \"\";\n+                    break;\n                 default:\n                     value = this.state.urlInput.includes(urlParameter);\n             }"
+      },
+      {
+        "sha": "8c8afcf7309eb4ad48df15a0dc3223aa50e0408e",
+        "filename": "addons/html_editor/static/src/main/media/media_dialog/video_selector.xml",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/57f7a3537bff44c56928a1db4df413465e92dff7/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fmain%2Fmedia%2Fmedia_dialog%2Fvideo_selector.xml",
+        "raw_url": "https://github.com/odoo/odoo/raw/57f7a3537bff44c56928a1db4df413465e92dff7/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fmain%2Fmedia%2Fmedia_dialog%2Fvideo_selector.xml",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fmain%2Fmedia%2Fmedia_dialog%2Fvideo_selector.xml?ref=57f7a3537bff44c56928a1db4df413465e92dff7",
+        "patch": "@@ -55,7 +55,7 @@\n             <div class=\"o_video_preview position-relative border-0 p-3\">\n                 <div t-if=\"this.state.src and !this.state.errorMessage\" class=\"o_video_dialog_preview_text mb-2\">Preview</div>\n                 <div class=\"media_iframe_video\">\n-                    <div class=\"media_iframe_video_size\"/>\n+                    <div t-att-class=\"this.state.isVertical ? 'media_iframe_video_size_for_vertical' : 'media_iframe_video_size'\"/>\n                     <VideoIframe\n                         t-if=\"this.state.src and !this.state.errorMessage\"\n                         src=\"this.state.src\"/>"
+      },
+      {
+        "sha": "d96edc32ca3685789c93ee3712dd5de4daf31b8d",
+        "filename": "addons/html_editor/static/src/scss/html_editor.common.scss",
+        "status": "modified",
+        "additions": 11,
+        "deletions": 0,
+        "changes": 11,
+        "blob_url": "https://github.com/odoo/odoo/blob/57f7a3537bff44c56928a1db4df413465e92dff7/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fscss%2Fhtml_editor.common.scss",
+        "raw_url": "https://github.com/odoo/odoo/raw/57f7a3537bff44c56928a1db4df413465e92dff7/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fscss%2Fhtml_editor.common.scss",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fscss%2Fhtml_editor.common.scss?ref=57f7a3537bff44c56928a1db4df413465e92dff7",
+        "patch": "@@ -342,13 +342,24 @@ div.media_iframe_video {\n         height: 0;\n     }\n \n+    .media_iframe_video_size_for_vertical {\n+        padding-bottom: 177.78%; /* 9:16 aspect ratio */\n+        position: relative;\n+        width: 100%;\n+        height: 0;\n+    }\n+\n     .css_editable_mode_display {\n         @include o-position-absolute(0,0,0,0);\n         width: 100%;\n         height: 100%;\n         display: none;\n         z-index: 2;\n     }\n+\n+    &:has(.media_iframe_video_size_for_vertical) {\n+        max-width: 315px;\n+    }\n }\n \n // Fields"
+      },
+      {
+        "sha": "f809c68ead0977f7086da300d5378470a37fcc7e",
+        "filename": "addons/html_editor/static/tests/paste.test.js",
+        "status": "modified",
+        "additions": 24,
+        "deletions": 12,
+        "changes": 36,
+        "blob_url": "https://github.com/odoo/odoo/blob/57f7a3537bff44c56928a1db4df413465e92dff7/addons%2Fhtml_editor%2Fstatic%2Ftests%2Fpaste.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/57f7a3537bff44c56928a1db4df413465e92dff7/addons%2Fhtml_editor%2Fstatic%2Ftests%2Fpaste.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_editor%2Fstatic%2Ftests%2Fpaste.test.js?ref=57f7a3537bff44c56928a1db4df413465e92dff7",
+        "patch": "@@ -3404,9 +3404,12 @@ describe(\"youtube video\", () => {\n             await press(\"Enter\");\n             // Wait for the getYoutubeVideoElement promise to resolve.\n             await tick();\n-            expect(getContent(el)).toBe(\n-                `<p>ab</p><div data-oe-expression=\"${videoUrl}\" class=\"media_iframe_video\" contenteditable=\"false\"><div class=\"css_editable_mode_display\"></div><div class=\"media_iframe_video_size\" contenteditable=\"false\"></div><iframe frameborder=\"0\" contenteditable=\"false\" allowfullscreen=\"allowfullscreen\" src=\"${videoUrl}\"></iframe></div><p>[]cd</p>`\n-            );\n+            const expected = `<p>ab</p><div data-oe-expression=\"${videoUrl}\" class=\"media_iframe_video\" contenteditable=\"false\">\n+                <div class=\"css_editable_mode_display\"></div>\n+                <div class=\"media_iframe_video_size\" contenteditable=\"false\"></div>\n+                <iframe loading=\"lazy\" frameborder=\"0\" contenteditable=\"false\" allowfullscreen=\"allowfullscreen\" src=\"${videoUrl}\"></iframe>\n+            </div><p>[]cd</p>`;\n+            expect(getContent(el)).toBe(expected);\n         });\n \n         test(\"should paste and transform a youtube URL in a span (1)\", async () => {\n@@ -3420,9 +3423,12 @@ describe(\"youtube video\", () => {\n             await press(\"Enter\");\n             // Wait for the getYoutubeVideoElement promise to resolve.\n             await tick();\n-            expect(getContent(el)).toBe(\n-                '<p>a<span class=\"a\">b</span></p><div data-oe-expression=\"https://youtu.be/dQw4w9WgXcQ\" class=\"media_iframe_video\" contenteditable=\"false\"><div class=\"css_editable_mode_display\"></div><div class=\"media_iframe_video_size\" contenteditable=\"false\"></div><iframe frameborder=\"0\" contenteditable=\"false\" allowfullscreen=\"allowfullscreen\" src=\"https://youtu.be/dQw4w9WgXcQ\"></iframe></div><p><span class=\"a\">[]c</span>d</p>'\n-            );\n+            const expected = `<p>a<span class=\"a\">b</span></p><div data-oe-expression=\"https://youtu.be/dQw4w9WgXcQ\" class=\"media_iframe_video\" contenteditable=\"false\">\n+                <div class=\"css_editable_mode_display\"></div>\n+                <div class=\"media_iframe_video_size\" contenteditable=\"false\"></div>\n+                <iframe loading=\"lazy\" frameborder=\"0\" contenteditable=\"false\" allowfullscreen=\"allowfullscreen\" src=\"https://youtu.be/dQw4w9WgXcQ\"></iframe>\n+            </div><p><span class=\"a\">[]c</span>d</p>`;\n+            expect(getContent(el)).toBe(expected);\n         });\n \n         test(\"should paste and not transform a youtube URL in a existing link\", async () => {\n@@ -3485,9 +3491,12 @@ describe(\"youtube video\", () => {\n             await press(\"Enter\");\n             // Wait for the getYoutubeVideoElement promise to resolve.\n             await tick();\n-            expect(getContent(el)).toBe(\n-                '<p>ab</p><div data-oe-expression=\"https://youtu.be/dQw4w9WgXcQ\" class=\"media_iframe_video\" contenteditable=\"false\"><div class=\"css_editable_mode_display\"></div><div class=\"media_iframe_video_size\" contenteditable=\"false\"></div><iframe frameborder=\"0\" contenteditable=\"false\" allowfullscreen=\"allowfullscreen\" src=\"https://youtu.be/dQw4w9WgXcQ\"></iframe></div><p>[]cd</p>'\n-            );\n+            const expected = `<p>ab</p><div data-oe-expression=\"https://youtu.be/dQw4w9WgXcQ\" class=\"media_iframe_video\" contenteditable=\"false\">\n+                <div class=\"css_editable_mode_display\"></div>\n+                <div class=\"media_iframe_video_size\" contenteditable=\"false\"></div>\n+                <iframe loading=\"lazy\" frameborder=\"0\" contenteditable=\"false\" allowfullscreen=\"allowfullscreen\" src=\"https://youtu.be/dQw4w9WgXcQ\"></iframe>\n+            </div><p>[]cd</p>`;\n+            expect(getContent(el)).toBe(expected);\n         });\n \n         test(\"should paste and transform a youtube URL in a span (2)\", async () => {\n@@ -3502,9 +3511,12 @@ describe(\"youtube video\", () => {\n             await press(\"Enter\");\n             // Wait for the getYoutubeVideoElement promise to resolve.\n             await tick();\n-            expect(getContent(el)).toBe(\n-                `<p>a<span class=\"a\">b</span></p><div data-oe-expression=\"${videoUrl}\" class=\"media_iframe_video\" contenteditable=\"false\"><div class=\"css_editable_mode_display\"></div><div class=\"media_iframe_video_size\" contenteditable=\"false\"></div><iframe frameborder=\"0\" contenteditable=\"false\" allowfullscreen=\"allowfullscreen\" src=\"${videoUrl}\"></iframe></div><p><span class=\"a\">[]c</span>d</p>`\n-            );\n+            const expected = `<p>a<span class=\"a\">b</span></p><div data-oe-expression=\"${videoUrl}\" class=\"media_iframe_video\" contenteditable=\"false\">\n+                <div class=\"css_editable_mode_display\"></div>\n+                <div class=\"media_iframe_video_size\" contenteditable=\"false\"></div>\n+                <iframe loading=\"lazy\" frameborder=\"0\" contenteditable=\"false\" allowfullscreen=\"allowfullscreen\" src=\"${videoUrl}\"></iframe>\n+            </div><p><span class=\"a\">[]c</span>d</p>`;\n+            expect(getContent(el)).toBe(expected);\n         });\n \n         test(\"should paste and not transform a youtube URL in a existing link\", async () => {"
+      },
+      {
+        "sha": "45d52dcf212ddb55077d8ea86575066e8426146f",
+        "filename": "addons/html_editor/tools.py",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/57f7a3537bff44c56928a1db4df413465e92dff7/addons%2Fhtml_editor%2Ftools.py",
+        "raw_url": "https://github.com/odoo/odoo/raw/57f7a3537bff44c56928a1db4df413465e92dff7/addons%2Fhtml_editor%2Ftools.py",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_editor%2Ftools.py?ref=57f7a3537bff44c56928a1db4df413465e92dff7",
+        "patch": "@@ -24,7 +24,7 @@\n     'youtube': r'^(?:(?:https?:)?//)?(?:www\\.|m\\.)?(?:youtu\\.be/|youtube(-nocookie)?\\.com/(?:embed/|v/|shorts/|live/|watch\\?v=|watch\\?.+&v=))((?:\\w|-){11})\\S*$',\n     'vimeo': r'//(player.)?vimeo.com/([a-z]*/)?(?P<id>[^/\\?]+)(?:/(?P<hash>[^/\\?]+))?(?:\\?(?P<params>[^\\s]+))?$',\n     'dailymotion': r'(https?:\\/\\/)(www\\.)?(dailymotion\\.com\\/(embed\\/video\\/|embed\\/|video\\/|hub\\/.*#video=)|geo\\.dailymotion\\.com\\/player\\.html\\?video=|dai\\.ly\\/)(?P<id>[A-Za-z0-9]{6,7})',\n-    'instagram': r'(?:(.*)instagram.com|instagr\\.am)/p/(.[a-zA-Z0-9-_\\.]*)',\n+    'instagram': r'(?:(.*)instagram\\.com|instagr\\.am)/(?:p|reel)/([a-zA-Z0-9\\-_\\.]+)',\n     'youku': r'(?:(https?:\\/\\/)?(v\\.youku\\.com/v_show/id_|player\\.youku\\.com/player\\.php/sid/|player\\.youku\\.com/embed/|cloud\\.youku\\.com/services/sharev\\?vid=|video\\.tudou\\.com/v/)|youku:)(?P<id>[A-Za-z0-9]+)(?:\\.html|/v\\.swf|)',\n     \"facebook\": r'^(?:(?:https?:)?//)?(?:www\\.)?facebook\\.com(?:/(?:[^/]+/)?videos/|/watch/?\\?v=|/reel/|/plugins/video\\.php\\?[^ ]*?href=.*?(?:videos|reel)%2[Ff])(?P<id>\\d+)',\n }"
+      },
+      {
+        "sha": "0ae5e755fb3c87abb58a3ebb80191d16b56db012",
+        "filename": "addons/website/static/tests/builder/videos.test.js",
+        "status": "modified",
+        "additions": 42,
+        "deletions": 1,
+        "changes": 43,
+        "blob_url": "https://github.com/odoo/odoo/blob/57f7a3537bff44c56928a1db4df413465e92dff7/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fvideos.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/57f7a3537bff44c56928a1db4df413465e92dff7/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fvideos.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fvideos.test.js?ref=57f7a3537bff44c56928a1db4df413465e92dff7",
+        "patch": "@@ -1,6 +1,7 @@\n import { expect, test } from \"@odoo/hoot\";\n-import { animationFrame, dblclick } from \"@odoo/hoot-dom\";\n+import { animationFrame, dblclick, waitFor, queryOne } from \"@odoo/hoot-dom\";\n import { defineWebsiteModels, setupWebsiteBuilder } from \"./website_helpers\";\n+import { onRpc } from \"@web/../tests/web_test_helpers\";\n \n defineWebsiteModels();\n \n@@ -19,3 +20,43 @@ test(\"double click on video\", async () => {\n     await animationFrame();\n     expect(\".modal-content:contains(Select a media) .o_video_dialog_form\").toHaveCount(1);\n });\n+\n+test(\"vertical toggle of video options\", async () => {\n+    onRpc(\"/html_editor/video_url/data\", () => ({\n+        platform: \"youtube\",\n+        embed_url: \"//www.youtube.com/embed/G8b4UZIcTfg?rel=0&autoplay=0\",\n+        video_id: \"G8b4UZIcTfg\",\n+        params: { rel: \"0\", autoplay: \"0\" },\n+    }));\n+    await setupWebsiteBuilder(`\n+        <div>\n+            <div data-oe-expression=\"//www.youtube.com/embed/wf9gPmNc2sc?rel=0&autoplay=0\"\n+                 class=\"media_iframe_video o_snippet_drop_in_only\">\n+                <div class=\"css_editable_mode_display\"></div>\n+                <div class=\"media_iframe_video_size\"></div>\n+                <iframe frameborder=\"0\" allowfullscreen=\"allowfullscreen\" aria-label=\"Video\"></iframe>\n+            </div>\n+        </div>\n+    `);\n+\n+    expect(\".modal-content\").toHaveCount(0);\n+    await dblclick(\":iframe iframe\");\n+    await animationFrame();\n+    expect(\".modal-content:contains(Select a media) .o_video_dialog_form\").toHaveCount(1);\n+    expect(\".modal-content:contains(Select a media) .media_iframe_video .media_iframe_video_size\").toHaveCount(1);\n+    // Wait for options to be rendered before interaction\n+    await waitFor(\".modal-content:contains(Select a media) .o_video_dialog_form .o_video_dialog_options\");\n+    // Toggle the \u201cVertical\u201d option\n+    const verticalToggle = queryOne('.modal-content:contains(\"Select a media\") .o_video_dialog_form .o_video_dialog_options label:contains(Vertical) input');\n+    verticalToggle.click();\n+\n+    // Confirm vertical class is applied in the preview area\n+    await waitFor(\".modal-content:contains(Select a media) .media_iframe_video .media_iframe_video_size_for_vertical\");\n+    queryOne('.modal-content:contains(Select a media) footer button:contains(Add)').click();\n+    await animationFrame();\n+    // Verify the vertical class persists in the website preview\n+    expect(\":iframe .media_iframe_video .media_iframe_video_size_for_vertical\").toHaveCount(1);\n+    // Reopen configurator and ensure the vertical setting is still active\n+    await dblclick(\":iframe iframe\");\n+    await waitFor(\".modal-content:contains(Select a media) .media_iframe_video .media_iframe_video_size_for_vertical\");\n+});"
+      }
+    ]
+  },
+  {
+    "sha": "54698f4d2854ca1777ec62a6464004b5b88a4dc5",
+    "node_id": "C_kwDOAS1I7NoAKDU0Njk4ZjRkMjg1NGNhMTc3N2VjNjJhNjQ2NDAwNGI1Yjg4YTRkYzU",
+    "commit": {
+      "author": {
+        "name": "Julien Mougenot",
+        "email": "jum@odoo.com",
+        "date": "2025-10-21T10:55:22Z"
+      },
+      "committer": {
+        "name": "Julien Mougenot",
+        "email": "jum@odoo.com",
+        "date": "2025-10-27T11:04:07Z"
+      },
+      "message": "[FIX] web,*: tests - properly handle server errors\n\nBefore this commit, errors dispatched from the mock server itself (e.g.\nwhen trying to fetch an unimplemented route), error messages were lost\nby the `rpc` module, which considers any actual server error as a\n\"connection lost\" error, and as such ignores the error message.\n\nTo prevent this kind of issue, the 'mockedFetch' internal function has\nbeen adapted to parse errors in a \"smarter\" way, i.e. recognize which\nrequests/responses are in the JSON-RPC format (based on their\n\"Content-Type\"), and as such should have the error thrown as-is, or\nwrapped inside a JSON-RPC object, that will itself be thrown by the\n`rpc` function.\n\nThis change also means that request handlers not having a JSON content\ntype do not have to be explicitly marked as \"pure\", and so tests have\nbeen simplified in these cases.\n\nPart-of: odoo/odoo#233147\nRelated: odoo/enterprise#98130\nSigned-off-by: Micha\u00ebl Mattiello (mcm) <mcm@odoo.com>\nSigned-off-by: Julien Mougenot (jum) <jum@odoo.com>",
+      "tree": {
+        "sha": "e2c87ad6e6a0e729aee4f90a88134a2aef02b263",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/e2c87ad6e6a0e729aee4f90a88134a2aef02b263"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/54698f4d2854ca1777ec62a6464004b5b88a4dc5",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/54698f4d2854ca1777ec62a6464004b5b88a4dc5",
+    "html_url": "https://github.com/odoo/odoo/commit/54698f4d2854ca1777ec62a6464004b5b88a4dc5",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/54698f4d2854ca1777ec62a6464004b5b88a4dc5/comments",
+    "author": {
+      "login": "jum-odoo",
+      "id": 180958525,
+      "node_id": "U_kgDOCsk1PQ",
+      "avatar_url": "https://avatars.githubusercontent.com/u/180958525?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/jum-odoo",
+      "html_url": "https://github.com/jum-odoo",
+      "followers_url": "https://api.github.com/users/jum-odoo/followers",
+      "following_url": "https://api.github.com/users/jum-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/jum-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/jum-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/jum-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/jum-odoo/orgs",
+      "repos_url": "https://api.github.com/users/jum-odoo/repos",
+      "events_url": "https://api.github.com/users/jum-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/jum-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "jum-odoo",
+      "id": 180958525,
+      "node_id": "U_kgDOCsk1PQ",
+      "avatar_url": "https://avatars.githubusercontent.com/u/180958525?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/jum-odoo",
+      "html_url": "https://github.com/jum-odoo",
+      "followers_url": "https://api.github.com/users/jum-odoo/followers",
+      "following_url": "https://api.github.com/users/jum-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/jum-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/jum-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/jum-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/jum-odoo/orgs",
+      "repos_url": "https://api.github.com/users/jum-odoo/repos",
+      "events_url": "https://api.github.com/users/jum-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/jum-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "32a84e75eda9d3f0004545794befc1dca5aff425",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/32a84e75eda9d3f0004545794befc1dca5aff425",
+        "html_url": "https://github.com/odoo/odoo/commit/32a84e75eda9d3f0004545794befc1dca5aff425"
+      }
+    ],
+    "stats": {
+      "total": 768,
+      "additions": 476,
+      "deletions": 292
+    },
+    "files": [
+      {
+        "sha": "2d2c9493af898d5119150dc2cb272ee904de4a1a",
+        "filename": "addons/html_editor/static/tests/link/popover.test.js",
+        "status": "modified",
+        "additions": 7,
+        "deletions": 11,
+        "changes": 18,
+        "blob_url": "https://github.com/odoo/odoo/blob/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fhtml_editor%2Fstatic%2Ftests%2Flink%2Fpopover.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fhtml_editor%2Fstatic%2Ftests%2Flink%2Fpopover.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_editor%2Fstatic%2Ftests%2Flink%2Fpopover.test.js?ref=54698f4d2854ca1777ec62a6464004b5b88a4dc5",
+        "patch": "@@ -1204,7 +1204,7 @@ describe(\"link preview\", () => {\n             description: markup(\"Test description\"),\n             link_preview_name: \"Task name | Project name\",\n         }));\n-        onRpc(\"/odoo/project/1/tasks/8\", () => \"\", { pure: true });\n+        onRpc(\"/odoo/project/1/tasks/8\", () => \"\");\n         const { editor, el } = await setupEditor(`<p>[]<br></p>`, {\n             config: {\n                 allowStripDomain: false,\n@@ -1258,7 +1258,7 @@ describe(\"link preview\", () => {\n                 link_preview_name: \"Task name | Project name\",\n             };\n         });\n-        onRpc(\"/odoo/cachetest/8\", () => \"\", { pure: true });\n+        onRpc(\"/odoo/cachetest/8\", () => \"\");\n         const { editor } = await setupEditor(`<p>abc[]</p>`);\n         await insertText(editor, \"/link\");\n         await animationFrame();\n@@ -1299,15 +1299,11 @@ describe(\"link preview\", () => {\n         });\n \n         const currentProtocol = window.location.protocol;\n-        onRpc(\n-            \"/odoo/cachetest/8\",\n-            (request) => {\n-                const urlProtocol = new URL(request.url).protocol;\n-                expect(urlProtocol).toBe(currentProtocol);\n-                return \"\";\n-            },\n-            { pure: true }\n-        );\n+        onRpc(\"/odoo/cachetest/8\", (request) => {\n+            const urlProtocol = new URL(request.url).protocol;\n+            expect(urlProtocol).toBe(currentProtocol);\n+            return \"\";\n+        });\n \n         const { editor } = await setupEditor(`<p>abc[]</p>`, {\n             config: {"
+      },
+      {
+        "sha": "8dd61d6dc52bbebc6996167760e7d467dea3b2c2",
+        "filename": "addons/point_of_sale/static/tests/unit/services/pos_service.test.js",
+        "status": "modified",
+        "additions": 8,
+        "deletions": 20,
+        "changes": 28,
+        "blob_url": "https://github.com/odoo/odoo/blob/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fpoint_of_sale%2Fstatic%2Ftests%2Funit%2Fservices%2Fpos_service.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fpoint_of_sale%2Fstatic%2Ftests%2Funit%2Fservices%2Fpos_service.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fpoint_of_sale%2Fstatic%2Ftests%2Funit%2Fservices%2Fpos_service.test.js?ref=54698f4d2854ca1777ec62a6464004b5b88a4dc5",
+        "patch": "@@ -435,16 +435,10 @@ describe(\"pos_store.js\", () => {\n         }\n \n         test(\"correctly cached\", async () => {\n-            onRpc(\n-                getCompanyLogo256Url(\"<int:id>\"),\n-                async (request, { id }) => {\n-                    expect.step(`Company logo ${id} fetched`);\n-                    return `Company logo ${id}`;\n-                },\n-                {\n-                    pure: true,\n-                }\n-            );\n+            onRpc(getCompanyLogo256Url(\"<int:id>\"), async (request, { id }) => {\n+                expect.step(`Company logo ${id} fetched`);\n+                return `Company logo ${id}`;\n+            });\n             const store = await setupPosEnv();\n             const companyId = store.company.id;\n             expect.verifySteps([`Company logo ${companyId} fetched`]);\n@@ -454,16 +448,10 @@ describe(\"pos_store.js\", () => {\n         });\n \n         test(\"fetch failed\", async () => {\n-            onRpc(\n-                getCompanyLogo256Url(\"<int:id>\"),\n-                async (request, { id }) => {\n-                    expect.step(`Company logo ${id} fetched`);\n-                    throw new Error(\"Fetch failed\");\n-                },\n-                {\n-                    pure: true,\n-                }\n-            );\n+            onRpc(getCompanyLogo256Url(\"<int:id>\"), async (request, { id }) => {\n+                expect.step(`Company logo ${id} fetched`);\n+                throw new Error(\"Fetch failed\");\n+            });\n             const store = await setupPosEnv();\n             const companyId = store.company.id;\n             expect.verifySteps([`Company logo ${companyId} fetched`]);"
+      },
+      {
+        "sha": "ae9337f5886026dbe658213be69f522e7326b2a3",
+        "filename": "addons/spreadsheet/static/tests/helpers/data.js",
+        "status": "modified",
+        "additions": 4,
+        "deletions": 7,
+        "changes": 11,
+        "blob_url": "https://github.com/odoo/odoo/blob/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fspreadsheet%2Fstatic%2Ftests%2Fhelpers%2Fdata.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fspreadsheet%2Fstatic%2Ftests%2Fhelpers%2Fdata.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fspreadsheet%2Fstatic%2Ftests%2Fhelpers%2Fdata.js?ref=54698f4d2854ca1777ec62a6464004b5b88a4dc5",
+        "patch": "@@ -122,13 +122,10 @@ export function getBasicListArchs() {\n     };\n }\n \n-function mockSpreadsheetDataController(request) {\n-    const parts = request.url.split(\"/\");\n-    const resModel = parts.at(-2);\n-    const resId = parseInt(parts.at(-1));\n-    const record = this.env[resModel].search_read([[\"id\", \"=\", resId]])[0];\n+function mockSpreadsheetDataController(_request, { res_model, res_id }) {\n+    const [record] = this.env[res_model].search_read([[\"id\", \"=\", parseInt(res_id)]]);\n     if (!record) {\n-        const error = new RPCError(`Spreadsheet ${resId} does not exist`);\n+        const error = new RPCError(`Spreadsheet ${res_id} does not exist`);\n         error.data = {};\n         throw error;\n     }\n@@ -141,7 +138,7 @@ function mockSpreadsheetDataController(request) {\n     };\n }\n \n-onRpc(\"/spreadsheet/data/*\", mockSpreadsheetDataController, { pure: true });\n+onRpc(\"/spreadsheet/data/<string:res_model>/<int:res_id>\", mockSpreadsheetDataController);\n \n export function defineSpreadsheetModels() {\n     defineModels(SpreadsheetModels);"
+      },
+      {
+        "sha": "11b2d5d59802ca1fd3caf3d4ebad12aa6df191d9",
+        "filename": "addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action.test.js",
+        "status": "modified",
+        "additions": 5,
+        "deletions": 9,
+        "changes": 14,
+        "blob_url": "https://github.com/odoo/odoo/blob/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fspreadsheet_dashboard%2Fstatic%2Ftests%2Fdashboard%2Fdashboard_action.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fspreadsheet_dashboard%2Fstatic%2Ftests%2Fdashboard%2Fdashboard_action.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fspreadsheet_dashboard%2Fstatic%2Ftests%2Fdashboard%2Fdashboard_action.test.js?ref=54698f4d2854ca1777ec62a6464004b5b88a4dc5",
+        "patch": "@@ -138,15 +138,11 @@ test(\"display no dashboard message\", async () => {\n \n test(\"display error message\", async () => {\n     expect.errors(1);\n-    onRpc(\n-        \"/spreadsheet/dashboard/data/2\",\n-        () => {\n-            const error = new RPCError();\n-            error.data = {};\n-            throw error;\n-        },\n-        { pure: true }\n-    );\n+    onRpc(\"/spreadsheet/dashboard/data/2\", () => {\n+        const error = new RPCError();\n+        error.data = {};\n+        throw error;\n+    });\n     await createSpreadsheetDashboard();\n     expect(\".o-spreadsheet\").toHaveCount(1, { message: \"It should display the spreadsheet\" });\n     await contains(\".o_search_panel li:eq(1)\").click();"
+      },
+      {
+        "sha": "d13e4289a768c8c1d2157f281e93a46bd4b6812e",
+        "filename": "addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_loader.test.js",
+        "status": "modified",
+        "additions": 15,
+        "deletions": 23,
+        "changes": 38,
+        "blob_url": "https://github.com/odoo/odoo/blob/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fspreadsheet_dashboard%2Fstatic%2Ftests%2Fdashboard%2Fdashboard_loader.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fspreadsheet_dashboard%2Fstatic%2Ftests%2Fdashboard%2Fdashboard_loader.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fspreadsheet_dashboard%2Fstatic%2Ftests%2Fdashboard%2Fdashboard_loader.test.js?ref=54698f4d2854ca1777ec62a6464004b5b88a4dc5",
+        "patch": "@@ -186,15 +186,11 @@ test(\"load multiple spreadsheets\", async () => {\n });\n \n test(\"load spreadsheet data with error\", async () => {\n-    onRpc(\n-        \"/spreadsheet/dashboard/data/*\",\n-        () => {\n-            const error = new RPCError();\n-            error.data = { message: \"Bip\" };\n-            throw error;\n-        },\n-        { pure: true }\n-    );\n+    onRpc(\"/spreadsheet/dashboard/data/*\", () => {\n+        const error = new RPCError();\n+        error.data = { message: \"Bip\" };\n+        throw error;\n+    });\n     const loader = await createDashboardLoader();\n     await loader.load();\n     const result = loader.getDashboard(3);\n@@ -271,20 +267,16 @@ test(\"Model is in dashboard mode [2]\", async () => {\n });\n \n test(\"default currency format\", async () => {\n-    onRpc(\n-        \"/spreadsheet/dashboard/data/*\",\n-        () => ({\n-            data: {},\n-            revisions: [],\n-            default_currency: {\n-                code: \"Odoo\",\n-                symbol: \"\u03b8\",\n-                position: \"after\",\n-                decimalPlaces: 2,\n-            },\n-        }),\n-        { pure: true }\n-    );\n+    onRpc(\"/spreadsheet/dashboard/data/*\", () => ({\n+        data: {},\n+        revisions: [],\n+        default_currency: {\n+            code: \"Odoo\",\n+            symbol: \"\u03b8\",\n+            position: \"after\",\n+            decimalPlaces: 2,\n+        },\n+    }));\n     const loader = await createDashboardLoader();\n     await loader.load();\n     const result = loader.getDashboard(3);"
+      },
+      {
+        "sha": "ee44d9f409bfea6c27f19689c4b541985970e905",
+        "filename": "addons/spreadsheet_dashboard/static/tests/helpers/data.js",
+        "status": "modified",
+        "additions": 4,
+        "deletions": 6,
+        "changes": 10,
+        "blob_url": "https://github.com/odoo/odoo/blob/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fspreadsheet_dashboard%2Fstatic%2Ftests%2Fhelpers%2Fdata.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fspreadsheet_dashboard%2Fstatic%2Ftests%2Fhelpers%2Fdata.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fspreadsheet_dashboard%2Fstatic%2Ftests%2Fhelpers%2Fdata.js?ref=54698f4d2854ca1777ec62a6464004b5b88a4dc5",
+        "patch": "@@ -69,12 +69,10 @@ export class SpreadsheetDashboardGroup extends models.Model {\n     ];\n }\n \n-function mockDashboardDataController(request) {\n-    const parts = request.url.split(\"/\");\n-    const resId = parseInt(parts.at(-1));\n-    const record = this.env[\"spreadsheet.dashboard\"].search_read([[\"id\", \"=\", resId]])[0];\n+function mockDashboardDataController(_request, { res_id }) {\n+    const [record] = this.env[\"spreadsheet.dashboard\"].search_read([[\"id\", \"=\", parseInt(res_id)]]);\n     if (!record) {\n-        const error = new RPCError(`Dashboard ${resId} does not exist`);\n+        const error = new RPCError(`Dashboard ${res_id} does not exist`);\n         error.data = {};\n         throw error;\n     }\n@@ -84,7 +82,7 @@ function mockDashboardDataController(request) {\n     };\n }\n \n-onRpc(\"/spreadsheet/dashboard/data/*\", mockDashboardDataController, { pure: true });\n+onRpc(\"/spreadsheet/dashboard/data/<int:res_id>\", mockDashboardDataController);\n \n export function defineSpreadsheetDashboardModels() {\n     const SpreadsheetDashboardModels = [SpreadsheetDashboard, SpreadsheetDashboardGroup];"
+      },
+      {
+        "sha": "ed135df4fa841a9b20b601f629dc14ac6c6bced0",
+        "filename": "addons/web/static/lib/hoot/core/logger.js",
+        "status": "modified",
+        "additions": 26,
+        "deletions": 10,
+        "changes": 36,
+        "blob_url": "https://github.com/odoo/odoo/blob/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fweb%2Fstatic%2Flib%2Fhoot%2Fcore%2Flogger.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fweb%2Fstatic%2Flib%2Fhoot%2Fcore%2Flogger.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fweb%2Fstatic%2Flib%2Fhoot%2Fcore%2Flogger.js?ref=54698f4d2854ca1777ec62a6464004b5b88a4dc5",
+        "patch": "@@ -1,7 +1,7 @@\n /** @odoo-module */\n \n import { getColorHex } from \"../../hoot-dom/hoot_dom_utils\";\n-import { stringify } from \"../hoot_utils\";\n+import { isNil, stringify } from \"../hoot_utils\";\n import { urlParams } from \"./url\";\n \n //-----------------------------------------------------------------------------\n@@ -288,29 +288,45 @@ export function makeNetworkLogger(prefix, title) {\n     return {\n         /**\n          * Request logger: blue-ish.\n-         * @param {() => any} getData\n+         * @param {() => any[]} getData\n          */\n-        async logRequest(getData) {\n+        logRequest(getData) {\n             if (!logger.canLog(\"debug\")) {\n                 return;\n             }\n             const color = `color: #66e`;\n-            const styles = [`${color}; font-weight: bold;`, color];\n-            $groupCollapsed(`-> %c${prefix}#${id}%c<${title}>`, ...styles, await getData());\n-            $trace(\"request trace\");\n+            const args = [`${color}; font-weight: bold;`, color];\n+            const [dataHeader, ...otherData] = getData();\n+            if (!isNil(dataHeader)) {\n+                args.push(dataHeader);\n+            }\n+            $groupCollapsed(`-> %c${prefix}#${id}%c<${title}>`, ...args);\n+            for (const data of otherData) {\n+                $log(data);\n+            }\n+            $trace(\"Request trace:\");\n             $groupEnd();\n         },\n         /**\n          * Response logger: orange.\n-         * @param {() => any} getData\n+         * @param {() => any[]} getData\n          */\n-        async logResponse(getData) {\n+        logResponse(getData) {\n             if (!logger.canLog(\"debug\")) {\n                 return;\n             }\n             const color = `color: #f80`;\n-            const styles = [`${color}; font-weight: bold;`, color];\n-            $log(`<- %c${prefix}#${id}%c<${title}>`, ...styles, await getData());\n+            const args = [`${color}; font-weight: bold;`, color];\n+            const [dataHeader, ...otherData] = getData();\n+            if (!isNil(dataHeader)) {\n+                args.push(dataHeader);\n+            }\n+            $groupCollapsed(`<- %c${prefix}#${id}%c<${title}>`, ...args);\n+            for (const data of otherData) {\n+                $log(data);\n+            }\n+            $trace(\"Response trace:\");\n+            $groupEnd();\n         },\n     };\n }"
+      },
+      {
+        "sha": "66ff36d69854733e4665f93d6c6104ee053906e2",
+        "filename": "addons/web/static/lib/hoot/hoot_utils.js",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 0,
+        "changes": 1,
+        "blob_url": "https://github.com/odoo/odoo/blob/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fweb%2Fstatic%2Flib%2Fhoot%2Fhoot_utils.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fweb%2Fstatic%2Flib%2Fhoot%2Fhoot_utils.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fweb%2Fstatic%2Flib%2Fhoot%2Fhoot_utils.js?ref=54698f4d2854ca1777ec62a6464004b5b88a4dc5",
+        "patch": "@@ -2038,6 +2038,7 @@ export const INCLUDE_LEVEL = {\n };\n \n export const MIME_TYPE = {\n+    formData: \"multipart/form-data\",\n     blob: \"application/octet-stream\",\n     json: \"application/json\",\n     text: \"text/plain\","
+      },
+      {
+        "sha": "3ad6093f8270c4b58275a2f3824a4abb22732614",
+        "filename": "addons/web/static/lib/hoot/mock/network.js",
+        "status": "modified",
+        "additions": 122,
+        "deletions": 47,
+        "changes": 169,
+        "blob_url": "https://github.com/odoo/odoo/blob/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fweb%2Fstatic%2Flib%2Fhoot%2Fmock%2Fnetwork.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fweb%2Fstatic%2Flib%2Fhoot%2Fmock%2Fnetwork.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fweb%2Fstatic%2Flib%2Fhoot%2Fmock%2Fnetwork.js?ref=54698f4d2854ca1777ec62a6464004b5b88a4dc5",
+        "patch": "@@ -7,7 +7,7 @@ import {\n } from \"@web/../lib/hoot-dom/helpers/time\";\n import { isInstanceOf } from \"../../hoot-dom/hoot_dom_utils\";\n import { makeNetworkLogger } from \"../core/logger\";\n-import { ensureArray, MIME_TYPE, MockEventTarget } from \"../hoot_utils\";\n+import { ensureArray, isNil, MIME_TYPE, MockEventTarget } from \"../hoot_utils\";\n import { getSyncValue, MockBlob, setSyncValue } from \"./sync_values\";\n \n /**\n@@ -32,15 +32,22 @@ const {\n     document,\n     fetch,\n     Headers,\n+    Map,\n     Math: { floor: $floor, max: $max, min: $min, random: $random },\n-    Object: { assign: $assign, create: $create, entries: $entries },\n+    Object: {\n+        assign: $assign,\n+        create: $create,\n+        defineProperty: $defineProperty,\n+        entries: $entries,\n+    },\n     ProgressEvent,\n     Request,\n     Response,\n     Set,\n     URL,\n     WebSocket,\n } = globalThis;\n+const { parse: $parse, stringify: $stringify } = globalThis.JSON;\n \n //-----------------------------------------------------------------------------\n // Internal\n@@ -86,6 +93,34 @@ async function dispatchMessage(target, data, transfer) {\n     }\n }\n \n+/**\n+ *\n+ * @param {{ headers?: HeadersInit } | undefined} object\n+ * @param {string} content\n+ */\n+function getHeaders(object, content) {\n+    /** @type {Headers} */\n+    let headers;\n+    if (isInstanceOf(object?.headers, Headers)) {\n+        headers = object.headers;\n+    } else {\n+        headers = new Headers(object?.headers);\n+    }\n+\n+    if (content && !headers.has(HEADER.contentType)) {\n+        if (typeof content === \"string\") {\n+            headers.set(HEADER.contentType, MIME_TYPE.text);\n+        } else if (isInstanceOf(content, Blob)) {\n+            headers.set(HEADER.contentType, MIME_TYPE.blob);\n+        } else if (isInstanceOf(content, FormData)) {\n+            headers.set(HEADER.contentType, MIME_TYPE.formData);\n+        } else {\n+            headers.set(HEADER.contentType, MIME_TYPE.json);\n+        }\n+    }\n+    return headers;\n+}\n+\n /**\n  * @param {...NetworkInstance} instances\n  */\n@@ -111,6 +146,37 @@ function markOpen(instance) {\n     return instance;\n }\n \n+/**\n+ * Helper used to parse JSON-RPC request/response parameters, and to make their\n+ * \"jsonrpc\", \"id\" and \"method\" properties non-enumerable, as to make them more\n+ * inconspicuous in console logs, effectively highlighting the 'params' or 'result'\n+ * keys.\n+ *\n+ * @param {string} stringParams\n+ */\n+function parseJsonRpcParams(stringParams) {\n+    const jsonParams = $assign($create(null), $parse(stringParams));\n+    if (jsonParams && \"jsonrpc\" in jsonParams) {\n+        $defineProperty(jsonParams, \"jsonrpc\", {\n+            value: jsonParams.jsonrpc,\n+            enumerable: false,\n+        });\n+        if (\"id\" in jsonParams) {\n+            $defineProperty(jsonParams, \"id\", {\n+                value: jsonParams.id,\n+                enumerable: false,\n+            });\n+        }\n+        if (\"method\" in jsonParams) {\n+            $defineProperty(jsonParams, \"method\", {\n+                value: jsonParams.method,\n+                enumerable: false,\n+            });\n+        }\n+    }\n+    return jsonParams;\n+}\n+\n /**\n  * @param {number} min\n  * @param {number} [max]\n@@ -201,87 +267,96 @@ export async function mockedFetch(input, init) {\n     if (!mockFetchFn) {\n         throw new Error(\"Can't make a request when fetch is not mocked\");\n     }\n-    init ||= {};\n-    const method = init.method?.toUpperCase() || (init.body ? \"POST\" : \"GET\");\n-    const { logRequest, logResponse } = makeNetworkLogger(method, input);\n-\n     const controller = markOpen(new AbortController());\n-    init.signal = controller.signal;\n \n-    logRequest(() => (typeof init.body === \"string\" ? JSON.parse(init.body) : init));\n+    init = { ...init };\n+    init.headers = getHeaders(init, init.body);\n+    init.method = init.method?.toUpperCase() || (isNil(init.body) ? \"GET\" : \"POST\");\n+\n+    // Allows 'signal' to not be logged with 'logRequest'.\n+    $defineProperty(init, \"signal\", {\n+        value: controller.signal,\n+        enumerable: false,\n+    });\n+\n+    const { logRequest, logResponse } = makeNetworkLogger(init.method, input);\n+\n+    logRequest(() => {\n+        const readableInit = {\n+            ...init,\n+            // Make headers easier to read in the console\n+            headers: new Map(init.headers),\n+        };\n+        if (init.headers.get(HEADER.contentType) === MIME_TYPE.json) {\n+            return [parseJsonRpcParams(init.body), readableInit];\n+        } else {\n+            return [init.body, readableInit];\n+        }\n+    });\n \n     if (getNetworkDelay) {\n         await getNetworkDelay();\n     }\n \n+    // keep separate from 'error', as it can be null or undefined even though the\n+    // callback has thrown an error.\n     let failed = false;\n-    let result;\n+    let error, result;\n     try {\n         result = await mockFetchFn(input, init);\n     } catch (err) {\n-        result = err;\n         failed = true;\n+        error = err;\n     }\n     if (isOpen(controller)) {\n         markClosed(controller);\n     } else {\n         return ENDLESS_PROMISE;\n     }\n     if (failed) {\n-        throw result;\n+        throw error;\n     }\n \n-    /** @type {Headers} */\n-    let headers;\n-    if (result && isInstanceOf(result.headers, Headers)) {\n-        headers = result.headers;\n-    } else if (isInstanceOf(init.headers, Headers)) {\n-        headers = init.headers;\n-    } else {\n-        headers = new Headers(init.headers);\n-    }\n-\n-    let contentType = headers.get(HEADER.contentType);\n+    // Result can be a request or the final request value\n+    const responseHeaders = getHeaders(result, result);\n \n     if (result instanceof MockResponse) {\n         // Mocked response\n-        logResponse(async () => {\n+        logResponse(() => {\n             const textValue = getSyncValue(result);\n-            return contentType === MIME_TYPE.json ? JSON.parse(textValue) : textValue;\n+            return [\n+                responseHeaders.get(HEADER.contentType) === MIME_TYPE.json\n+                    ? parseJsonRpcParams(textValue)\n+                    : textValue,\n+                result,\n+            ];\n         });\n         return result;\n     }\n \n     if (isInstanceOf(result, Response)) {\n         // Actual fetch\n-        logResponse(() => \"(go to network tab for request content)\");\n+        logResponse(() => [\"(go to network tab for request content)\", result]);\n         return result;\n     }\n \n     // Not a response object:\n     // Determine the return type based on:\n     // - the content type header\n     // - or the type of the returned value\n-    if (!contentType) {\n-        if (typeof result === \"string\") {\n-            contentType = MIME_TYPE.text;\n-        } else if (isInstanceOf(result, Blob)) {\n-            contentType = MIME_TYPE.blob;\n-        } else {\n-            contentType = MIME_TYPE.json;\n-        }\n-    }\n \n-    if (contentType === MIME_TYPE.json) {\n+    if (responseHeaders.get(HEADER.contentType) === MIME_TYPE.json) {\n         // JSON response\n-        const strBody = JSON.stringify(result ?? null);\n-        logResponse(() => result);\n-        return new MockResponse(strBody, { [HEADER.contentType]: contentType });\n+        const strBody = $stringify(result ?? null);\n+        const response = new MockResponse(strBody, { headers: responseHeaders });\n+        logResponse(() => [parseJsonRpcParams(strBody), response]);\n+        return response;\n     }\n \n     // Any other type (blob / text)\n-    logResponse(() => result);\n-    return new MockResponse(result, { [HEADER.contentType]: contentType });\n+    const response = new MockResponse(result, { headers: responseHeaders });\n+    logResponse(() => [result, response]);\n+    return response;\n }\n \n /**\n@@ -669,7 +744,7 @@ export class MockRequest extends Request {\n     }\n \n     async json() {\n-        return JSON.parse(getSyncValue(this));\n+        return $parse(getSyncValue(this));\n     }\n \n     async text() {\n@@ -697,7 +772,7 @@ export class MockResponse extends Response {\n     }\n \n     async json() {\n-        return JSON.parse(getSyncValue(this));\n+        return $parse(getSyncValue(this));\n     }\n \n     async text() {\n@@ -788,7 +863,7 @@ export class MockWebSocket extends MockEventTarget {\n             markOpen(this);\n \n             this._readyState = WebSocket.OPEN;\n-            this._logger.logRequest(() => \"connection open\");\n+            this._logger.logRequest(() => [\"connection open\"]);\n \n             this.dispatchEvent(new Event(\"open\"));\n         });\n@@ -808,7 +883,7 @@ export class MockWebSocket extends MockEventTarget {\n         if (this.readyState !== WebSocket.OPEN) {\n             return;\n         }\n-        this._logger.logRequest(() => data);\n+        this._logger.logRequest(() => [data]);\n         dispatchMessage(this._serverWs, data);\n     }\n }\n@@ -936,8 +1011,8 @@ export class MockXMLHttpRequest extends MockEventTarget {\n                 this._response = await response.text();\n             }\n             this.dispatchEvent(new ProgressEvent(\"load\"));\n-        } catch (error) {\n-            this.dispatchEvent(new ProgressEvent(\"error\", { error }));\n+        } catch {\n+            this.dispatchEvent(new ProgressEvent(\"error\"));\n         }\n \n         markClosed(this);\n@@ -1001,7 +1076,7 @@ export class ServerWebSocket extends MockEventTarget {\n \n         this.addEventListener(\"close\", (ev) => {\n             dispatchClose(this._clientWs, ev);\n-            this._logger.logResponse(() => \"connection closed\");\n+            this._logger.logResponse(() => [\"connection closed\", ev]);\n         });\n \n         mockWebSocketConnection?.(this);"
+      },
+      {
+        "sha": "8affafdb2039f1d0e46fd6b98faa45fa1402c0a2",
+        "filename": "addons/web/static/lib/hoot/tests/hoot-dom/events.test.js",
+        "status": "modified",
+        "additions": 3,
+        "deletions": 2,
+        "changes": 5,
+        "blob_url": "https://github.com/odoo/odoo/blob/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fweb%2Fstatic%2Flib%2Fhoot%2Ftests%2Fhoot-dom%2Fevents.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fweb%2Fstatic%2Flib%2Fhoot%2Ftests%2Fhoot-dom%2Fevents.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fweb%2Fstatic%2Flib%2Fhoot%2Ftests%2Fhoot-dom%2Fevents.test.js?ref=54698f4d2854ca1777ec62a6464004b5b88a4dc5",
+        "patch": "@@ -1823,10 +1823,11 @@ describe(parseUrl(import.meta.url), () => {\n             </form>\n         `);\n \n-        mockFetch((url, { body, method }) => {\n+        mockFetch((url, { body, headers, method }) => {\n             expect.step(new URL(url).pathname);\n \n-            expect(method).toBe(\"post\");\n+            expect(method).toBe(\"POST\");\n+            expect(headers).toEqual(new Headers([[\"Content-Type\", \"multipart/form-data\"]]));\n             expect(body).toBeInstanceOf(FormData);\n             expect(body.get(\"csrf_token\")).toBe(\"CSRF_TOKEN_VALUE\");\n             expect(body.get(\"name\")).toBe(\"Pierre\");"
+      },
+      {
+        "sha": "04d565a373d75584e7e3fc2971c33f9006e055e9",
+        "filename": "addons/web/static/tests/_framework/mock_server/mock_fields.js",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fweb%2Fstatic%2Ftests%2F_framework%2Fmock_server%2Fmock_fields.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fweb%2Fstatic%2Ftests%2F_framework%2Fmock_server%2Fmock_fields.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fweb%2Fstatic%2Ftests%2F_framework%2Fmock_server%2Fmock_fields.js?ref=54698f4d2854ca1777ec62a6464004b5b88a4dc5",
+        "patch": "@@ -70,7 +70,7 @@ function makeFieldGenerator(type, { aggregator, requiredKeys = [] } = {}) {\n             for (const key of requiredKeys) {\n                 if (!(key in field)) {\n                     throw new MockServerError(\n-                        `missing key \"${key}\" in ${type || \"generic\"} field definition`\n+                        `Missing key \"${key}\" in ${type || \"generic\"} field definition`\n                     );\n                 }\n             }"
+      },
+      {
+        "sha": "7752f93d0d17f3874fc26e658f3cd566f1c29b7a",
+        "filename": "addons/web/static/tests/_framework/mock_server/mock_model.js",
+        "status": "modified",
+        "additions": 15,
+        "deletions": 18,
+        "changes": 33,
+        "blob_url": "https://github.com/odoo/odoo/blob/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fweb%2Fstatic%2Ftests%2F_framework%2Fmock_server%2Fmock_model.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fweb%2Fstatic%2Ftests%2F_framework%2Fmock_server%2Fmock_model.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fweb%2Fstatic%2Ftests%2F_framework%2Fmock_server%2Fmock_model.js?ref=54698f4d2854ca1777ec62a6464004b5b88a4dc5",
+        "patch": "@@ -166,7 +166,7 @@ function createRawInstance(ModelClass) {\n  * @param {string} fieldName\n  */\n function fieldNotFoundError(modelName, fieldName, consequence) {\n-    let message = `cannot find a definition for field \"${fieldName}\" in model \"${modelName}\"`;\n+    let message = `Cannot find a definition for field \"${fieldName}\" in model \"${modelName}\"`;\n     if (consequence) {\n         message += `: ${consequence}`;\n     }\n@@ -536,9 +536,6 @@ function isValidFieldValue(record, fieldDef) {\n         case \"text\": {\n             return typeof value === \"string\";\n         }\n-        case \"json\": {\n-            return typeof value === \"string\" || typeof value === \"object\";\n-        }\n         case \"boolean\": {\n             return typeof value === \"boolean\";\n         }\n@@ -781,7 +778,7 @@ function orderByField(model, orderBy, records) {\n         } else {\n             if (![\"boolean\", \"number\", \"string\"].includes(typeof v1) || typeof v1 !== typeof v2) {\n                 throw new MockServerError(\n-                    `cannot order by field \"${fieldNameSpec}\" in model \"${\n+                    `Cannot order by field \"${fieldNameSpec}\" in model \"${\n                         model._name\n                     }\": values must be of the same primitive type (got ${typeof v1} and ${typeof v2})`\n                 );\n@@ -918,7 +915,7 @@ function parseView(model, params) {\n     for (const [name, node] of Object.entries(groupbyNodes)) {\n         const field = fields[name];\n         if (!isM2OField(field)) {\n-            throw new MockServerError(\"cannot group: 'groupby' can only target many2one fields\");\n+            throw new MockServerError(\"Cannot group: 'groupby' can only target many2one fields\");\n         }\n         field.views = {};\n         const coModel = getRelation(field);\n@@ -1242,7 +1239,7 @@ function updateComodelRelationalFields(model, record, originalRecord) {\n function validateFieldDefinition(fieldName, fieldDef) {\n     if (fieldDef[S_FIELD] && fieldDef.name) {\n         throw new MockServerError(\n-            `cannot set the name of field \"${fieldName}\" from its definition: got \"${fieldDef.name}\"`\n+            `Cannot set the name of field \"${fieldName}\" from its definition: got \"${fieldDef.name}\"`\n         );\n     }\n     delete fieldDef[S_FIELD];\n@@ -1255,7 +1252,7 @@ function validateFieldDefinition(fieldName, fieldDef) {\n  * @param {number | false} viewId\n  */\n function viewNotFoundError(modelName, viewType, viewId, consequence) {\n-    let message = `cannot find an arch for view \"${viewType}\" with ID ${JSON.stringify(\n+    let message = `Cannot find an arch for view \"${viewType}\" with ID ${JSON.stringify(\n         viewId\n     )} in model \"${modelName}\"`;\n     if (consequence) {\n@@ -1740,7 +1737,7 @@ export class Model extends Array {\n         const ids = [];\n         for (const values of allValues) {\n             if (\"id\" in values) {\n-                throw new MockServerError(`cannot create a record with a given ID value`);\n+                throw new MockServerError(`Cannot create a record with a given ID value`);\n             }\n             const record = { id: this._getNextId() };\n             ids.push(record.id);\n@@ -1782,7 +1779,7 @@ export class Model extends Array {\n             } else {\n                 if (!(field.type in DEFAULT_FIELD_VALUES)) {\n                     throw new MockServerError(\n-                        `missing default value for field type \"${field.type}\"`\n+                        `Missing default value for field type \"${field.type}\"`\n                     );\n                 }\n                 result[fieldName] = DEFAULT_FIELD_VALUES[field.type]();\n@@ -1847,10 +1844,10 @@ export class Model extends Array {\n             }\n             const [, fieldName, func] = fspec.match(R_AGGREGATE_FUNCTION);\n             if (func && !(func in AGGREGATOR_FUNCTIONS)) {\n-                throw new MockServerError(`invalid aggregation function \"${func}\"`);\n+                throw new MockServerError(`Invalid aggregation function \"${func}\"`);\n             }\n             if (!this._fields[fieldName]) {\n-                throw new MockServerError(`invalid field in \"${fspec}\"`);\n+                throw new MockServerError(`Invalid field in \"${fspec}\"`);\n             }\n             return { fieldName, func, name: fspec };\n         });\n@@ -2314,7 +2311,7 @@ export class Model extends Array {\n         const supportedTypes = [\"many2one\", \"selection\"];\n         if (!supportedTypes.includes(field.type)) {\n             throw new MockServerError(\n-                `only category types ${supportedTypes.join(\" and \")} are supported, got \"${\n+                `Only category types ${supportedTypes.join(\" and \")} are supported, got \"${\n                     field.type\n                 }\"`\n             );\n@@ -2455,7 +2452,7 @@ export class Model extends Array {\n         const supportedTypes = [\"many2many\", \"many2one\", \"selection\"];\n         if (!supportedTypes.includes(field.type)) {\n             throw new MockServerError(\n-                `only filter types ${supportedTypes} are supported, got \"${field.type}\"`\n+                `Only filter types ${supportedTypes} are supported, got \"${field.type}\"`\n             );\n         }\n         let modelDomain = kwargs.search_domain || [];\n@@ -3073,7 +3070,7 @@ export class Model extends Array {\n                 const fieldDef = this._fields[fieldName];\n                 if (!isValidFieldValue(record, fieldDef)) {\n                     throw new MockServerError(\n-                        `invalid value for field \"${fieldName}\" on ${getRecordQualifier(\n+                        `Invalid value for field \"${fieldName}\" on ${getRecordQualifier(\n                             record\n                         )} in model \"${this._name}\": expected \"${fieldDef.type}\" and got: ${\n                             record[fieldName]\n@@ -3367,7 +3364,7 @@ export class Model extends Array {\n         for (const id of ids) {\n             if (!id) {\n                 throw new MockServerError(\n-                    `cannot read: falsy ID value would result in an access error on the actual server`\n+                    `Cannot read: falsy ID value would result in an access error on the actual server`\n                 );\n             }\n             const record = modelMap[this._name][id];\n@@ -3601,7 +3598,7 @@ export class Model extends Array {\n                         ids = [...command[2]];\n                     } else {\n                         throw new MockServerError(\n-                            `command \"${JSON.stringify(\n+                            `Command \"${JSON.stringify(\n                                 value\n                             )}\" is not supported by the MockServer on field \"${fieldName}\" in model \"${\n                                 this._name\n@@ -3619,7 +3616,7 @@ export class Model extends Array {\n                             continue;\n                         }\n                         throw new MockServerError(\n-                            `invalid ID \"${JSON.stringify(\n+                            `Invalid ID \"${JSON.stringify(\n                                 value\n                             )}\" for a many2one on field \"${fieldName}\" in model \"${this._name}\"`\n                         );"
+      },
+      {
+        "sha": "86a58a52d0fbb96846e3de1291334647b8567fe1",
+        "filename": "addons/web/static/tests/_framework/mock_server/mock_server.js",
+        "status": "modified",
+        "additions": 98,
+        "deletions": 53,
+        "changes": 151,
+        "blob_url": "https://github.com/odoo/odoo/blob/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fweb%2Fstatic%2Ftests%2F_framework%2Fmock_server%2Fmock_server.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fweb%2Fstatic%2Ftests%2F_framework%2Fmock_server%2Fmock_server.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fweb%2Fstatic%2Ftests%2F_framework%2Fmock_server%2Fmock_server.js?ref=54698f4d2854ca1777ec62a6464004b5b88a4dc5",
+        "patch": "@@ -8,7 +8,7 @@ import {\n     mockWebSocket,\n     registerDebugInfo,\n } from \"@odoo/hoot\";\n-import { rpc, RPCError } from \"@web/core/network/rpc\";\n+import { makeErrorFromResponse, rpc, RPCError } from \"@web/core/network/rpc\";\n import { ensureArray, isIterable } from \"@web/core/utils/arrays\";\n import { isObject } from \"@web/core/utils/objects\";\n import { RPCCache } from \"@web/core/network/rpc_cache\";\n@@ -190,6 +190,27 @@ function getCurrentMockServer() {\n     return mockServers.get(test.run);\n }\n \n+/**\n+ * @param {RequestInit} init\n+ */\n+function getJsonRpcParams({ headers, body }) {\n+    if (headers.get(\"Content-Type\") !== \"application/json\" || typeof body !== \"string\") {\n+        return null;\n+    }\n+    try {\n+        const parsedParams = JSON.parse(body);\n+        return {\n+            id: parsedParams.id,\n+            jsonrpc: parsedParams.jsonrpc,\n+        };\n+    } catch {\n+        return {\n+            id: nextJsonRpcId++,\n+            jsonrpc: \"2.0\",\n+        };\n+    }\n+}\n+\n /**\n  * @param {MockServer[\"_models\"]}\n  * @returns {MockServerEnvironment}\n@@ -227,12 +248,9 @@ function match(target, matchers) {\n  * @param {string} modelName\n  */\n function modelNotFoundError(modelName, consequence) {\n-    let message = `cannot find a definition for model \"${modelName}\"`;\n-    if (consequence) {\n-        message += `: ${consequence}`;\n-    }\n-    message += ` (did you forget to use \\`defineModels()?\\`)`;\n-    return new MockServerError(message);\n+    return new MockServerError(\n+        `Cannot find a definition for model \"${modelName}\": ${consequence} (did you forget to use \\`defineModels()?\\`)`\n+    );\n }\n \n /**\n@@ -355,6 +373,8 @@ const mockServers = new WeakMap();\n /** @type {WeakSet<typeof Model>} */\n const seenModels = new WeakSet();\n \n+let nextJsonRpcId = 1e9;\n+\n //-----------------------------------------------------------------------------\n // Exports\n //-----------------------------------------------------------------------------\n@@ -584,7 +604,7 @@ export class MockServer {\n             }\n         }\n \n-        throw new MockServerError(`unimplemented ORM method: ${modelName}.${method}`);\n+        throw new MockServerError(`Unimplemented ORM method: ${modelName}.${method}`);\n     }\n \n     /**\n@@ -722,7 +742,7 @@ export class MockServer {\n             default: {\n                 if (!(action.type in ACTION_TYPES)) {\n                     throw new MockServerError(\n-                        `invalid action type \"${action.type}\" in action ${id}`\n+                        `Invalid action type \"${action.type}\" in action ${id}`\n                     );\n                 }\n             }\n@@ -752,50 +772,71 @@ export class MockServer {\n      * @param {RequestInit} init\n      */\n     async _handleRequest(url, init) {\n-        const method = init?.method?.toUpperCase() || (init?.body ? \"POST\" : \"GET\");\n-        const request = new Request(url, { method, ...(init || {}) });\n-\n+        const request = new Request(url, init);\n         const route = new URL(request.url).pathname;\n+        let jsonRpcParams = getJsonRpcParams(init);\n+        let error = null;\n+        let result = null;\n+\n         const listeners = this._findRouteListeners(route);\n         if (!listeners.length) {\n-            throw new MockServerError(`unimplemented server route: ${route}`);\n-        }\n-\n-        let result = null;\n-        for (const [callback, routeParams, routeOptions] of listeners) {\n-            const { final, pure } = routeOptions;\n-            try {\n-                result = await callback.call(this, request, routeParams);\n-            } catch (error) {\n-                if (pure) {\n-                    throw error;\n-                }\n-                result = error instanceof Error ? error : new Error(error);\n-            }\n-            if (final || (result !== null && result !== undefined)) {\n-                if (pure) {\n-                    return result;\n+            error = new MockServerError(`Unimplemented server route: ${route}`);\n+        } else {\n+            for (const [callback, routeParams, { final, pure }] of listeners) {\n+                try {\n+                    const callbackResult = await callback.call(this, request, routeParams);\n+                    if (result instanceof Error) {\n+                        error = callbackResult;\n+                    } else {\n+                        result = callbackResult;\n+                    }\n+                } catch (err) {\n+                    error = err instanceof Error ? err : new Error(err);\n                 }\n-                if (result instanceof RPCError) {\n-                    return { error: result, result: null };\n+                if (final || error || (result !== null && result !== undefined)) {\n+                    if (pure) {\n+                        jsonRpcParams = null;\n+                    }\n+                    break;\n                 }\n-                if (result instanceof Error) {\n-                    return {\n-                        error: {\n-                            code: 418,\n-                            data: result,\n-                            message: result.message,\n-                            type: result.name,\n-                        },\n-                        result: null,\n+            }\n+        }\n+\n+        // We have several scenarios at this point:\n+        //\n+        // - either the request is considered to be a JSON-RPC:\n+        //  -> the response is formatted accordingly (i.e. { error, result })\n+        //\n+        // - in other cases:\n+        //  -> the response is returned or thrown as-is.\n+        if (jsonRpcParams) {\n+            if (error) {\n+                if (error instanceof RPCError) {\n+                    jsonRpcParams.error = { ...error };\n+                } else {\n+                    jsonRpcParams.error = {\n+                        ...makeErrorFromResponse({\n+                            code: 200,\n+                            data: {\n+                                name: error.name,\n+                                message: error.message,\n+                                subType: error.type,\n+                            },\n+                            message: error.message,\n+                            type: error.name,\n+                        }),\n                     };\n                 }\n-                return { error: null, result };\n+                return jsonRpcParams;\n+            } else {\n+                jsonRpcParams.result = result;\n+                return jsonRpcParams;\n             }\n+        } else if (error) {\n+            throw error;\n+        } else {\n+            return result;\n         }\n-\n-        // There was a matching controller that wasn't call_kw but it didn't return anything: treat it as JSON\n-        return { error: null, result };\n     }\n \n     /**\n@@ -875,7 +916,7 @@ export class MockServer {\n             if (model._rec_name) {\n                 if (!(model._rec_name in model._fields)) {\n                     throw new MockServerError(\n-                        `invalid _rec_name \"${model._rec_name}\" on model \"${model._name}\": field does not exist`\n+                        `Invalid _rec_name \"${model._rec_name}\" on model \"${model._name}\": field does not exist`\n                     );\n                 }\n             } else if (\"name\" in model._fields) {\n@@ -895,7 +936,7 @@ export class MockServer {\n                 Object.setPrototypeOf(Object.getPrototypeOf(model), existingModel);\n             } else if (model._name in this.env) {\n                 throw new MockServerError(\n-                    `cannot register model \"${model._name}\": a server environment property with the same name already exists`\n+                    `Cannot register model \"${model._name}\": a server environment property with the same name already exists`\n                 );\n             }\n \n@@ -956,7 +997,7 @@ export class MockServer {\n                         computeFn = model[computeFn];\n                         if (typeof computeFn !== \"function\") {\n                             throw new MockServerError(\n-                                `could not find compute function \"${computeFn}\" on model \"${model._name}\"`\n+                                `Could not find compute function \"${computeFn}\" on model \"${model._name}\"`\n                             );\n                         }\n                     }\n@@ -976,7 +1017,7 @@ export class MockServer {\n                 for (const fieldName in record) {\n                     if (!(fieldName in model._fields)) {\n                         throw new MockServerError(\n-                            `unknown field \"${fieldName}\" on ${getRecordQualifier(\n+                            `Unknown field \"${fieldName}\" on ${getRecordQualifier(\n                                 record\n                             )} in model \"${model._name}\"`\n                         );\n@@ -985,7 +1026,7 @@ export class MockServer {\n                 if (record.id) {\n                     if (seenIds.has(record.id)) {\n                         throw new MockServerError(\n-                            `duplicate ID ${record.id} in model \"${model._name}\"`\n+                            `Duplicate ID ${record.id} in model \"${model._name}\"`\n                         );\n                     }\n                     seenIds.add(record.id);\n@@ -1060,7 +1101,9 @@ export class MockServer {\n         const model = ensureArray(args.pop() || \"*\");\n \n         if (typeof callback !== \"function\") {\n-            throw new Error(`onRpc: expected callback to be a function, got: ${callback}`);\n+            throw new MockServerError(\n+                `onRpc: expected callback to be a function, got: ${callback}`\n+            );\n         }\n \n         this._ormListeners.push([model, method, callback]);\n@@ -1192,11 +1235,13 @@ export class MockServer {\n                 }\n             } else if (model) {\n                 if (!resId) {\n-                    throw new Error(\"Actions with a 'model' should also have a 'resId'\");\n+                    throw new MockServerError(\"Actions with a 'model' should also have a 'resId'\");\n                 }\n                 displayName = this.env[model].browse(resId)[0].display_name;\n             } else {\n-                throw new Error(\"Actions should have either an 'action' (ID or path) or a 'model'\");\n+                throw new MockServerError(\n+                    \"Actions should have either an 'action' (ID or path) or a 'model'\"\n+                );\n             }\n             return { display_name: displayName };\n         });\n@@ -1259,7 +1304,7 @@ export class MockServer {\n         }\n         const missingMenuIds = [...allChildIds].filter((id) => !(id in menuDict));\n         if (missingMenuIds.length) {\n-            throw new MockServerError(`missing menu ID(s): ${missingMenuIds.join(\", \")}`);\n+            throw new MockServerError(`Missing menu ID(s): ${missingMenuIds.join(\", \")}`);\n         }\n         return menuDict;\n     }"
+      },
+      {
+        "sha": "1e44fbe59e7959a7ae11bf898521be6585c02cf9",
+        "filename": "addons/web/static/tests/_framework/mock_server/mock_server_utils.js",
+        "status": "modified",
+        "additions": 18,
+        "deletions": 4,
+        "changes": 22,
+        "blob_url": "https://github.com/odoo/odoo/blob/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fweb%2Fstatic%2Ftests%2F_framework%2Fmock_server%2Fmock_server_utils.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fweb%2Fstatic%2Ftests%2F_framework%2Fmock_server%2Fmock_server_utils.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fweb%2Fstatic%2Ftests%2F_framework%2Fmock_server%2Fmock_server_utils.js?ref=54698f4d2854ca1777ec62a6464004b5b88a4dc5",
+        "patch": "@@ -1,5 +1,18 @@\n import { makeErrorFromResponse } from \"@web/core/network/rpc\";\n \n+/**\n+ * @typedef {{\n+ *  code?: number;\n+ *  context?: import(\"@web/core/context\").Context;\n+ *  description?: string;\n+ *  message?: string;\n+ *  subType?: string;\n+ *  errorName?: string;\n+ *  type?: string;\n+ *  args?: unknown[];\n+ * }} ServerErrorInit\n+ */\n+\n /**\n  * @template T\n  * @typedef {import(\"./mock_server\").KwArgs<T>} KwArgs\n@@ -46,7 +59,7 @@ export function getKwArgs(allArgs, ...argNames) {\n     const args = [...allArgs];\n     const kwargs = args.at(-1)?.[KWARGS_SYMBOL] ? args.pop() : makeKwArgs({});\n     if (args.length > argNames.length) {\n-        throw new MockServerError(\"more positional arguments than there are given argument names\");\n+        throw new MockServerError(\"More positional arguments than there are given argument names\");\n     }\n     for (let i = 0; i < args.length; i++) {\n         if (args[i] !== null && args[i] !== undefined) {\n@@ -71,7 +84,7 @@ export function getRecordQualifier(record) {\n }\n \n /**\n- * @param {Record<string, string | any>} params\n+ * @param {ServerErrorInit} params\n  */\n export function makeServerError({\n     code,\n@@ -85,15 +98,16 @@ export function makeServerError({\n } = {}) {\n     return makeErrorFromResponse({\n         code: code || 0,\n-        message: message || \"Odoo Server Error\",\n         data: {\n             name: errorName || `odoo.exceptions.${type || \"UserError\"}`,\n             debug: \"traceback\",\n             arguments: args || [],\n             context: context || {},\n             subType,\n-            message: description,\n+            message: description || message,\n         },\n+        message: message || \"Odoo Server Error\",\n+        type: \"server\",\n     });\n }\n "
+      },
+      {
+        "sha": "1b9d2150992ffa287fc9ea1dfac783fcd1ab8537",
+        "filename": "addons/web/static/tests/core/l10n/translation.test.js",
+        "status": "modified",
+        "additions": 7,
+        "deletions": 11,
+        "changes": 18,
+        "blob_url": "https://github.com/odoo/odoo/blob/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fweb%2Fstatic%2Ftests%2Fcore%2Fl10n%2Ftranslation.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fweb%2Fstatic%2Ftests%2Fcore%2Fl10n%2Ftranslation.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fweb%2Fstatic%2Ftests%2Fcore%2Fl10n%2Ftranslation.test.js?ref=54698f4d2854ca1777ec62a6464004b5b88a4dc5",
+        "patch": "@@ -1,5 +1,6 @@\n /* eslint no-restricted-syntax: 0 */\n import { after, describe, expect, test } from \"@odoo/hoot\";\n+import { animationFrame, Deferred } from \"@odoo/hoot-mock\";\n import {\n     defineParams,\n     makeMockEnv,\n@@ -10,9 +11,8 @@ import {\n     serverState,\n } from \"@web/../tests/web_test_helpers\";\n import { _t as basic_t, translatedTerms, translationLoaded } from \"@web/core/l10n/translation\";\n-import { session } from \"@web/session\";\n import { IndexedDB } from \"@web/core/utils/indexed_db\";\n-import { animationFrame, Deferred } from \"@odoo/hoot-mock\";\n+import { session } from \"@web/session\";\n \n import { Component, markup, xml } from \"@odoo/owl\";\n const { DateTime } = luxon;\n@@ -75,19 +75,15 @@ test(\"lang is given by an attribute on the DOM root node\", async () => {\n });\n \n test(\"url is given by the session\", async () => {\n-    expect.assertions(1);\n     patchWithCleanup(session, {\n         translationURL: \"/get_translations\",\n     });\n-    onRpc(\n-        \"/get_translations\",\n-        function (request) {\n-            expect(request.url).toInclude(\"/get_translations\");\n-            return this.loadTranslations(request);\n-        },\n-        { pure: true }\n-    );\n+    onRpc(\"/get_translations\", function (request) {\n+        expect.step(\"/get_translations\");\n+        return this.loadTranslations(request);\n+    });\n     await makeMockEnv();\n+    expect.verifySteps([\"/get_translations\"]);\n });\n \n test(\"can translate a text node\", async () => {"
+      },
+      {
+        "sha": "0be7c877d3bcc14d4e956e56220dbd4a088a3d85",
+        "filename": "addons/web/static/tests/core/network/rpc.test.js",
+        "status": "modified",
+        "additions": 6,
+        "deletions": 4,
+        "changes": 10,
+        "blob_url": "https://github.com/odoo/odoo/blob/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fweb%2Fstatic%2Ftests%2Fcore%2Fnetwork%2Frpc.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fweb%2Fstatic%2Ftests%2Fcore%2Fnetwork%2Frpc.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fweb%2Fstatic%2Ftests%2Fcore%2Fnetwork%2Frpc.test.js?ref=54698f4d2854ca1777ec62a6464004b5b88a4dc5",
+        "patch": "@@ -138,10 +138,12 @@ test(\"trigger a ConnectionLostError when response isn't json parsable\", async ()\n \n test(\"rpc can send additional headers\", async () => {\n     mockFetch((url, settings) => {\n-        expect(settings.headers).toEqual({\n-            \"Content-Type\": \"application/json\",\n-            Hello: \"World\",\n-        });\n+        expect(settings.headers).toEqual(\n+            new Headers([\n+                [\"Content-Type\", \"application/json\"],\n+                [\"Hello\", \"World\"],\n+            ])\n+        );\n         return { result: true };\n     });\n     await rpc(\"/test/\", null, { headers: { Hello: \"World\" } });"
+      },
+      {
+        "sha": "6e703a34085142acfff3c856517106ef196d0a76",
+        "filename": "addons/web/static/tests/mock_server/mock_server.test.js",
+        "status": "modified",
+        "additions": 96,
+        "deletions": 21,
+        "changes": 117,
+        "blob_url": "https://github.com/odoo/odoo/blob/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fweb%2Fstatic%2Ftests%2Fmock_server%2Fmock_server.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fweb%2Fstatic%2Ftests%2Fmock_server%2Fmock_server.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fweb%2Fstatic%2Ftests%2Fmock_server%2Fmock_server.test.js?ref=54698f4d2854ca1777ec62a6464004b5b88a4dc5",
+        "patch": "@@ -10,6 +10,8 @@ import {\n } from \"@web/../tests/web_test_helpers\";\n import { localization } from \"@web/core/l10n/localization\";\n \n+import { ConnectionLostError, rpc } from \"@web/core/network/rpc\";\n+\n class Partner extends models.Model {\n     _name = \"res.partner\";\n \n@@ -177,6 +179,16 @@ const ormRequest = async (params) => {\n     return result;\n };\n \n+/**\n+ * Minimal parameters to have a request considered as a JSON-RPC request\n+ */\n+const JSON_RPC_BASIC_PARAMS = {\n+    body: \"{}\",\n+    headers: {\n+        [\"Content-Type\"]: \"application/json\",\n+    },\n+};\n+\n describe.current.tags(\"headless\");\n \n test(\"onRpc: normal result\", async () => {\n@@ -188,35 +200,17 @@ test(\"onRpc: normal result\", async () => {\n \n     expect(response).toBeInstanceOf(Response);\n \n-    await expect(response.json()).resolves.toEqual({ result: \"result\", error: null });\n+    await expect(response.text()).resolves.toBe(\"result\");\n });\n \n test(\"onRpc: error handling\", async () => {\n-    class CustomError extends Error {\n-        name = \"CustomError\";\n-    }\n-\n     onRpc(\"/boom\", () => {\n-        throw new CustomError(\"boom\");\n+        throw new Error(\"boom\");\n     });\n \n     await makeMockServer();\n \n-    const response = await fetch(\"/boom\");\n-\n-    expect(response).toBeInstanceOf(Response);\n-\n-    await expect(response.json()).resolves.toEqual({\n-        result: null,\n-        error: {\n-            code: 418,\n-            data: {\n-                name: \"CustomError\",\n-            },\n-            message: \"boom\",\n-            type: \"CustomError\",\n-        },\n-    });\n+    await expect(fetch(\"/boom\")).rejects.toThrow(\"boom\");\n });\n \n test(\"onRpc: pure, normal result\", async () => {\n@@ -245,6 +239,87 @@ test(\"onRpc: pure, error handling\", async () => {\n     await expect(fetch(\"/boom\")).rejects.toThrow(\"boom\");\n });\n \n+test(\"onRpc: JSON-RPC normal result\", async () => {\n+    onRpc(\"/get_result\", () => \"get_result value\");\n+\n+    await makeMockServer();\n+\n+    const response = await fetch(\"/get_result\", JSON_RPC_BASIC_PARAMS);\n+\n+    expect(response).toBeInstanceOf(Response);\n+\n+    const result = await response.json();\n+    expect(result).toMatchObject({\n+        result: \"get_result value\",\n+    });\n+    expect(result).not.toInclude(\"error\");\n+});\n+\n+test(\"onRpc: JSON-RPC error handling\", async () => {\n+    class CustomError extends Error {\n+        name = \"CustomError\";\n+    }\n+\n+    onRpc(\"/boom\", () => {\n+        throw new CustomError(\"boom\");\n+    });\n+\n+    await makeMockServer();\n+\n+    const response = await fetch(\"/boom\", JSON_RPC_BASIC_PARAMS);\n+\n+    expect(response).toBeInstanceOf(Response);\n+\n+    const result = await response.json();\n+    expect(result).not.toInclude(\"result\");\n+    expect(result).toMatchObject({\n+        error: {\n+            code: 200,\n+            data: {\n+                name: \"CustomError\",\n+                message: \"boom\",\n+            },\n+            message: \"boom\",\n+            type: \"server\",\n+        },\n+    });\n+});\n+\n+test(\"rpc: calls on mock server\", async () => {\n+    onRpc(\"/route\", () => true);\n+    onRpc(\"/pure/route\", () => true);\n+    onRpc(\"/boom\", () => {\n+        throw new Error(\"Boom\");\n+    });\n+    onRpc(\n+        \"/boom/pure\",\n+        () => {\n+            throw new Error(\"Pure boom\");\n+        },\n+        { pure: true }\n+    );\n+    await makeMockServer();\n+\n+    await expect(rpc(\"/pure/route\")).resolves.toBe(true);\n+    await expect(rpc(\"/route\")).resolves.toBe(true);\n+\n+    await expect(rpc(\"/boom\")).rejects.toThrow(\"RPC_ERROR: Boom\");\n+    await expect(rpc(\"/boom/pure\")).rejects.toThrow(ConnectionLostError);\n+\n+    // MockServer error handling with 'rpc'\n+    await expect(rpc(\"/unknown/route\")).rejects.toThrow(\n+        \"Unimplemented server route: /unknown/route\"\n+    );\n+    await expect(\n+        rpc(\"/web/dataset/call_kw/fake.model/fake_method\", {\n+            model: \"fake.model\",\n+            method: \"fake_method\",\n+        })\n+    ).rejects.toThrow(\n+        `Cannot find a definition for model \"fake.model\": could not get model from server environment`\n+    );\n+});\n+\n test(\"performRPC: search with active_test=false\", async () => {\n     await makeMockServer();\n     const result = await ormRequest({"
+      },
+      {
+        "sha": "816632886000dc641a34244159ab60317d710902",
+        "filename": "addons/web/static/tests/webclient/clickbot.test.js",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 0,
+        "changes": 1,
+        "blob_url": "https://github.com/odoo/odoo/blob/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fweb%2Fstatic%2Ftests%2Fwebclient%2Fclickbot.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fweb%2Fstatic%2Ftests%2Fwebclient%2Fclickbot.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fweb%2Fstatic%2Ftests%2Fwebclient%2Fclickbot.test.js?ref=54698f4d2854ca1777ec62a6464004b5b88a4dc5",
+        "patch": "@@ -449,6 +449,7 @@ test(\"clickbot show rpc error when an error dialog is detected\", async () => {\n                 debug: \"traceback\",\n                 arguments: [],\n                 context: {},\n+                message: \"This is a server Error, it should be displayed in an error dialog\",\n             },\n             exceptionName: \"odoo.exceptions.Programming error\",\n             subType: \"server\","
+      },
+      {
+        "sha": "0733c9c1ac177a789ca1f66202af6bbabdc83d2b",
+        "filename": "addons/website/static/tests/builder/image_test_helpers.js",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fimage_test_helpers.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fimage_test_helpers.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fimage_test_helpers.js?ref=54698f4d2854ca1777ec62a6464004b5b88a4dc5",
+        "patch": "@@ -2,7 +2,7 @@ import { before, globals } from \"@odoo/hoot\";\n import { onRpc } from \"@web/../tests/web_test_helpers\";\n \n function onRpcReal(route) {\n-    onRpc(route, async () => globals.fetch.call(window, route), { pure: true });\n+    onRpc(route, () => globals.fetch.call(window, route));\n }\n \n export const testImgSrc = \"/web/image/website.s_text_image_default_image\";"
+      },
+      {
+        "sha": "5cbc21b761bf10289f864349aba420099090f1fa",
+        "filename": "addons/website/static/tests/builder/website_builder/cover_properties_option.test.js",
+        "status": "modified",
+        "additions": 10,
+        "deletions": 11,
+        "changes": 21,
+        "blob_url": "https://github.com/odoo/odoo/blob/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fwebsite_builder%2Fcover_properties_option.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fwebsite_builder%2Fcover_properties_option.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fwebsite_builder%2Fcover_properties_option.test.js?ref=54698f4d2854ca1777ec62a6464004b5b88a4dc5",
+        "patch": "@@ -9,7 +9,10 @@ import {\n     onRpc,\n     patchWithCleanup,\n } from \"@web/../tests/web_test_helpers\";\n-import { defineWebsiteModels, setupWebsiteBuilder } from \"@website/../tests/builder/website_helpers\";\n+import {\n+    defineWebsiteModels,\n+    setupWebsiteBuilder,\n+} from \"@website/../tests/builder/website_helpers\";\n \n defineWebsiteModels();\n \n@@ -57,16 +60,12 @@ test(\"Add image as cover\", async () => {\n         original: { id: 1, image_src: \"/web/image/hoot.png\", mimetype: \"image/png\" },\n     }));\n \n-    onRpc(\n-        \"/web/image/hoot.png\",\n-        () => {\n-            const base64Image =\n-                \"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYIIA\" +\n-                \"A\".repeat(1000); // converted image won't be used if original is not larger\n-            return dataURItoBlob(base64Image);\n-        },\n-        { pure: true }\n-    );\n+    onRpc(\"/web/image/hoot.png\", () => {\n+        const base64Image =\n+            \"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYIIA\" +\n+            \"A\".repeat(1000); // converted image won't be used if original is not larger\n+        return dataURItoBlob(base64Image);\n+    });\n \n     const blogPostTitle = \"Title of Test Post\";\n "
+      },
+      {
+        "sha": "a810faa29213ea11ab91b7e5d941e87a460b0336",
+        "filename": "addons/website/static/tests/builder/website_builder/image_gallery.test.js",
+        "status": "modified",
+        "additions": 11,
+        "deletions": 15,
+        "changes": 26,
+        "blob_url": "https://github.com/odoo/odoo/blob/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fwebsite_builder%2Fimage_gallery.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fwebsite_builder%2Fimage_gallery.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fwebsite_builder%2Fimage_gallery.test.js?ref=54698f4d2854ca1777ec62a6464004b5b88a4dc5",
+        "patch": "@@ -1,16 +1,16 @@\n+import {\n+    confirmAddSnippet,\n+    dummyBase64Img,\n+    waitForEndOfOperation,\n+} from \"@html_builder/../tests/helpers\";\n import { expect, test } from \"@odoo/hoot\";\n import { click, queryAll, queryOne, waitFor } from \"@odoo/hoot-dom\";\n import { contains, dataURItoBlob, onRpc, patchWithCleanup } from \"@web/../tests/web_test_helpers\";\n+import { uniqueId } from \"@web/core/utils/functions\";\n import {\n     defineWebsiteModels,\n     setupWebsiteBuilder,\n } from \"@website/../tests/builder/website_helpers\";\n-import {\n-    confirmAddSnippet,\n-    dummyBase64Img,\n-    waitForEndOfOperation,\n-} from \"@html_builder/../tests/helpers\";\n-import { uniqueId } from \"@web/core/utils/functions\";\n \n defineWebsiteModels();\n \n@@ -26,15 +26,11 @@ test(\"Add image in gallery\", async () => {\n         },\n     ]);\n \n-    onRpc(\n-        \"/web/image/hoot.png\",\n-        () => {\n-            const base64Image =\n-                \"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII=\";\n-            return dataURItoBlob(base64Image);\n-        },\n-        { pure: true }\n-    );\n+    onRpc(\"/web/image/hoot.png\", () => {\n+        const base64Image =\n+            \"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII=\";\n+        return dataURItoBlob(base64Image);\n+    });\n \n     await setupWebsiteBuilder(\n         `"
+      },
+      {
+        "sha": "fc82ffb2577825b1a88dbc75963dfbac67d6d4ac",
+        "filename": "addons/website/static/tests/interactions/image_shape_hover_effect.test.js",
+        "status": "modified",
+        "additions": 2,
+        "deletions": 4,
+        "changes": 6,
+        "blob_url": "https://github.com/odoo/odoo/blob/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fwebsite%2Fstatic%2Ftests%2Finteractions%2Fimage_shape_hover_effect.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fwebsite%2Fstatic%2Ftests%2Finteractions%2Fimage_shape_hover_effect.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Ftests%2Finteractions%2Fimage_shape_hover_effect.test.js?ref=54698f4d2854ca1777ec62a6464004b5b88a4dc5",
+        "patch": "@@ -40,10 +40,8 @@ test(\"image_shape_hover_effect changes image on enter & leave\", async () => {\n     `);\n     onRpc(\n         \"/web/image/384-8a55a748/s_banner_3.svg\",\n-        () => {\n-            return `<svg viewBox=\"0 0 300 100\" width=\"500px\"><g id=\"hoverEffects\"><animate values=\"a=1;b=2\"><rect width=\"100%\" fill=\"red\" height=\"100%\" /></animate></g></svg>`;\n-        },\n-        { pure: true }\n+        () =>\n+            `<svg viewBox=\"0 0 300 100\" width=\"500px\"><g id=\"hoverEffects\"><animate values=\"a=1;b=2\"><rect width=\"100%\" fill=\"red\" height=\"100%\" /></animate></g></svg>`\n     );\n     expect(core.interactions).toHaveLength(1);\n     await onceAllImagesLoaded(queryOne(\"#wrapwrap\"));"
+      },
+      {
+        "sha": "f7e0d1a8b63321f2f7612568fb5bc5dab2f311d1",
+        "filename": "addons/website_sale/static/tests/builder/product_page_option.test.js",
+        "status": "modified",
+        "additions": 15,
+        "deletions": 14,
+        "changes": 29,
+        "blob_url": "https://github.com/odoo/odoo/blob/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fwebsite_sale%2Fstatic%2Ftests%2Fbuilder%2Fproduct_page_option.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/54698f4d2854ca1777ec62a6464004b5b88a4dc5/addons%2Fwebsite_sale%2Fstatic%2Ftests%2Fbuilder%2Fproduct_page_option.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite_sale%2Fstatic%2Ftests%2Fbuilder%2Fproduct_page_option.test.js?ref=54698f4d2854ca1777ec62a6464004b5b88a4dc5",
+        "patch": "@@ -1,6 +1,12 @@\n import { expect, test } from \"@odoo/hoot\";\n import { waitForNone } from \"@odoo/hoot-dom\";\n-import { contains, dataURItoBlob, defineModels, models, onRpc } from \"@web/../tests/web_test_helpers\";\n+import {\n+    contains,\n+    dataURItoBlob,\n+    defineModels,\n+    models,\n+    onRpc,\n+} from \"@web/../tests/web_test_helpers\";\n import {\n     defineWebsiteModels,\n     setupWebsiteBuilder,\n@@ -62,10 +68,9 @@ test(\"Product page options\", async () => {\n         return [];\n     });\n \n-    const base64Image = (\n-        \"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5\"\n-        + \"AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYIIA\"\n-    );\n+    const base64Image =\n+        \"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5\" +\n+        \"AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYIIA\";\n     onRpc(\"ir.attachment\", \"search_read\", () => [\n         {\n             mimetype: \"image/png\",\n@@ -81,14 +86,10 @@ test(\"Product page options\", async () => {\n             original: { id: 1, image_src: \"/web/image/hoot.png\", mimetype: \"image/png\" },\n         };\n     });\n-    onRpc(\n-        \"/web/image/hoot.png\",\n-        () => {\n-            // converted image won't be used if original is not larger\n-            return dataURItoBlob(base64Image + \"A\".repeat(1000));\n-        },\n-        { pure: true },\n-    );\n+    onRpc(\"/web/image/hoot.png\", () => {\n+        // converted image won't be used if original is not larger\n+        return dataURItoBlob(base64Image + \"A\".repeat(1000));\n+    });\n     onRpc(\"/html_editor/modify_image/1\", () => {\n         expect.step(\"modify_image\");\n         return base64Image; // Simulate image compression/convertion\n@@ -122,7 +123,7 @@ test(\"Product page options\", async () => {\n         // Save the image changes\n         \"save\",\n         // Reload the view\n-        \"theme_customize_data_get\"\n+        \"theme_customize_data_get\",\n     ]);\n \n     // Make sure that clicking quickly on a builder button after an clicking on"
+      }
+    ]
+  },
+  {
+    "sha": "350da9c8561276a45d65b3e74418a8cfc28eda16",
+    "node_id": "C_kwDOAS1I7NoAKDM1MGRhOWM4NTYxMjc2YTQ1ZDY1YjNlNzQ0MThhOGNmYzI4ZWRhMTY",
+    "commit": {
+      "author": {
+        "name": "Antoine (anso)",
+        "email": "anso@odoo.com",
+        "date": "2024-11-27T12:20:43Z"
+      },
+      "committer": {
+        "name": "Antoine (anso)",
+        "email": "anso@odoo.com",
+        "date": "2025-10-27T14:33:51Z"
+      },
+      "message": "[IMP] website(*): add new `s_newsletter_aside` snippet\n\n*: _mass_mailing\n\nThis commit adds the new `s_newsletter_aside` snippet\n\ntask-4306896\n\ncloses odoo/odoo#188802\n\nSigned-off-by: Benoit Socias (bso) <bso@odoo.com>\nCo-authored-by: Benoit Socias (bso) <bso@odoo.com>",
+      "tree": {
+        "sha": "f5c631085c886c181e8d09c63124dcfd8611fa42",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/f5c631085c886c181e8d09c63124dcfd8611fa42"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/350da9c8561276a45d65b3e74418a8cfc28eda16",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/350da9c8561276a45d65b3e74418a8cfc28eda16",
+    "html_url": "https://github.com/odoo/odoo/commit/350da9c8561276a45d65b3e74418a8cfc28eda16",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/350da9c8561276a45d65b3e74418a8cfc28eda16/comments",
+    "author": {
+      "login": "anso-odoo",
+      "id": 110090660,
+      "node_id": "U_kgDOBo_ZpA",
+      "avatar_url": "https://avatars.githubusercontent.com/u/110090660?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/anso-odoo",
+      "html_url": "https://github.com/anso-odoo",
+      "followers_url": "https://api.github.com/users/anso-odoo/followers",
+      "following_url": "https://api.github.com/users/anso-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/anso-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/anso-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/anso-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/anso-odoo/orgs",
+      "repos_url": "https://api.github.com/users/anso-odoo/repos",
+      "events_url": "https://api.github.com/users/anso-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/anso-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "anso-odoo",
+      "id": 110090660,
+      "node_id": "U_kgDOBo_ZpA",
+      "avatar_url": "https://avatars.githubusercontent.com/u/110090660?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/anso-odoo",
+      "html_url": "https://github.com/anso-odoo",
+      "followers_url": "https://api.github.com/users/anso-odoo/followers",
+      "following_url": "https://api.github.com/users/anso-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/anso-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/anso-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/anso-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/anso-odoo/orgs",
+      "repos_url": "https://api.github.com/users/anso-odoo/repos",
+      "events_url": "https://api.github.com/users/anso-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/anso-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "846b0c6ebd84ad336b6eec0baffc29b0bfa098fe",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/846b0c6ebd84ad336b6eec0baffc29b0bfa098fe",
+        "html_url": "https://github.com/odoo/odoo/commit/846b0c6ebd84ad336b6eec0baffc29b0bfa098fe"
+      }
+    ],
+    "stats": {
+      "total": 125,
+      "additions": 125,
+      "deletions": 0
+    },
+    "files": [
+      {
+        "sha": "1cc92a9fc3fca006ad1e8040606024d5e418710e",
+        "filename": "addons/website/data/image_library.xml",
+        "status": "modified",
+        "additions": 6,
+        "deletions": 0,
+        "changes": 6,
+        "blob_url": "https://github.com/odoo/odoo/blob/350da9c8561276a45d65b3e74418a8cfc28eda16/addons%2Fwebsite%2Fdata%2Fimage_library.xml",
+        "raw_url": "https://github.com/odoo/odoo/raw/350da9c8561276a45d65b3e74418a8cfc28eda16/addons%2Fwebsite%2Fdata%2Fimage_library.xml",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fdata%2Fimage_library.xml?ref=350da9c8561276a45d65b3e74418a8cfc28eda16",
+        "patch": "@@ -1130,6 +1130,12 @@\n     <field name=\"type\">url</field>\n     <field name=\"url\">/web/image/website.s_banner_default_image_2</field>\n </record>\n+<record id=\"website.s_newsletter_aside_default_image\" model=\"ir.attachment\">\n+    <field name=\"public\" eval=\"True\"/>\n+    <field name=\"name\">s_newsletter_aside_default_image.jpg</field>\n+    <field name=\"type\">url</field>\n+    <field name=\"url\">/web/image/website.library_image_08</field>\n+</record>\n <record id=\"website.s_website_form_info_default_image\" model=\"ir.attachment\">\n     <field name=\"public\" eval=\"True\"/>\n     <field name=\"name\">s_website_form_info_default_image.webp</field>"
+      },
+      {
+        "sha": "885c08d9e93ecbeefbf22526f881bf59853f87a0",
+        "filename": "addons/website/static/src/img/snippets_previews/s_newsletter_aside_preview.webp",
+        "status": "added",
+        "additions": 0,
+        "deletions": 0,
+        "changes": 0,
+        "blob_url": "https://github.com/odoo/odoo/blob/350da9c8561276a45d65b3e74418a8cfc28eda16/addons%2Fwebsite%2Fstatic%2Fsrc%2Fimg%2Fsnippets_previews%2Fs_newsletter_aside_preview.webp",
+        "raw_url": "https://github.com/odoo/odoo/raw/350da9c8561276a45d65b3e74418a8cfc28eda16/addons%2Fwebsite%2Fstatic%2Fsrc%2Fimg%2Fsnippets_previews%2Fs_newsletter_aside_preview.webp",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fimg%2Fsnippets_previews%2Fs_newsletter_aside_preview.webp?ref=350da9c8561276a45d65b3e74418a8cfc28eda16"
+      },
+      {
+        "sha": "578520dfa5703c114fc18ac3ef098955ee00d3ad",
+        "filename": "addons/website/views/snippets/snippets.xml",
+        "status": "modified",
+        "additions": 3,
+        "deletions": 0,
+        "changes": 3,
+        "blob_url": "https://github.com/odoo/odoo/blob/350da9c8561276a45d65b3e74418a8cfc28eda16/addons%2Fwebsite%2Fviews%2Fsnippets%2Fsnippets.xml",
+        "raw_url": "https://github.com/odoo/odoo/raw/350da9c8561276a45d65b3e74418a8cfc28eda16/addons%2Fwebsite%2Fviews%2Fsnippets%2Fsnippets.xml",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fviews%2Fsnippets%2Fsnippets.xml?ref=350da9c8561276a45d65b3e74418a8cfc28eda16",
+        "patch": "@@ -447,6 +447,7 @@\n             <t id=\"mass_mailing_newsletter_centered_hook\"/>\n             <t id=\"mass_mailing_newsletter_sms_notifications_hook\"/>\n             <t id=\"mass_mailing_newsletter_benefits_popup_hook\"/>\n+            <t id=\"mass_mailing_newsletter_aside_hook\"/>\n \n             <!-- Social group -->\n             <t t-snippet=\"website.s_instagram_page\" string=\"Instagram Page\" group=\"social\"\n@@ -527,6 +528,8 @@\n     <xpath expr=\"//snippets[@id='snippet_structure']\" position=\"inside\">\n         <t t-install=\"mass_mailing\" string=\"Newsletter Block\" group=\"contact_and_forms\"\n             t-image-preview=\"/website/static/src/img/snippets_previews/s_newsletter_block_preview.png\"/>\n+        <t t-install=\"mass_mailing\" string=\"Newsletter Aside\" group=\"contact_and_forms\"\n+            t-image-preview=\"/website/static/src/img/snippets_previews/s_newsletter_aside_preview.webp\"/>\n         <t t-install=\"mass_mailing\" string=\"Newsletter Centered\" group=\"contact_and_forms\"\n             t-image-preview=\"/website/static/src/img/snippets_previews/s_newsletter_centered_preview.jpg\"/>\n         <t t-install=\"mass_mailing\" string=\"Newsletter Grid\" group=\"contact_and_forms\""
+      },
+      {
+        "sha": "65dbf122025b7ad09c95d98b0678853f2aa3fae2",
+        "filename": "addons/website_mass_mailing/static/src/website_builder/newsletter_subscribe_common_option.xml",
+        "status": "modified",
+        "additions": 14,
+        "deletions": 0,
+        "changes": 14,
+        "blob_url": "https://github.com/odoo/odoo/blob/350da9c8561276a45d65b3e74418a8cfc28eda16/addons%2Fwebsite_mass_mailing%2Fstatic%2Fsrc%2Fwebsite_builder%2Fnewsletter_subscribe_common_option.xml",
+        "raw_url": "https://github.com/odoo/odoo/raw/350da9c8561276a45d65b3e74418a8cfc28eda16/addons%2Fwebsite_mass_mailing%2Fstatic%2Fsrc%2Fwebsite_builder%2Fnewsletter_subscribe_common_option.xml",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite_mass_mailing%2Fstatic%2Fsrc%2Fwebsite_builder%2Fnewsletter_subscribe_common_option.xml?ref=350da9c8561276a45d65b3e74418a8cfc28eda16",
+        "patch": "@@ -8,4 +8,18 @@\n \n </t>\n \n+<t t-name=\"website_mass_mailing.NewsletterMailingListsCheckboxes\">\n+    <t t-foreach=\"mailingLists\" t-as=\"record\" t-key=\"record_index\">\n+        <div class=\"checkbox col-12\">\n+            <div class=\"form-check\">\n+                <input type=\"checkbox\" class=\"s_website_form_input form-check-input\" name=\"list_ids\"\n+                    t-attf-id=\"mailing_list_#{record.id}\" t-att-checked=\"mailingLists.length &lt;= 1\" t-att-value=\"record.id\" required=\"1\"/>\n+                <label class=\"form-check-label s_website_form_check_label\" t-attf-for=\"mailing_list_#{record.id}\">\n+                    <t t-out=\"record.name\"/>\n+                </label>\n+            </div>\n+        </div>\n+    </t>\n+</t>\n+\n </templates>"
+      },
+      {
+        "sha": "f29c8ab50de61416d135852eb8f293716b27cf1e",
+        "filename": "addons/website_mass_mailing/static/src/website_builder/newsletter_subscribe_common_option_plugin.js",
+        "status": "modified",
+        "additions": 26,
+        "deletions": 0,
+        "changes": 26,
+        "blob_url": "https://github.com/odoo/odoo/blob/350da9c8561276a45d65b3e74418a8cfc28eda16/addons%2Fwebsite_mass_mailing%2Fstatic%2Fsrc%2Fwebsite_builder%2Fnewsletter_subscribe_common_option_plugin.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/350da9c8561276a45d65b3e74418a8cfc28eda16/addons%2Fwebsite_mass_mailing%2Fstatic%2Fsrc%2Fwebsite_builder%2Fnewsletter_subscribe_common_option_plugin.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite_mass_mailing%2Fstatic%2Fsrc%2Fwebsite_builder%2Fnewsletter_subscribe_common_option_plugin.js?ref=350da9c8561276a45d65b3e74418a8cfc28eda16",
+        "patch": "@@ -3,6 +3,7 @@ import { POPUP } from \"@website/builder/plugins/options/popup_option_plugin\";\n import { Plugin } from \"@html_editor/plugin\";\n import { withSequence } from \"@html_editor/utils/resource\";\n import { registry } from \"@web/core/registry\";\n+import { renderToFragment } from \"@web/core/utils/render\";\n import { NewsletterSubscribeCommonOption } from \"./newsletter_subscribe_common_option\";\n \n export const NEWSLETTER_SELECT = before(POPUP);\n@@ -22,6 +23,7 @@ class NewsletterSubscribeCommonOptionPlugin extends Plugin {\n                     \".s_newsletter_box .s_newsletter_list\",\n                     \".s_newsletter_centered .s_newsletter_list\",\n                     \".s_newsletter_grid .s_newsletter_list\",\n+                    \".s_newsletter_aside .s_newsletter_list\",\n                 ].join(\", \"),\n             }),\n             withSequence(NEWSLETTER_SELECT, {\n@@ -42,6 +44,7 @@ class NewsletterSubscribeCommonOptionPlugin extends Plugin {\n                 dropIn: \".row.o_grid_mode\",\n             },\n         ],\n+        on_snippet_dropped_handlers: withSequence(-1, (args) => this.onSnippetDropped(args)),\n     };\n \n     getProps() {\n@@ -50,6 +53,29 @@ class NewsletterSubscribeCommonOptionPlugin extends Plugin {\n             hasRecaptcha: this.dependencies.recaptchaSubscribeOption.hasRecaptcha,\n         };\n     }\n+\n+    async onSnippetDropped({ snippetEl }) {\n+        if (snippetEl.matches(\".s_newsletter_aside\")) {\n+            const sampleEl = snippetEl.querySelector(\"#checkbox_sample\");\n+            if (sampleEl) {\n+                const mailingLists = await this.services.orm.searchRead(\n+                    \"mailing.list\",\n+                    [[\"is_public\", \"=\", true]],\n+                    [\"id\", \"name\"],\n+                );\n+                if (mailingLists.length) {\n+                    const parentEl = sampleEl.parentElement;\n+                    sampleEl.remove();\n+                    const checkboxesFragment = renderToFragment(\n+                        \"website_mass_mailing.NewsletterMailingListsCheckboxes\", { mailingLists }\n+                    );\n+                    parentEl.append(...checkboxesFragment.children);\n+                } else {\n+                    sampleEl.closest(\".s_website_form_field\").remove();\n+                }\n+            }\n+        }\n+    }\n }\n \n registry"
+      },
+      {
+        "sha": "8facdea966d076da0ddb5bcccb5cd83b37cdeb34",
+        "filename": "addons/website_mass_mailing/views/snippets_templates.xml",
+        "status": "modified",
+        "additions": 76,
+        "deletions": 0,
+        "changes": 76,
+        "blob_url": "https://github.com/odoo/odoo/blob/350da9c8561276a45d65b3e74418a8cfc28eda16/addons%2Fwebsite_mass_mailing%2Fviews%2Fsnippets_templates.xml",
+        "raw_url": "https://github.com/odoo/odoo/raw/350da9c8561276a45d65b3e74418a8cfc28eda16/addons%2Fwebsite_mass_mailing%2Fviews%2Fsnippets_templates.xml",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite_mass_mailing%2Fviews%2Fsnippets_templates.xml?ref=350da9c8561276a45d65b3e74418a8cfc28eda16",
+        "patch": "@@ -25,6 +25,11 @@\n             <keywords>updates, digest, bulletin, announcements, notifications, communication, promotional, email, alert, dialog, prompt, subscription, subscribe, mailing-list, news, grid, image, picture</keywords>\n         </t>\n     </xpath>\n+    <xpath expr=\"//t[@id='mass_mailing_newsletter_aside_hook']\" position=\"replace\">\n+        <t t-snippet=\"website_mass_mailing.s_newsletter_aside\" string=\"Newsletter Aside\" t-forbid-sanitize=\"form\" group=\"contact_and_forms\">\n+            <keywords>updates, digest, bulletin, announcements, notifications, communication, promotional, email, subscription, subscribe, mailing-list, news, grid, image, picture</keywords>\n+        </t>\n+    </xpath>\n     <xpath expr=\"//t[@id='mass_mailing_newsletter_popup_hook']\" position=\"replace\">\n         <t t-snippet=\"website_mass_mailing.s_newsletter_subscribe_popup\" string=\"Newsletter Popup\" t-forbid-sanitize=\"form\" group=\"contact_and_forms\" label=\"Popup\"/>\n     </xpath>\n@@ -290,6 +295,77 @@ database, without the s_newsletter_list class. See fixNewsletterListClass.\n     </div>\n </template>\n \n+<template id=\"s_newsletter_aside\" name=\"Newsletter Aside\">\n+    <section class=\"s_newsletter_aside\" data-name=\"Newsletter Aside\">\n+        <div class=\"container-fluid\">\n+            <div class=\"row o_grid_mode\" data-row-count=\"12\">\n+                <div class=\"o_grid_item o_grid_item_image g-height-12 g-col-lg-6 col-lg-6 o_cc o_cc1\" style=\"grid-area: 1 / 1 / 13 / 7; --grid-item-padding-x: 0px; --grid-item-padding-y: 0px;\">\n+                    <img src=\"/web/image/website.s_newsletter_aside_default_image\" class=\"img img-fluid\" alt=\"\"/>\n+                </div>\n+                <div class=\"o_grid_item g-height-12 g-col-lg-5 col-lg-5\" style=\"grid-area: 1 / 7 / 13 / 12; --grid-item-padding-x: 40px; --grid-item-padding-y: 40px;\">\n+                    <h2 class=\"h3-fs\">Subscribe for updates, offers <br/>and insights!</h2>\n+                    <section class=\"s_website_form\" data-vcss=\"001\" data-snippet=\"s_website_form\" data-name=\"Form\">\n+                        <form id=\"newsletter_form\" action=\"/website/form/\" method=\"post\" enctype=\"multipart/form-data\" class=\"o_mark_required\"\n+                                data-mark=\"*\" data-model_name=\"mailing.contact\" data-success-mode=\"message\" hide-change-model=\"true\">\n+                            <div class=\"s_website_form_rows row s_col_no_bgcolor\">\n+                                <div class=\"s_website_form_field col-lg-6 mb-3\" data-type=\"char\" data-name=\"Field\">\n+                                    <label class=\"s_website_form_label\" style=\"width: 200px\" for=\"mailing_sub1\">\n+                                        <span class=\"s_website_form_label_content\">Name</span>\n+                                        <span class=\"s_website_form_mark\"> *</span>\n+                                    </label>\n+                                    <input id=\"mailing_sub1\" type=\"text\" class=\"form-control s_website_form_input\" name=\"name\" required=\"1\" placeholder=\"John Smith\"/>\n+                                </div>\n+                                <div class=\"col-lg-6 mb-3 s_website_form_field s_website_form_model_required\" data-type=\"email\" data-name=\"Field\">\n+                                    <label class=\"s_website_form_label\" style=\"width: 200px\" for=\"mailing_sub2\">\n+                                        <span class=\"s_website_form_label_content\">Email</span>\n+                                        <span class=\"s_website_form_mark\"> *</span>\n+                                    </label>\n+                                    <input id=\"mailing_sub2\" type='email' class='form-control s_website_form_input' name=\"email\" placeholder=\"johnsmith@example.com\"/>\n+                                </div>\n+                                <div class=\"s_hr pt8 pb24\" data-snippet=\"s_hr\" data-name=\"Separator\">\n+                                    <hr class=\"s_hr_1px s_hr_solid\"/>\n+                                </div>\n+                                <div class=\"col-lg-12 s_website_form_field s_website_form_model_required mb-3\" data-type=\"many2many\" data-name=\"Field\">\n+                                    <label class=\"col-sm-auto s_website_form_label d-none\" style=\"width: 250px\">\n+                                        <span class=\"s_website_form_label_content\">Our mailing lists</span>\n+                                        <span class=\"s_website_form_mark\"> *</span>\n+                                    </label>\n+                                    <div class=\"s_website_form_multiple\" data-name=\"list_ids\" data-display=\"vertical\">\n+                                        <div id=\"checkbox_sample\" class=\"checkbox col-12\">\n+                                            <div class=\"form-check\">\n+                                                <input type=\"checkbox\" class=\"s_website_form_input form-check-input\" name=\"list_ids\"/>\n+                                                <label class=\"form-check-label s_website_form_check_label\">Newsletter</label>\n+                                            </div>\n+                                        </div>\n+                                    </div>\n+                                    <div class=\"s_website_form_field_description small form-text text-muted\">\n+                                        We send one weekly newsletter per list and always try to keep it interesting. You can unsubscribe at any time.\n+                                    </div>\n+                                </div>\n+                                <div class=\"s_website_form_submit s_website_form_no_submit_label col-12\" data-name=\"Submit Button\">\n+                                    <a href=\"#\" role=\"button\" class=\"btn btn-primary s_website_form_send\">Subscribe</a>\n+                                    <span id=\"s_website_form_result\"/>\n+                                </div>\n+                            </div>\n+                        </form>\n+                        <div class=\"s_website_form_end_message d-none mt-4\">\n+                            <div class=\"oe_structure\">\n+                                <section class=\"s_text_block border rounded pt40 pb40 text-center\" data-snippet=\"s_text_block\">\n+                                    <div class=\"container\">\n+                                        <i class=\"fa fa-paper-plane mb-3 rounded-circle text-bg-success\" role=\"presentation\"/>\n+                                        <h2 class=\"h4\">Thank you for subscribing!</h2>\n+                                        <p class=\"text-muted\">You will now be informed about the latest news.</p>\n+                                    </div>\n+                                </section>\n+                            </div>\n+                        </div>\n+                    </section>\n+                </div>\n+            </div>\n+        </div>\n+    </section>\n+</template>\n+\n <!-- Extend default mass_mailing snippets with website feature -->\n \n <template id=\"s_mail_block_footer_social\" inherit_id=\"mass_mailing.s_mail_block_footer_social\">"
+      }
+    ]
+  },
+  {
+    "sha": "df5e7396f93418a96be703b2a58ed20c09740671",
+    "node_id": "C_kwDOAS1I7NoAKGRmNWU3Mzk2ZjkzNDE4YTk2YmU3MDNiMmE1OGVkMjBjMDk3NDA2NzE",
+    "commit": {
+      "author": {
+        "name": "Walid (wasa)",
+        "email": "wasa@odoo.com",
+        "date": "2025-10-01T09:38:30Z"
+      },
+      "committer": {
+        "name": "Walid (wasa)",
+        "email": "wasa@odoo.com",
+        "date": "2025-10-28T06:53:49Z"
+      },
+      "message": "[FIX] html_editor: prevent header content loss on type change\n\nProblem:\nWhen trying to change the header type of \"All products\" in the\n\"/shop\" page on Website, the title disappears.\n\nCause:\nThe title is `h1[data-oe-field]`. When we update it, we replace the\nnode with a new header node. This triggers `handleMutations` with\nboth the removed node and the new node. The old removed node with no\ncontent is processed in `normalizeHandler`, which causes removal of\nthe content from the new node as well.\n\nSolution:\nWe disable `setTag` on `o_editable`.\n\nSteps to reproduce:\n1. Enter Website.\n2. Go to the cart and select the header \"Order Summary\".\n3. Attempt to change the font style (Header 1, Header 2, etc.).\n\u2192 The header disappears.\n\nopw-5106712\n\ncloses odoo/odoo#233286\n\nX-original-commit: a10217b177dafa039b34a06ec6ef655ed66e6273\nSigned-off-by: David Monjoie (dmo) <dmo@odoo.com>\nSigned-off-by: Walid Sahli (wasa) <wasa@odoo.com>",
+      "tree": {
+        "sha": "8578e0aaa3c94bac069657e1d92f0df58c123118",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/8578e0aaa3c94bac069657e1d92f0df58c123118"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/df5e7396f93418a96be703b2a58ed20c09740671",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/df5e7396f93418a96be703b2a58ed20c09740671",
+    "html_url": "https://github.com/odoo/odoo/commit/df5e7396f93418a96be703b2a58ed20c09740671",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/df5e7396f93418a96be703b2a58ed20c09740671/comments",
+    "author": {
+      "login": "walidsahli",
+      "id": 46481707,
+      "node_id": "MDQ6VXNlcjQ2NDgxNzA3",
+      "avatar_url": "https://avatars.githubusercontent.com/u/46481707?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/walidsahli",
+      "html_url": "https://github.com/walidsahli",
+      "followers_url": "https://api.github.com/users/walidsahli/followers",
+      "following_url": "https://api.github.com/users/walidsahli/following{/other_user}",
+      "gists_url": "https://api.github.com/users/walidsahli/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/walidsahli/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/walidsahli/subscriptions",
+      "organizations_url": "https://api.github.com/users/walidsahli/orgs",
+      "repos_url": "https://api.github.com/users/walidsahli/repos",
+      "events_url": "https://api.github.com/users/walidsahli/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/walidsahli/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "walidsahli",
+      "id": 46481707,
+      "node_id": "MDQ6VXNlcjQ2NDgxNzA3",
+      "avatar_url": "https://avatars.githubusercontent.com/u/46481707?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/walidsahli",
+      "html_url": "https://github.com/walidsahli",
+      "followers_url": "https://api.github.com/users/walidsahli/followers",
+      "following_url": "https://api.github.com/users/walidsahli/following{/other_user}",
+      "gists_url": "https://api.github.com/users/walidsahli/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/walidsahli/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/walidsahli/subscriptions",
+      "organizations_url": "https://api.github.com/users/walidsahli/orgs",
+      "repos_url": "https://api.github.com/users/walidsahli/repos",
+      "events_url": "https://api.github.com/users/walidsahli/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/walidsahli/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "c743e072c869c2fc8fa56cecaefc0e8222af5a44",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/c743e072c869c2fc8fa56cecaefc0e8222af5a44",
+        "html_url": "https://github.com/odoo/odoo/commit/c743e072c869c2fc8fa56cecaefc0e8222af5a44"
+      }
+    ],
+    "stats": {
+      "total": 31,
+      "additions": 31,
+      "deletions": 0
+    },
+    "files": [
+      {
+        "sha": "a062c9c0068ab6389eae44a12a3db13c2a7fd010",
+        "filename": "addons/html_builder/static/src/core/setup_editor_plugin.js",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 0,
+        "changes": 1,
+        "blob_url": "https://github.com/odoo/odoo/blob/df5e7396f93418a96be703b2a58ed20c09740671/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fcore%2Fsetup_editor_plugin.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/df5e7396f93418a96be703b2a58ed20c09740671/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fcore%2Fsetup_editor_plugin.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_builder%2Fstatic%2Fsrc%2Fcore%2Fsetup_editor_plugin.js?ref=df5e7396f93418a96be703b2a58ed20c09740671",
+        "patch": "@@ -9,6 +9,7 @@ export class SetupEditorPlugin extends Plugin {\n         clean_for_save_handlers: this.cleanForSave.bind(this),\n         closest_savable_providers: withSequence(10, (el) => el.closest(\".o_editable\")),\n         o_editable_selectors: \"[data-oe-model]\",\n+        unremovable_node_predicates: (node) => node.classList?.contains(\"o_editable\"),\n     };\n \n     setup() {"
+      },
+      {
+        "sha": "a50f8c15fbd13449fae65c20e6dc234fd84cad4f",
+        "filename": "addons/html_builder/static/tests/editor.test.js",
+        "status": "modified",
+        "additions": 10,
+        "deletions": 0,
+        "changes": 10,
+        "blob_url": "https://github.com/odoo/odoo/blob/df5e7396f93418a96be703b2a58ed20c09740671/addons%2Fhtml_builder%2Fstatic%2Ftests%2Feditor.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/df5e7396f93418a96be703b2a58ed20c09740671/addons%2Fhtml_builder%2Fstatic%2Ftests%2Feditor.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_builder%2Fstatic%2Ftests%2Feditor.test.js?ref=df5e7396f93418a96be703b2a58ed20c09740671",
+        "patch": "@@ -276,4 +276,14 @@ describe(\"font types\", () => {\n         expect(\".o-we-toolbar .btn[name='font']\").toHaveText(\"Small\");\n         expect(editor.editable.querySelector(\"p\")).toHaveClass(\"small\");\n     });\n+\n+    test(\"Should not be able to change tag of `o_editable` element\", async () => {\n+        const { getEditor } = await setupHTMLBuilder(`<h1 class=\"o_editable\">abcd</h1>`);\n+        const editor = getEditor();\n+        const h1 = editor.editable.querySelector(\"h1\");\n+        setSelection({ anchorNode: h1, anchorOffset: 0, focusOffset: 1 });\n+        await waitFor(\".o-we-toolbar\");\n+        await expandToolbar();\n+        expect(\".o-we-toolbar .btn[name='font']\").toHaveCount(0);\n+    });\n });"
+      },
+      {
+        "sha": "d304a103f57927bcf6538dd16c9ae87d6758d7a0",
+        "filename": "addons/html_editor/static/src/core/dom_plugin.js",
+        "status": "modified",
+        "additions": 20,
+        "deletions": 0,
+        "changes": 20,
+        "blob_url": "https://github.com/odoo/odoo/blob/df5e7396f93418a96be703b2a58ed20c09740671/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fcore%2Fdom_plugin.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/df5e7396f93418a96be703b2a58ed20c09740671/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fcore%2Fdom_plugin.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fcore%2Fdom_plugin.js?ref=df5e7396f93418a96be703b2a58ed20c09740671",
+        "patch": "@@ -574,10 +574,30 @@ export class DomPlugin extends Plugin {\n         this.dependencies.selection.setSelection({ anchorNode, anchorOffset });\n     }\n \n+    /**\n+     * Determines if a block element can be safely retagged.\n+     *\n+     * Certain blocks (like 'o_editable') should not be retagged because doing so\n+     * will recreate the block, potentially causing issues. This function checks\n+     * if retagging a block is safe.\n+     *\n+     * @param {HTMLElement} block\n+     * @returns {boolean}\n+     */\n+    isRetaggingSafe(block) {\n+        return !(\n+            (isParagraphRelatedElement(block) ||\n+                isListItemElement(block) ||\n+                isPhrasingContent(block)) &&\n+            this.getResource(\"unremovable_node_predicates\").some((predicate) => predicate(block))\n+        );\n+    }\n+\n     getBlocksToSet() {\n         const targetedBlocks = [...this.dependencies.selection.getTargetedBlocks()];\n         return targetedBlocks.filter(\n             (block) =>\n+                this.isRetaggingSafe(block) &&\n                 !descendants(block).some((descendant) => targetedBlocks.includes(descendant)) &&\n                 block.isContentEditable\n         );"
+      }
+    ]
+  },
+  {
+    "sha": "68bfe6fec67b0d87c59454b254a98bee57dc5d4c",
+    "node_id": "C_kwDOAS1I7NoAKDY4YmZlNmZlYzY3YjBkODdjNTk0NTRiMjU0YTk4YmVlNTdkYzVkNGM",
+    "commit": {
+      "author": {
+        "name": "Julien (jula)",
+        "email": "jula@odoo.com",
+        "date": "2025-10-08T09:36:26Z"
+      },
+      "committer": {
+        "name": "Julien (jula)",
+        "email": "jula@odoo.com",
+        "date": "2025-10-28T17:38:24Z"
+      },
+      "message": "[FIX] html_editor, mass_mailing, website: fix background repeat pattern\n\n__Current behavior before commit:__\nWhen setting the background image position to \"Repeat pattern\" in the\nwebsite builder, the background image does not repeat as expected. This\nis due to conflicting CSS rules where `background-repeat: no-repeat`\nfrom [`html_builder/static/src/scss/background.scss`][1] overrides the\nintended `background-repeat: repeat` from `html_editor.common.scss`.\n\n__Description of the fix:__\n1. Added `!important` to `background-repeat: repeat` to ensure the\nrepeat pattern takes precedence over other styles\n2. Removed duplicate and conflicting background styles from\n`mass_mailing/theme_default.scss` since these are already properly\ndefined in `html_editor.common.scss`\n3. Updated the test in `parallax_option.test.js` to verify\n`background-repeat: repeat` style is actually applied\n\n__Steps to reproduce:__\n1. Open website builder\n2. Add a section with a background image\n3. Change image position to \"Repeat pattern\"\n4. Bug: background doesn't repeat\n\n[1]: https://github.com/odoo/odoo/blob/f0a34badefd432e9c2ab36acaf018d20d0e342fe/addons/html_builder/static/src/scss/background.scss#L25\n\ntask-5145343\n\ncloses odoo/odoo#233433\n\nX-original-commit: 12d3b477ca8efdda273b4557c64c62e6990a5df2\nSigned-off-by: Damien Abeloos (abd) <abd@odoo.com>",
+      "tree": {
+        "sha": "43084acbc246bd619e0dc445143228330d188bd9",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/43084acbc246bd619e0dc445143228330d188bd9"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/68bfe6fec67b0d87c59454b254a98bee57dc5d4c",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/68bfe6fec67b0d87c59454b254a98bee57dc5d4c",
+    "html_url": "https://github.com/odoo/odoo/commit/68bfe6fec67b0d87c59454b254a98bee57dc5d4c",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/68bfe6fec67b0d87c59454b254a98bee57dc5d4c/comments",
+    "author": {
+      "login": "Dj0ulo",
+      "id": 46035353,
+      "node_id": "MDQ6VXNlcjQ2MDM1MzUz",
+      "avatar_url": "https://avatars.githubusercontent.com/u/46035353?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/Dj0ulo",
+      "html_url": "https://github.com/Dj0ulo",
+      "followers_url": "https://api.github.com/users/Dj0ulo/followers",
+      "following_url": "https://api.github.com/users/Dj0ulo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/Dj0ulo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/Dj0ulo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/Dj0ulo/subscriptions",
+      "organizations_url": "https://api.github.com/users/Dj0ulo/orgs",
+      "repos_url": "https://api.github.com/users/Dj0ulo/repos",
+      "events_url": "https://api.github.com/users/Dj0ulo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/Dj0ulo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "Dj0ulo",
+      "id": 46035353,
+      "node_id": "MDQ6VXNlcjQ2MDM1MzUz",
+      "avatar_url": "https://avatars.githubusercontent.com/u/46035353?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/Dj0ulo",
+      "html_url": "https://github.com/Dj0ulo",
+      "followers_url": "https://api.github.com/users/Dj0ulo/followers",
+      "following_url": "https://api.github.com/users/Dj0ulo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/Dj0ulo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/Dj0ulo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/Dj0ulo/subscriptions",
+      "organizations_url": "https://api.github.com/users/Dj0ulo/orgs",
+      "repos_url": "https://api.github.com/users/Dj0ulo/repos",
+      "events_url": "https://api.github.com/users/Dj0ulo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/Dj0ulo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "e3b69448540f649e95bc2617579aa27e411e1f59",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/e3b69448540f649e95bc2617579aa27e411e1f59",
+        "html_url": "https://github.com/odoo/odoo/commit/e3b69448540f649e95bc2617579aa27e411e1f59"
+      }
+    ],
+    "stats": {
+      "total": 33,
+      "additions": 16,
+      "deletions": 17
+    },
+    "files": [
+      {
+        "sha": "dd51e5c28de68d069658970cb3a271e8913d2802",
+        "filename": "addons/html_editor/static/src/scss/html_editor.common.scss",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 1,
+        "changes": 2,
+        "blob_url": "https://github.com/odoo/odoo/blob/68bfe6fec67b0d87c59454b254a98bee57dc5d4c/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fscss%2Fhtml_editor.common.scss",
+        "raw_url": "https://github.com/odoo/odoo/raw/68bfe6fec67b0d87c59454b254a98bee57dc5d4c/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fscss%2Fhtml_editor.common.scss",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fhtml_editor%2Fstatic%2Fsrc%2Fscss%2Fhtml_editor.common.scss?ref=68bfe6fec67b0d87c59454b254a98bee57dc5d4c",
+        "patch": "@@ -745,7 +745,7 @@ pre {\n \n     &.o_bg_img_opt_repeat {\n         background-size: auto;\n-        background-repeat: repeat;\n+        background-repeat: repeat !important;\n     }\n     &.o_bg_img_center {\n         background-position: center;"
+      },
+      {
+        "sha": "3f277b3ee0943a153813257827d6214d406efa4a",
+        "filename": "addons/mass_mailing/static/src/scss/themes/theme_default.scss",
+        "status": "modified",
+        "additions": 0,
+        "deletions": 11,
+        "changes": 11,
+        "blob_url": "https://github.com/odoo/odoo/blob/68bfe6fec67b0d87c59454b254a98bee57dc5d4c/addons%2Fmass_mailing%2Fstatic%2Fsrc%2Fscss%2Fthemes%2Ftheme_default.scss",
+        "raw_url": "https://github.com/odoo/odoo/raw/68bfe6fec67b0d87c59454b254a98bee57dc5d4c/addons%2Fmass_mailing%2Fstatic%2Fsrc%2Fscss%2Fthemes%2Ftheme_default.scss",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fmass_mailing%2Fstatic%2Fsrc%2Fscss%2Fthemes%2Ftheme_default.scss?ref=68bfe6fec67b0d87c59454b254a98bee57dc5d4c",
+        "patch": "@@ -76,17 +76,6 @@ div.col:not([align]) {\n     }\n     // Background Images\n     .oe_img_bg {\n-        background-size: cover;\n-        background-repeat: no-repeat;\n-\n-        &.o_bg_img_opt_repeat {\n-            background-size: auto;\n-            background-repeat: repeat;\n-        }\n-        &.o_bg_img_center {\n-            background-position: center;\n-        }\n-\n         // Compatibility <= 13.0, TODO remove?\n         // -----------------------------------\n         &.o_bg_img_opt_contain {"
+      },
+      {
+        "sha": "11386fb751856bee50e928ce1371cc7e6fa5afd4",
+        "filename": "addons/website/static/tests/builder/website_builder/parallax_option.test.js",
+        "status": "modified",
+        "additions": 15,
+        "deletions": 5,
+        "changes": 20,
+        "blob_url": "https://github.com/odoo/odoo/blob/68bfe6fec67b0d87c59454b254a98bee57dc5d4c/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fwebsite_builder%2Fparallax_option.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/68bfe6fec67b0d87c59454b254a98bee57dc5d4c/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fwebsite_builder%2Fparallax_option.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fwebsite_builder%2Fparallax_option.test.js?ref=68bfe6fec67b0d87c59454b254a98bee57dc5d4c",
+        "patch": "@@ -1,6 +1,9 @@\n import { expect, test } from \"@odoo/hoot\";\n import { contains } from \"@web/../tests/web_test_helpers\";\n-import { defineWebsiteModels, setupWebsiteBuilder } from \"@website/../tests/builder/website_helpers\";\n+import {\n+    defineWebsiteModels,\n+    setupWebsiteBuilder,\n+} from \"@website/../tests/builder/website_helpers\";\n import { waitFor } from \"@odoo/hoot-dom\";\n \n defineWebsiteModels();\n@@ -13,12 +16,13 @@ test(\"test parallax zoom\", async () => {\n     expect(\"[data-label='Intensity'] input\").toBeVisible();\n });\n test(\"add parallax changes editing element\", async () => {\n-    await setupWebsiteAndOpenParallaxOptions();\n+    await setupWebsiteAndOpenParallaxOptions({}, { loadIframeBundles: true });\n     await contains(\"[data-action-value='fixed']\").click();\n     await contains(\"[data-label='Position'] .dropdown-toggle\").click();\n     await contains(\"[data-action-value='repeat-pattern']\").click();\n     expect(\":iframe section\").not.toHaveClass(\"o_bg_img_opt_repeat\");\n     expect(\":iframe section .s_parallax_bg\").toHaveClass(\"o_bg_img_opt_repeat\");\n+    expect(\":iframe section .s_parallax_bg\").toHaveStyle(\"background-repeat: repeat\");\n });\n test(\"add parallax removes classes on the original editing element\", async () => {\n     await setupWebsiteAndOpenParallaxOptions({ editingElClasses: \"o_modified_image_to_save\" });\n@@ -104,12 +108,18 @@ test(\"parallax scroll effect 'none' doesn't remove the color filter\", async () =\n     expect(\":iframe section .o_we_bg_filter\").toHaveCount(1);\n });\n \n-async function setupWebsiteAndOpenParallaxOptions({ editingElClasses = \"\" } = {}) {\n+async function setupWebsiteAndOpenParallaxOptions(\n+    { editingElClasses = \"\" } = {},\n+    builderOptions = {}\n+) {\n     const backgroundImageUrl = \"url('/web/image/123/transparent.png')\";\n     const editingElClass = editingElClasses ? `class=${editingElClasses}` : \"\";\n-    const websiteBuilder = await setupWebsiteBuilder(`\n+    const websiteBuilder = await setupWebsiteBuilder(\n+        `\n         <section ${editingElClass} style=\"background-image: ${backgroundImageUrl}; width: 500px; height:500px\">\n-        </section>`);\n+        </section>`,\n+        builderOptions\n+    );\n     await contains(\":iframe section\").click();\n     await websiteBuilder.waitSidebarUpdated();\n     await contains(\"[data-label='Scroll Effect'] button.o-dropdown\").click();"
+      }
+    ]
+  },
+  {
+    "sha": "c528c9c198825c01e67d89f2dad79aceb010e22f",
+    "node_id": "C_kwDOAS1I7NoAKGM1MjhjOWMxOTg4MjVjMDFlNjdkODlmMmRhZDc5YWNlYjAxMGUyMmY",
+    "commit": {
+      "author": {
+        "name": "assh-odoo",
+        "email": "assh@odoo.com",
+        "date": "2025-09-11T04:59:49Z"
+      },
+      "committer": {
+        "name": "assh-odoo",
+        "email": "assh@odoo.com",
+        "date": "2025-10-29T07:55:39Z"
+      },
+      "message": "[FIX] website: prevent error when submitting the 'Send Email' form\n\nCurrently, an error occurs when submitting the 'Send Email' form.\n\nSteps to Reproduce:\n\n - Install the website module.\n - Go to website > Click on Edit > Drag and drop form.\n - Click the form and in actions select again Send an E-mail action\n   and save.\n - Submit the form, and the error appears in the logs.\n\nKeyError: 'website_form_signature'\n\nThis error occurs when submitting the \"Send Email\" form from the\nwebsite. When the user chooses the model Outgoing Mails (mail.mail),\nthe email_to hidden field is not added. This is because email_to is only\nadded when the recipient email value is changed from the sidebar via\napply [1]. As a result, the email_to hidden field is missing from the form.\nAnd the website_form_signature is added from [2], but due to the\ncondition at [3], the code at [2] is not executed. When it is accessed\nat [4], KeyError is raised.\n\nThis commit ensures that when the user selects the action model,\nif there are hidden field, it is added to the form with its\ndefault value.\n\n[1]: https://github.com/odoo/odoo/blob/3b16debc6d6557334082fdf841b20ef0e31fc9d2/addons/website/static/src/builder/plugins/form/form_option_plugin.js#L863\n\n[2]: https://github.com/odoo/odoo/blob/82639728f2bcb4e7786f120de2aeba3f5fbab209/addons/website/tools.py#L252\n\n[3]: https://github.com/odoo/odoo/blob/82639728f2bcb4e7786f120de2aeba3f5fbab209/addons/website/tools.py#L236\n\n[4]: https://github.com/odoo/odoo/blob/82639728f2bcb4e7786f120de2aeba3f5fbab209/addons/website/controllers/form.py#L88\n\nsentry-6746753251\n\ncloses odoo/odoo#233519\n\nX-original-commit: 6376b596cc2bdd587cc71f9dacbfd25dc7795e15\nSigned-off-by: Benoit Socias (bso) <bso@odoo.com>\nSigned-off-by: Ashutosh Sharma (assh) <assh@odoo.com>",
+      "tree": {
+        "sha": "c18f4babb23a42fa2d9490c7e542c3f418585f68",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/c18f4babb23a42fa2d9490c7e542c3f418585f68"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/c528c9c198825c01e67d89f2dad79aceb010e22f",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/c528c9c198825c01e67d89f2dad79aceb010e22f",
+    "html_url": "https://github.com/odoo/odoo/commit/c528c9c198825c01e67d89f2dad79aceb010e22f",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/c528c9c198825c01e67d89f2dad79aceb010e22f/comments",
+    "author": {
+      "login": "assh-odoo",
+      "id": 197610379,
+      "node_id": "U_kgDOC8dLiw",
+      "avatar_url": "https://avatars.githubusercontent.com/u/197610379?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/assh-odoo",
+      "html_url": "https://github.com/assh-odoo",
+      "followers_url": "https://api.github.com/users/assh-odoo/followers",
+      "following_url": "https://api.github.com/users/assh-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/assh-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/assh-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/assh-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/assh-odoo/orgs",
+      "repos_url": "https://api.github.com/users/assh-odoo/repos",
+      "events_url": "https://api.github.com/users/assh-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/assh-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "assh-odoo",
+      "id": 197610379,
+      "node_id": "U_kgDOC8dLiw",
+      "avatar_url": "https://avatars.githubusercontent.com/u/197610379?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/assh-odoo",
+      "html_url": "https://github.com/assh-odoo",
+      "followers_url": "https://api.github.com/users/assh-odoo/followers",
+      "following_url": "https://api.github.com/users/assh-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/assh-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/assh-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/assh-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/assh-odoo/orgs",
+      "repos_url": "https://api.github.com/users/assh-odoo/repos",
+      "events_url": "https://api.github.com/users/assh-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/assh-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "56bc4e4ee63c9ad4572f7da2b6e58c89826a2fbc",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/56bc4e4ee63c9ad4572f7da2b6e58c89826a2fbc",
+        "html_url": "https://github.com/odoo/odoo/commit/56bc4e4ee63c9ad4572f7da2b6e58c89826a2fbc"
+      }
+    ],
+    "stats": {
+      "total": 29,
+      "additions": 29,
+      "deletions": 0
+    },
+    "files": [
+      {
+        "sha": "5ba896c54dd1bd65bfd9e78f86920fcd27f47cd1",
+        "filename": "addons/website/static/src/builder/plugins/form/form_option_plugin.js",
+        "status": "modified",
+        "additions": 9,
+        "deletions": 0,
+        "changes": 9,
+        "blob_url": "https://github.com/odoo/odoo/blob/c528c9c198825c01e67d89f2dad79aceb010e22f/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fplugins%2Fform%2Fform_option_plugin.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/c528c9c198825c01e67d89f2dad79aceb010e22f/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fplugins%2Fform%2Fform_option_plugin.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fbuilder%2Fplugins%2Fform%2Fform_option_plugin.js?ref=c528c9c198825c01e67d89f2dad79aceb010e22f",
+        "patch": "@@ -382,6 +382,15 @@ export class FormOptionPlugin extends Plugin {\n                 );\n                 locationEl.insertAdjacentElement(\"beforebegin\", renderField(_field));\n             });\n+            // Special case: handle hidden fields separately.\n+            // In some forms (e.g., contact forms), the \"email_to\" field must be included as hidden.\n+            // For example, this may force the 'email_to' value to a dummy/default one on the\n+            // contact us form just by interacting with it.\n+            formInfo.fields?.forEach(field => {\n+                if (field.defaultValue) {\n+                    this.addHiddenField(el, field.defaultValue, field.name);\n+                }\n+            });\n         }\n     }\n     /**"
+      },
+      {
+        "sha": "c1948f69991e7fb44d8bfd318a0ecd9d3d31e370",
+        "filename": "addons/website/static/tests/builder/website_builder/form_option.test.js",
+        "status": "modified",
+        "additions": 20,
+        "deletions": 0,
+        "changes": 20,
+        "blob_url": "https://github.com/odoo/odoo/blob/c528c9c198825c01e67d89f2dad79aceb010e22f/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fwebsite_builder%2Fform_option.test.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/c528c9c198825c01e67d89f2dad79aceb010e22f/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fwebsite_builder%2Fform_option.test.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Ftests%2Fbuilder%2Fwebsite_builder%2Fform_option.test.js?ref=c528c9c198825c01e67d89f2dad79aceb010e22f",
+        "patch": "@@ -368,3 +368,23 @@ test(\"Changing max files number option updates file input 'multiple' attribute\",\n     expect(\":iframe input[type=file]\").toHaveAttribute(\"data-max-files-number\", \"1\");\n     expect(\":iframe input[type=file]\").not.toHaveAttribute(\"multiple\");\n });\n+\n+test(\"Form using the Outgoing Mails model includes hidden email_to field\", async () => {\n+    await setupWebsiteBuilder(\n+        `<section class=\"s_website_form\">\n+            <form data-model_name=\"mail.mail\">\n+                <div class=\"s_website_form_submit\">\n+                    <div class=\"s_website_form_label\"/>\n+                    <a>Submit</a>\n+                </div>\n+            </form>\n+        </section>`\n+    );\n+\n+    await contains(\":iframe section\").click();\n+    await contains(\"div:has(>span:contains('Action')) + div button\").click();\n+    await contains(\"div.o-dropdown-item:contains('Send an E-mail')\").click();\n+\n+    expect(\":iframe input[type='hidden'][name='email_to']\").toHaveCount(1);\n+    expect(\":iframe input[type='hidden'][name='email_to']\").toHaveValue(\"info@yourcompany.example.com\");\n+});"
+      }
+    ]
+  },
+  {
+    "sha": "7406a05116d9adeb8f0aada996cda06f978194f2",
+    "node_id": "C_kwDOAS1I7NoAKDc0MDZhMDUxMTZkOWFkZWI4ZjBhYWRhOTk2Y2RhMDZmOTc4MTk0ZjI",
+    "commit": {
+      "author": {
+        "name": "divy-odoo",
+        "email": "divy@odoo.com",
+        "date": "2025-10-08T11:56:41Z"
+      },
+      "committer": {
+        "name": "divy-odoo",
+        "email": "divy@odoo.com",
+        "date": "2025-10-29T09:19:36Z"
+      },
+      "message": "[FIX] website: add fullscreen loader when loading more themes\n\nSteps to reproduce:\n\n1. Create a new website and proceed to the theme configuration step.\n2. Click on View More Themes.\n-> You\u2019ll notice a loading effect on the button, but the existing themes\nremain selectable.\n\nBefore this commit:\nUsers could still select existing themes while additional themes were\nbeing loaded.\n\nAfter this commit:\nA fullscreen loader is displayed while loading more themes via the View\nMore Themes button, preventing any unintended interactions.\n\ntask-4661292\n\ncloses odoo/odoo#233561\n\nX-original-commit: a199127e171de72a1cbfa18217eea501c46c0ec9\nSigned-off-by: Benoit Socias (bso) <bso@odoo.com>\nSigned-off-by: Divyesh Vyas (divy) <divy@odoo.com>",
+      "tree": {
+        "sha": "94a5a0c1bfb01ab0b8297d86d470d12483aa15db",
+        "url": "https://api.github.com/repos/odoo/odoo/git/trees/94a5a0c1bfb01ab0b8297d86d470d12483aa15db"
+      },
+      "url": "https://api.github.com/repos/odoo/odoo/git/commits/7406a05116d9adeb8f0aada996cda06f978194f2",
+      "comment_count": 0,
+      "verification": {
+        "verified": false,
+        "reason": "unsigned",
+        "signature": null,
+        "payload": null,
+        "verified_at": null
+      }
+    },
+    "url": "https://api.github.com/repos/odoo/odoo/commits/7406a05116d9adeb8f0aada996cda06f978194f2",
+    "html_url": "https://github.com/odoo/odoo/commit/7406a05116d9adeb8f0aada996cda06f978194f2",
+    "comments_url": "https://api.github.com/repos/odoo/odoo/commits/7406a05116d9adeb8f0aada996cda06f978194f2/comments",
+    "author": {
+      "login": "divy-odoo",
+      "id": 125337508,
+      "node_id": "U_kgDOB3h_pA",
+      "avatar_url": "https://avatars.githubusercontent.com/u/125337508?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/divy-odoo",
+      "html_url": "https://github.com/divy-odoo",
+      "followers_url": "https://api.github.com/users/divy-odoo/followers",
+      "following_url": "https://api.github.com/users/divy-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/divy-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/divy-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/divy-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/divy-odoo/orgs",
+      "repos_url": "https://api.github.com/users/divy-odoo/repos",
+      "events_url": "https://api.github.com/users/divy-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/divy-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "divy-odoo",
+      "id": 125337508,
+      "node_id": "U_kgDOB3h_pA",
+      "avatar_url": "https://avatars.githubusercontent.com/u/125337508?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/divy-odoo",
+      "html_url": "https://github.com/divy-odoo",
+      "followers_url": "https://api.github.com/users/divy-odoo/followers",
+      "following_url": "https://api.github.com/users/divy-odoo/following{/other_user}",
+      "gists_url": "https://api.github.com/users/divy-odoo/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/divy-odoo/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/divy-odoo/subscriptions",
+      "organizations_url": "https://api.github.com/users/divy-odoo/orgs",
+      "repos_url": "https://api.github.com/users/divy-odoo/repos",
+      "events_url": "https://api.github.com/users/divy-odoo/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/divy-odoo/received_events",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "3d061f62d8d481be41c0d50a454883c2b8c70d32",
+        "url": "https://api.github.com/repos/odoo/odoo/commits/3d061f62d8d481be41c0d50a454883c2b8c70d32",
+        "html_url": "https://github.com/odoo/odoo/commit/3d061f62d8d481be41c0d50a454883c2b8c70d32"
+      }
+    ],
+    "stats": {
+      "total": 5,
+      "additions": 2,
+      "deletions": 3
+    },
+    "files": [
+      {
+        "sha": "22e936c2948650416ba64fb9497d6376dc8d5723",
+        "filename": "addons/website/static/src/client_actions/configurator/configurator.js",
+        "status": "modified",
+        "additions": 2,
+        "deletions": 3,
+        "changes": 5,
+        "blob_url": "https://github.com/odoo/odoo/blob/7406a05116d9adeb8f0aada996cda06f978194f2/addons%2Fwebsite%2Fstatic%2Fsrc%2Fclient_actions%2Fconfigurator%2Fconfigurator.js",
+        "raw_url": "https://github.com/odoo/odoo/raw/7406a05116d9adeb8f0aada996cda06f978194f2/addons%2Fwebsite%2Fstatic%2Fsrc%2Fclient_actions%2Fconfigurator%2Fconfigurator.js",
+        "contents_url": "https://api.github.com/repos/odoo/odoo/contents/addons%2Fwebsite%2Fstatic%2Fsrc%2Fclient_actions%2Fconfigurator%2Fconfigurator.js?ref=7406a05116d9adeb8f0aada996cda06f978194f2",
+        "patch": "@@ -26,7 +26,6 @@ import {\n     useExternalListener,\n } from \"@odoo/owl\";\n import { standardActionServiceProps } from \"@web/webclient/actions/action_service\";\n-import { addLoadingEffect as addButtonLoadingEffect } from \"@web/core/utils/ui\";\n import { fuzzyLevenshteinLookup } from \"@web/core/utils/search\";\n import { isBrowserSafari } from \"@web/core/browser/feature_detection\";\n \n@@ -709,7 +708,7 @@ export class ThemeSelectionScreen extends ApplyConfiguratorScreen {\n     }\n \n     async getMoreThemes() {\n-        const removeLoadingEffect = addButtonLoadingEffect(this.extraThemesButtonRef.el);\n+        this.uiService.block();\n         const themes = await getRecommendedThemes(\n             this.orm,\n             this.state,\n@@ -720,7 +719,7 @@ export class ThemeSelectionScreen extends ApplyConfiguratorScreen {\n         const mainThemeNames = this.state.themes.map((theme) => theme.name);\n         this.state.extraThemes = themes.filter((extraTheme) => !mainThemeNames.includes(extraTheme.name));\n         this.state.extraThemesLoaded = true;\n-        removeLoadingEffect();\n+        this.uiService.unblock();\n     }\n \n     getExtraThemeName(idx) {"
+      }
+    ]
+  }
+]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ nav:
   - VoIP:
     - Commit History Report: voip/index.md
   - Reports:
+    - Website & HTML Builder Commits (22–29 Oct 2025): reports/2025-10-29-odoo-website-html-builder-commits.md
     - Website & HTML Builder Commits (16–22 Oct 2025): reports/2025-10-22-odoo-website-html-builder-commits.md
     - Website & HTML Builder Commits (9–15 Oct 2025): reports/2025-10-15-odoo-website-html-builder-commits.md
     - Website & HTML Builder Commits (1–8 Oct 2025): reports/2025-10-08-odoo-website-html-builder-commits.md


### PR DESCRIPTION
## Summary
- add the 22–29 Oct 2025 Website & HTML Builder commit digest with "Commit of the Week" ahead of the highlights
- store the corresponding GitHub export covering website, html_builder, and website_sale builder paths for that window
- register the new report in the MkDocs navigation

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_690220900abc833193d07f90022555b3